### PR TITLE
Fix partition extraction of unformatted partitions.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/checkfilesystem.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/checkfilesystem.go
@@ -69,6 +69,12 @@ func checkFileSystemsHelper(diskDevice string) error {
 }
 
 func checkFileSystemFile(fileSystemType string, path string) error {
+	if fileSystemType == "" {
+		// Skip partitions that don't have a known file system type (e.g. the BIOS boot partition).
+		logger.Log.Debugf("Skipping file system check (%s)", path)
+		return nil
+	}
+
 	loopback, err := safeloopback.NewLoopback(path)
 	if err != nil {
 		return err

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/partitions-unformatted-partition.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/partitions-unformatted-partition.yaml
@@ -1,0 +1,34 @@
+storage:
+  disks:
+  - partitionTableType: gpt
+    partitions:
+    - id: esp
+      type: esp
+      size: 8M
+
+    - id: rootfs
+      label: rootfs
+      size: 2G
+
+    - id: empty
+      size: 2G
+      
+  bootType: efi
+
+  filesystems:
+  - deviceId: esp
+    type: fat32
+    mountPoint:
+      path: /boot/efi
+      options: umask=0077
+
+  - deviceId: rootfs
+    type: ext4
+    mountPoint:
+      path: /
+
+os:
+  resetBootLoaderType: hard-reset
+
+  kernelCommandLine:
+    extraCommandLine: console=tty0 console=ttyS0


### PR DESCRIPTION
When image customizer does partition extraction, it runs `fsck` on all the partitions before and after the extraction. This is a sanity check to ensure the copy was successful.

However, there is a bug where after partition extraction, `fsck` is mistakenly run on partitions that aren't formatted (i.e. partitions that were not assigned a filesystem) and `fsck` unsurprisingly fails. This change fixes this problem and adds a regression test.