### PR TITLE
OSModifier: Extend EMU API to update verity and root device

### DIFF
--- a/toolkit/tools/osmodifierapi/os.go
+++ b/toolkit/tools/osmodifierapi/os.go
@@ -20,6 +20,8 @@ type OS struct {
 	KernelCommandLine imagecustomizerapi.KernelCommandLine `yaml:"kernelCommandLine"`
 	Services          imagecustomizerapi.Services          `yaml:"services"`
 	Modules           imagecustomizerapi.ModuleList        `yaml:"modules"`
+	Verity            *Verity                              `yaml:"verity"`
+	RootDevice        string                               `yaml:"rootDevice"`
 }
 
 func (s *OS) IsValid() error {
@@ -74,6 +76,12 @@ func (s *OS) IsValid() error {
 
 	if err := s.Modules.IsValid(); err != nil {
 		return err
+	}
+
+	if s.Verity != nil {
+		if err := s.Verity.IsValid(); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/toolkit/tools/osmodifierapi/verity.go
+++ b/toolkit/tools/osmodifierapi/verity.go
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package osmodifierapi
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/imagecustomizerapi"
+)
+
+var (
+	verityNameRegex = regexp.MustCompile("^[a-z]+$")
+)
+
+type Verity struct {
+	// ID is used to correlate `Verity` objects with `FileSystem` objects.
+	Id string `yaml:"id"`
+	// The name of the mapper block device.
+	// Must be 'root' for the rootfs (/) filesystem.
+	Name string `yaml:"name"`
+	// The ID of the 'Partition' to use as the data partition.
+	DataDeviceId string `yaml:"dataDeviceId"`
+	// The ID of the 'Partition' to use as the hash partition.
+	HashDeviceId string `yaml:"hashDeviceId"`
+	// How to handle corruption.
+	CorruptionOption imagecustomizerapi.CorruptionOption `yaml:"corruptionOption"`
+}
+
+func (v *Verity) IsValid() error {
+	if v.Id == "" {
+		return fmt.Errorf("'id' may not be empty")
+	}
+
+	if !verityNameRegex.MatchString(v.Name) {
+		return fmt.Errorf("invalid 'name' value (%s)", v.Name)
+	}
+
+	if v.DataDeviceId == "" {
+		return fmt.Errorf("'dataDeviceId' may not be empty")
+	}
+
+	if v.HashDeviceId == "" {
+		return fmt.Errorf("'hashDeviceId' may not be empty")
+	}
+
+	if err := v.CorruptionOption.IsValid(); err != nil {
+		return fmt.Errorf("invalid corruptionOption:\n%w", err)
+	}
+
+	return nil
+}

--- a/toolkit/tools/osmodifierapi/verity.go
+++ b/toolkit/tools/osmodifierapi/verity.go
@@ -20,10 +20,10 @@ type Verity struct {
 	// The name of the mapper block device.
 	// Must be 'root' for the rootfs (/) filesystem.
 	Name string `yaml:"name"`
-	// The ID of the 'Partition' to use as the data partition.
-	DataDeviceId string `yaml:"dataDeviceId"`
-	// The ID of the 'Partition' to use as the hash partition.
-	HashDeviceId string `yaml:"hashDeviceId"`
+	// The 'Partition' to use as the data partition.
+	DataDevice string `yaml:"dataDevice"`
+	// The 'Partition' to use as the hash partition.
+	HashDevice string `yaml:"hashDevice"`
 	// How to handle corruption.
 	CorruptionOption imagecustomizerapi.CorruptionOption `yaml:"corruptionOption"`
 }
@@ -37,11 +37,11 @@ func (v *Verity) IsValid() error {
 		return fmt.Errorf("invalid 'name' value (%s)", v.Name)
 	}
 
-	if v.DataDeviceId == "" {
+	if v.DataDevice == "" {
 		return fmt.Errorf("'dataDeviceId' may not be empty")
 	}
 
-	if v.HashDeviceId == "" {
+	if v.HashDevice == "" {
 		return fmt.Errorf("'hashDeviceId' may not be empty")
 	}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
@@ -106,33 +106,13 @@ func prepareGrubConfigForVerity(imageChroot *safechroot.Chroot) error {
 }
 
 func updateGrubConfigForVerity(rootfsVerity imagecustomizerapi.Verity, rootHash string, grubCfgFullPath string,
-	partIdToPartUuid map[string]string, partitions []diskutils.PartitionInfo,
+	partIdToPartUuid map[string]string, partitions []diskutils.PartitionInfo, buildDir string,
 ) error {
 	var err error
 
-	// Format the dataPartitionId and hashPartitionId using the helper function.
-	formattedDataPartition, err := systemdFormatPartitionId(rootfsVerity.DataDeviceId,
-		rootfsVerity.DataDeviceMountIdType, partIdToPartUuid, partitions)
+	newArgs, err := constructVerityKernelCmdlineArgs(rootfsVerity, rootHash, partIdToPartUuid, partitions, buildDir)
 	if err != nil {
-		return err
-	}
-	formattedHashPartition, err := systemdFormatPartitionId(rootfsVerity.HashDeviceId,
-		rootfsVerity.HashDeviceMountIdType, partIdToPartUuid, partitions)
-	if err != nil {
-		return err
-	}
-
-	formattedCorruptionOption, err := SystemdFormatCorruptionOption(rootfsVerity.CorruptionOption)
-	if err != nil {
-		return err
-	}
-
-	newArgs := []string{
-		"rd.systemd.verity=1",
-		fmt.Sprintf("roothash=%s", rootHash),
-		fmt.Sprintf("systemd.verity_root_data=%s", formattedDataPartition),
-		fmt.Sprintf("systemd.verity_root_hash=%s", formattedHashPartition),
-		fmt.Sprintf("systemd.verity_root_options=%s", formattedCorruptionOption),
+		return fmt.Errorf("failed to generate verity kernel arguments:\n%w", err)
 	}
 
 	grub2Config, err := file.Read(grubCfgFullPath)
@@ -174,6 +154,39 @@ func updateGrubConfigForVerity(rootfsVerity imagecustomizerapi.Verity, rootHash 
 	return nil
 }
 
+func constructVerityKernelCmdlineArgs(rootfsVerity imagecustomizerapi.Verity, rootHash string,
+	partIdToPartUuid map[string]string, partitions []diskutils.PartitionInfo, buildDir string,
+) ([]string, error) {
+	// Format the dataPartitionId and hashPartitionId using the helper function.
+	formattedDataPartition, err := systemdFormatPartitionId(rootfsVerity.DataDeviceId,
+		rootfsVerity.DataDeviceMountIdType, partIdToPartUuid, partitions, buildDir)
+	if err != nil {
+		return nil, err
+	}
+
+	formattedHashPartition, err := systemdFormatPartitionId(rootfsVerity.HashDeviceId,
+		rootfsVerity.HashDeviceMountIdType, partIdToPartUuid, partitions, buildDir)
+	if err != nil {
+		return nil, err
+	}
+
+	formattedCorruptionOption, err := SystemdFormatCorruptionOption(rootfsVerity.CorruptionOption)
+	if err != nil {
+		return nil, err
+	}
+
+	// Construct the verity-related kernel arguments.
+	newArgs := []string{
+		"rd.systemd.verity=1",
+		fmt.Sprintf("roothash=%s", rootHash),
+		fmt.Sprintf("systemd.verity_root_data=%s", formattedDataPartition),
+		fmt.Sprintf("systemd.verity_root_hash=%s", formattedHashPartition),
+		fmt.Sprintf("systemd.verity_root_options=%s", formattedCorruptionOption),
+	}
+
+	return newArgs, nil
+}
+
 func verityDevicePath(verity imagecustomizerapi.Verity) string {
 	return verityDevicePathFromName(verity.Name)
 }
@@ -206,11 +219,11 @@ func partitionMatchesDeviceId(configDeviceId string, partition diskutils.Partiti
 
 // systemdFormatPartitionId formats the partition ID based on the ID type following systemd dm-verity style.
 func systemdFormatPartitionId(configDeviceId string, mountIdType imagecustomizerapi.MountIdentifierType,
-	partIdToPartUuid map[string]string, partitions []diskutils.PartitionInfo,
+	partIdToPartUuid map[string]string, partitions []diskutils.PartitionInfo, buildDir string,
 ) (string, error) {
 	partUuid := partIdToPartUuid[configDeviceId]
 
-	partition, _, err := findPartition(imagecustomizerapi.MountIdentifierTypePartUuid, partUuid, partitions)
+	partition, _, err := findPartition(imagecustomizerapi.MountIdentifierTypePartUuid, partUuid, partitions, buildDir)
 	if err != nil {
 		return "", err
 	}
@@ -254,6 +267,23 @@ func validateVerityDependencies(imageChroot *safechroot.Chroot) error {
 		if !isPackageInstalled(imageChroot, pkg) {
 			return fmt.Errorf("package (%s) is not installed:\nthe following packages must be installed to use Verity: %v", pkg, requiredRpms)
 		}
+	}
+
+	return nil
+}
+
+func updateUkiKernelArgsForVerity(rootfsVerity imagecustomizerapi.Verity, rootHash string,
+	partIdToPartUuid map[string]string, partitions []diskutils.PartitionInfo, buildDir string,
+) error {
+	newArgs, err := constructVerityKernelCmdlineArgs(rootfsVerity, rootHash, partIdToPartUuid, partitions, buildDir)
+	if err != nil {
+		return fmt.Errorf("failed to generate verity kernel arguments:\n%w", err)
+	}
+
+	// UKI is enabled, update ukify kernel cmdline args file instead of grub.cfg.
+	err = appendKernelArgsToUkiCmdlineFile(buildDir, newArgs)
+	if err != nil {
+		return fmt.Errorf("failed to append verity kernel arguments to UKI cmdline file:\n%w", err)
 	}
 
 	return nil

--- a/toolkit/tools/pkg/osmodifierlib/modifydefaultgrub.go
+++ b/toolkit/tools/pkg/osmodifierlib/modifydefaultgrub.go
@@ -16,10 +16,6 @@ var grubArgs = []string{
 	"rd.overlayfs",
 	"roothash",
 	"root",
-	"rd.systemd.verity",
-	"systemd.verity_root_data",
-	"systemd.verity_root_hash",
-	"systemd.verity_root_options",
 	"selinux",
 	"enforcing",
 }


### PR DESCRIPTION
<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

---
This is a pr that moved from https://github.com/microsoft/azurelinux/pull/10584/files from old repo with comments addressed.

Changes included:
- Add verity and root device to EMU API (Did not make Verity a list like in MIC because Trident logic filters root Verity)
- Add a dedicated verity type for EMU as there are less fields needed in trident (see [here](https://dev.azure.com/mariner-org/ECF/_git/trident?path=/src/engine/boot/grub.rs&version=GBmain&line=182&lineEnd=183&lineStartColumn=1&lineEndColumn=1&lineStyle=plain&_a=contents ))
- revised EMU GRUB update logic to create bootCustomizer and call WriteToFile just once


### **Checklist**
- [x] Code conforms to style guidelines
