### PR TITLE
Image Customizer: Restrict capabilities on scripts.

### DIFF
--- a/toolkit/tools/imagecustomizer/docs/configuration.md
+++ b/toolkit/tools/imagecustomizer/docs/configuration.md
@@ -1171,6 +1171,20 @@ For example, `/boot` will be mounted before `/boot/efi`.
 
 Points to a script file (typically a Bash script) to be run during customization.
 
+Scripts are run with a limited set of capabilities. Specifically:
+
+- `CAP_CHOWN`
+- `CAP_DAC_OVERRIDE`
+- `CAP_DAC_READ_SEARCH`
+- `CAP_FOWNER`
+- `CAP_SETFCAP`
+
+Restricting the set of capabilities helps prevent scripts from accidentally affecting
+the host kernel.
+
+WARNING: Custom scripts are not considered to be on security boundary.
+Only use config files that you trust (or run image customizer in a security sandbox).
+
 <div id="script-path"></div>
 
 ### path [string]

--- a/toolkit/tools/imagecustomizer/docs/configuration.md
+++ b/toolkit/tools/imagecustomizer/docs/configuration.md
@@ -1151,7 +1151,8 @@ Supported options:
 
 The additional options used when mounting the file system.
 
-These options are in the same format as [mount](https://linux.die.net/man/8/mount)'s
+These options are in the same format as
+[mount](https://man7.org/linux/man-pages/man8/mount.8.html)'s
 `-o` option (or the `fs_mntops` field of the
 [fstab](https://man7.org/linux/man-pages/man5/fstab.5.html) file).
 
@@ -1171,7 +1172,8 @@ For example, `/boot` will be mounted before `/boot/efi`.
 
 Points to a script file (typically a Bash script) to be run during customization.
 
-Scripts are run with a limited set of capabilities. Specifically:
+Scripts are run with a limited set of
+[capabilities](https://man7.org/linux/man-pages/man7/capabilities.7.html). Specifically:
 
 - `CAP_CHOWN`
 - `CAP_DAC_OVERRIDE`

--- a/toolkit/tools/internal/shell/capabilities.go
+++ b/toolkit/tools/internal/shell/capabilities.go
@@ -1,0 +1,79 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package shell
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/sliceutils"
+	"golang.org/x/sys/unix"
+)
+
+func setOSThreadCapabilities(capabilities []uintptr) error {
+	maxBoundingCapability, err := getMaxBoundingCapability()
+	if err != nil {
+		return fmt.Errorf("failed to get number of Linux capabilities:\n%w", err)
+	}
+
+	for i := uintptr(0); i <= maxBoundingCapability; i++ {
+		keep := sliceutils.ContainsValue(capabilities, i)
+		if keep {
+			continue
+		}
+
+		enabled, err := readBoundingCapability(i)
+		if err != nil {
+			return fmt.Errorf("failed to read bounding capability state (%d)", i)
+		}
+
+		if !enabled {
+			continue
+		}
+
+		err = dropBoundingCapability(i)
+		if err != nil {
+			return fmt.Errorf("failed to drop bounding capability (%d)", i)
+		}
+	}
+
+	return nil
+}
+
+func getMaxBoundingCapability() (uintptr, error) {
+	const lastCapFile = "/proc/sys/kernel/cap_last_cap"
+
+	contentsBytes, err := os.ReadFile(lastCapFile)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read cap_last_cap file:\n%w", err)
+	}
+
+	contents := strings.TrimSpace(string(contentsBytes))
+	lastCap, err := strconv.Atoi(contents)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse cap_last_cap (%s):\n%w", contents, err)
+	}
+
+	return uintptr(lastCap), nil
+}
+
+func dropBoundingCapability(capability uintptr) error {
+	err := unix.Prctl(unix.PR_CAPBSET_DROP, capability, 0, 0, 0)
+	if err != nil {
+		return fmt.Errorf("prctl failed:\n%w", err)
+	}
+
+	return nil
+}
+
+func readBoundingCapability(capability uintptr) (bool, error) {
+	r, _, errno := unix.Syscall6(unix.SYS_PRCTL, unix.PR_CAPBSET_READ, capability, 0, 0, 0, 0)
+	enabled := r != 0
+	if errno != 0 {
+		return enabled, errno
+	}
+	return enabled, nil
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/runscripts.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/runscripts.go
@@ -20,6 +20,23 @@ const (
 	configDirMountPathInChroot = "/_imageconfigs"
 )
 
+var (
+	// The set of Linux capabilities given to custom scripts.
+	// For the most part, the capabilities given are those related to configuring filesystems and files.
+	scriptsCapabilities = []uintptr{
+		// Change file ownership,
+		unix.CAP_CHOWN,
+		// Ignore file permissions.
+		unix.CAP_DAC_OVERRIDE,
+		// Ignore read-only file permissions.
+		unix.CAP_DAC_READ_SEARCH,
+		// Set file permissions and extended attributes.
+		unix.CAP_FOWNER,
+		// Set capabilities on files.
+		unix.CAP_SETFCAP,
+	}
+)
+
 func runUserScripts(baseConfigPath string, scripts []imagecustomizerapi.Script, listName string,
 	imageChroot *safechroot.Chroot,
 ) error {
@@ -103,12 +120,13 @@ func runUserScript(scriptIndex int, script imagecustomizerapi.Script, listName s
 	}
 
 	// Run the script.
-	err = imageChroot.UnsafeRun(func() error {
-		return shell.NewExecBuilder(process, args...).
-			EnvironmentVariables(envVars).
-			ErrorStderrLines(1).
-			Execute()
-	})
+	err = shell.NewExecBuilder(process, args...).
+		Chroot(imageChroot.RootDir()).
+		EnvironmentVariables(envVars).
+		Capabilities(scriptsCapabilities).
+		WorkingDirectory("/").
+		ErrorStderrLines(1).
+		Execute()
 	if err != nil {
 		return fmt.Errorf("script (%s) failed:\n%w", scriptLogName, err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/runscripts_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/runscripts_test.go
@@ -66,3 +66,37 @@ resolv.conf exists
 
 	verifyFileContentsSame(t, aOrigFilePath, aNewFilePath)
 }
+
+func TestCustomizeImageRunScriptsIptables(t *testing.T) {
+	var err error
+
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+
+	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageRunScriptsIptables")
+	buildDir := filepath.Join(testTmpDir, "build")
+	configFile := filepath.Join(testDir, "runscripts-iptables.yaml")
+	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
+
+	// Customize image.
+	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	assert.ErrorContains(t, err, "failed to customize raw image")
+	assert.ErrorContains(t, err, "script (postCustomization[0]) failed")
+}
+
+func TestCustomizeImageRunScriptsModprobe(t *testing.T) {
+	var err error
+
+	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+
+	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageRunScriptsModprobe")
+	buildDir := filepath.Join(testTmpDir, "build")
+	configFile := filepath.Join(testDir, "runscripts-modprobe.yaml")
+	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
+
+	// Customize image.
+	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	assert.ErrorContains(t, err, "failed to customize raw image")
+	assert.ErrorContains(t, err, "script (postCustomization[0]) failed")
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/runscripts-iptables.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/runscripts-iptables.yaml
@@ -1,0 +1,7 @@
+os:
+
+scripts:
+  postCustomization:
+  - content: |
+      set -eux
+      iptables -L

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/runscripts-modprobe.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/runscripts-modprobe.yaml
@@ -1,0 +1,7 @@
+os:
+
+scripts:
+  postCustomization:
+  - content: |
+      set -eux
+      modprobe nbd


### PR DESCRIPTION
Restrict the set of Linux (root) capabilities given to custom scripts. This is intended to prevent scripts from accidentally affecting the build host machine. This is not intended as a security boundary, just a sanity check.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
