### PR TITLE
Clarify logs of build host metadata.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -679,6 +679,13 @@ func customizeImageHelper(buildDir string, baseConfigPath string, config *imagec
 	}
 	defer imageConnection.Close()
 
+	imageConnection.Chroot().UnsafeRun(func() error {
+		distro, version := getDistroAndVersion()
+		logger.Log.Infof("Base OS distro: %s", distro)
+		logger.Log.Infof("Base OS version: %s", version)
+		return nil
+	})
+
 	// Do the actual customizations.
 	err = doOsCustomizations(buildDir, baseConfigPath, config, imageConnection, rpmsSources,
 		useBaseImageRpmRepos, partitionsCustomized, imageUuidStr)

--- a/toolkit/tools/pkg/imagecustomizerlib/versionsOfToolDependencies.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/versionsOfToolDependencies.go
@@ -33,10 +33,11 @@ func logVersionsOfToolDeps() {
 
 	// Get distro and version
 	distro, version := getDistroAndVersion()
-	logger.Log.Debugf("Distro: %s, Version: %s", distro, version)
+	logger.Log.Debugf("Build host OS distro: %s", distro)
+	logger.Log.Debugf("Build host OS version: %s", version)
 
 	// Get versions of packages
-	logger.Log.Debugf("Tool Dependencies:")
+	logger.Log.Debugf("Build Host Tools:")
 	for versionFlag, pkgList := range versionFlags {
 		for _, pkg := range pkgList {
 			version, err := getPackageVersion(pkg, versionFlag)

--- a/toolkit/tools/pkg/imagecustomizerlib/versionsOfToolDependencies.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/versionsOfToolDependencies.go
@@ -33,11 +33,11 @@ func logVersionsOfToolDeps() {
 
 	// Get distro and version
 	distro, version := getDistroAndVersion()
-	logger.Log.Debugf("Build host OS distro: %s", distro)
-	logger.Log.Debugf("Build host OS version: %s", version)
+	logger.Log.Debugf("Host OS distro: %s", distro)
+	logger.Log.Debugf("Host OS version: %s", version)
 
 	// Get versions of packages
-	logger.Log.Debugf("Build Host Tools:")
+	logger.Log.Debugf("Host Tools:")
 	for versionFlag, pkgList := range versionFlags {
 		for _, pkg := range pkgList {
 			version, err := getPackageVersion(pkg, versionFlag)


### PR DESCRIPTION
We currently log information about the build host to assist with debugging. But some customers have confused the logs for metadata about the OS being customized. So, make it explicit that the logs are for the build host. Also, add the distro + version of the base image to the logs.