### PR TITLE
Allow 'ro' partitions.

### DIFF
--- a/toolkit/tools/imagecustomizer/docs/configuration.md
+++ b/toolkit/tools/imagecustomizer/docs/configuration.md
@@ -575,6 +575,9 @@ Specifies the configuration for dm-verity integrity verification.
 Note: Currently only root partition (`/`) is supported. Support for other partitions
 (e.g. `/usr`) may be added in the future.
 
+Note: The [filesystem](#filesystem-type) item pointing to this verity device, must
+include the `ro` option in the [mountPoint.options](#options-string).
+
 There are multiple ways to configure a verity enabled image. For
 recommendations, see [Verity Image Recommendations](./verity.md).
 

--- a/toolkit/tools/imagecustomizerapi/config_test.go
+++ b/toolkit/tools/imagecustomizerapi/config_test.go
@@ -416,7 +416,8 @@ func TestConfigIsValidVerityValid(t *testing.T) {
 					DeviceId: "rootverity",
 					Type:     "ext4",
 					MountPoint: &MountPoint{
-						Path: "/",
+						Path:    "/",
+						Options: "ro",
 					},
 				},
 			},

--- a/toolkit/tools/imagecustomizerapi/storage.go
+++ b/toolkit/tools/imagecustomizerapi/storage.go
@@ -5,6 +5,9 @@ package imagecustomizerapi
 
 import (
 	"fmt"
+	"strings"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/sliceutils"
 )
 
 type Storage struct {
@@ -157,6 +160,11 @@ func (s *Storage) IsValid() error {
 		if verity.Name != VerityRootDeviceName {
 			return fmt.Errorf("verity 'name' (%s) must be \"%s\" for filesystem (%s) partition (%s)", verity.Name,
 				VerityRootDeviceName, filesystem.MountPoint.Path, verity.DataDeviceId)
+		}
+
+		mountOptions := strings.Split(filesystem.MountPoint.Options, ",")
+		if !sliceutils.ContainsValue(mountOptions, "ro") {
+			return fmt.Errorf("verity device's (%s) filesystem must include the 'ro' mount option", verity.Id)
 		}
 	}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
@@ -73,7 +73,6 @@ func updateFstabForVerity(verityList []imagecustomizerapi.Verity, imageChroot *s
 			if entry.Target == mountPath {
 				// Replace mount's source with verity device.
 				entry.Source = verityDevicePath(verity)
-				entry.Options = "ro," + entry.Options
 			}
 		}
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-config.yaml
@@ -47,6 +47,7 @@ storage:
     type: ext4
     mountPoint:
       path: /
+      options: ro
 
   - deviceId: var
     type: ext4

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-partition-labels.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-partition-labels.yaml
@@ -51,6 +51,7 @@ storage:
     type: ext4
     mountPoint:
       path: /
+      options: ro
 
   - deviceId: var
     type: ext4


### PR DESCRIPTION
When customizing a partition, don't apply the 'ro' mount option to allow the partitions to be customized.

In addition, require the user to specify the 'ro' option on verity partitions.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
