### PR TITLE
Refresh partitions after veritysetup so that hash partition's UUID is accurate

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -814,6 +814,12 @@ func customizeVerityImageHelper(buildDir string, baseConfigPath string, config *
 		return fmt.Errorf("failed to stat file (%s):\n%w", grubCfgFullPath, err)
 	}
 
+	// Refresh disk partitions so that the hash partition's UUID is correct
+	diskPartitions, err = diskutils.GetDiskPartitions(loopback.DevicePath())
+	if err != nil {
+		return err
+	}
+
 	err = updateGrubConfigForVerity(rootfsVerity, rootHash, grubCfgFullPath, partIdToPartUuid, diskPartitions)
 	if err != nil {
 		return err

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -792,6 +792,12 @@ func customizeVerityImageHelper(buildDir string, baseConfigPath string, config *
 	}
 	rootHash = rootHashMatches[1]
 
+	// Refresh disk partitions after running veritysetup so that the hash partition's UUID is correct.
+	diskPartitions, err = diskutils.GetDiskPartitions(loopback.DevicePath())
+	if err != nil {
+		return err
+	}
+
 	systemBootPartition, err := findSystemBootPartition(diskPartitions)
 	if err != nil {
 		return err
@@ -812,12 +818,6 @@ func customizeVerityImageHelper(buildDir string, baseConfigPath string, config *
 	grubCfgFullPath := filepath.Join(bootPartitionTmpDir, "grub2/grub.cfg")
 	if err != nil {
 		return fmt.Errorf("failed to stat file (%s):\n%w", grubCfgFullPath, err)
-	}
-
-	// Refresh disk partitions so that the hash partition's UUID is correct
-	diskPartitions, err = diskutils.GetDiskPartitions(loopback.DevicePath())
-	if err != nil {
-		return err
 	}
 
 	err = updateGrubConfigForVerity(rootfsVerity, rootHash, grubCfgFullPath, partIdToPartUuid, diskPartitions)


### PR DESCRIPTION
Same as https://github.com/microsoft/azurelinux/pull/11247 but against new repository.

---
This change corrects the value set for the systemd.verity_root_hash= kernel cmdline parameter when hashDeviceMountIdType in the configuration is set to uuid.
 
In particular, the veritysetup command earlier in the function generates the UUID for the verity hash partition. But since the diskPartitions array is queried before that call, the partition would be marked as having an empty filesystem UUID.

An alternative would be to edit only the specific partition's UUID in the diskPartitions array, either by passing a manually generated UUID to veritysetup (via the --uuid=UUID flag) or by querying the chosen UUID after veritysetup had run.

