### PR TITLE
Fix shrink partitions race condition.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
@@ -107,10 +107,11 @@ func shrinkFilesystems(imageLoopDevice string, verity []imagecustomizerapi.Verit
 			return fmt.Errorf("failed to resizepart %s with parted (and flock):\n%v", partitionLoopDevice, stderr)
 		}
 
-		// Re-read the partition table
-		err = refreshPartitions(imageLoopDevice)
+		// Changes to the partition table causes all of the disk's parition /dev nodes to be deleted and then
+		// recreated. So, wait for that to finish.
+		err = diskutils.WaitForDevicesToSettle()
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to list disk (%s) partitions:\n%w", partitionLoopDevice, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
After changes to a partition table has been made, including resizing a partition, all the disk's partition nodes under /dev are removed and then recreated. We need to ensure we wait for this to complete before trying to shrink the next partition.

Also, remove the call to `partprobe` since calls to `parted` do this automatically. So, the `partprobe` call is redundant.

---

### **Checklist**
- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
