### PR TITLE
imagehistory tests

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
@@ -65,7 +65,7 @@ func doOsCustomizations(buildDir string, baseConfigPath string, config *imagecus
 	}
 
 	if config.OS.ImageHistory != imagecustomizerapi.ImageHistoryNone {
-		err = addImageHistory(imageChroot, imageUuid, baseConfigPath, ToolVersion, buildTime, config)
+		err = addImageHistory(imageChroot.RootDir(), imageUuid, baseConfigPath, ToolVersion, buildTime, config)
 		if err != nil {
 			return err
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagehistory.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagehistory.go
@@ -12,7 +12,6 @@ import (
 	"github.com/microsoft/azurelinux/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
-	"github.com/microsoft/azurelinux/toolkit/tools/internal/safechroot"
 )
 
 type ImageHistory struct {
@@ -28,7 +27,7 @@ const (
 	redactedString       = "[redacted]"
 )
 
-func addImageHistory(imageChroot *safechroot.Chroot, imageUuid string, baseConfigPath string, toolVersion string, buildTime string, config *imagecustomizerapi.Config) error {
+func addImageHistory(rootDir string, imageUuid string, baseConfigPath string, toolVersion string, buildTime string, config *imagecustomizerapi.Config) error {
 	var err error
 	logger.Log.Infof("Creating image customizer history file")
 
@@ -43,7 +42,7 @@ func addImageHistory(imageChroot *safechroot.Chroot, imageUuid string, baseConfi
 		return fmt.Errorf("failed to modify config while writing image history:\n%w", err)
 	}
 
-	customizerLoggingDirPath := filepath.Join(imageChroot.RootDir(), customizerLoggingDir)
+	customizerLoggingDirPath := filepath.Join(rootDir, customizerLoggingDir)
 	err = os.MkdirAll(customizerLoggingDirPath, 0o755)
 	if err != nil {
 		return fmt.Errorf("failed to create customizer logging directory:\n%w", err)

--- a/toolkit/tools/pkg/imagecustomizerlib/imagehistory.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagehistory.go
@@ -25,6 +25,7 @@ type ImageHistory struct {
 const (
 	customizerLoggingDir = "/usr/share/image-customizer"
 	historyFileName      = "history.json"
+	redactedString       = "[redacted]"
 )
 
 func addImageHistory(imageChroot *safechroot.Chroot, imageUuid string, baseConfigPath string, toolVersion string, buildTime string, config *imagecustomizerapi.Config) error {
@@ -122,7 +123,6 @@ func deepCopyConfig(config *imagecustomizerapi.Config) (*imagecustomizerapi.Conf
 
 func modifyConfig(configCopy *imagecustomizerapi.Config, baseConfigPath string) error {
 	var err error
-	redactedString := "[redacted]"
 
 	err = populateScriptsList(configCopy.Scripts, baseConfigPath)
 	if err != nil {
@@ -139,7 +139,7 @@ func modifyConfig(configCopy *imagecustomizerapi.Config, baseConfigPath string) 
 		return fmt.Errorf("failed to populate additional dirs:\n%w", err)
 	}
 
-	err = redactSshPublicKeys(configCopy.OS.Users, redactedString)
+	err = redactSshPublicKeys(configCopy.OS.Users)
 	if err != nil {
 		return fmt.Errorf("failed to redact ssh public keys:\n%w", err)
 	}
@@ -198,7 +198,7 @@ func populateAdditionalFiles(configAdditionalFiles imagecustomizerapi.Additional
 	return nil
 }
 
-func redactSshPublicKeys(configUsers []imagecustomizerapi.User, redactedString string) error {
+func redactSshPublicKeys(configUsers []imagecustomizerapi.User) error {
 	for i := range configUsers {
 		user := configUsers[i]
 		for j := range user.SSHPublicKeys {

--- a/toolkit/tools/pkg/imagecustomizerlib/imagehistory_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagehistory_test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/microsoft/azurelinux/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
-	"github.com/microsoft/azurelinux/toolkit/tools/internal/safechroot"
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/yaml.v3"
 )
@@ -25,10 +24,6 @@ func createTestConfig(configFilePath string, t *testing.T) imagecustomizerapi.Co
 
 func TestAddImageHistory(t *testing.T) {
 	tempDir := filepath.Join(tmpDir, "TestAddImageHistory")
-	chroot := safechroot.NewChroot(tempDir, false)
-	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{}, false)
-	assert.NoError(t, err)
-	defer chroot.Close(false)
 
 	historyDir := filepath.Join(tempDir, customizerLoggingDir)
 	historyFilePath := filepath.Join(historyDir, historyFileName)
@@ -43,7 +38,7 @@ func TestAddImageHistory(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Test adding the first entry
-	err = addImageHistory(chroot, expectedUuid, testDir, expectedVersion, expectedDate, &config)
+	err = addImageHistory(tempDir, expectedUuid, testDir, expectedVersion, expectedDate, &config)
 	assert.NoError(t, err, "addImageHistory should not return an error")
 
 	verifyHistoryFile(t, 1, expectedUuid, expectedVersion, expectedDate, config, historyFilePath)
@@ -56,7 +51,7 @@ func TestAddImageHistory(t *testing.T) {
 	// Test adding another entry with a different uuid
 	_, expectedUuid, err = createUuid()
 	assert.NoError(t, err)
-	err = addImageHistory(chroot, expectedUuid, testDir, expectedVersion, expectedDate, &config)
+	err = addImageHistory(tempDir, expectedUuid, testDir, expectedVersion, expectedDate, &config)
 	assert.NoError(t, err, "addImageHistory should not return an error")
 
 	allHistory := verifyHistoryFile(t, 2, expectedUuid, expectedVersion, expectedDate, config, historyFilePath)

--- a/toolkit/tools/pkg/imagecustomizerlib/imagehistory_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagehistory_test.go
@@ -58,7 +58,6 @@ func TestAddImageHistory(t *testing.T) {
 
 	// Verify the imageUuid is unique for each entry
 	assert.NotEqual(t, allHistory[0].ImageUuid, allHistory[1].ImageUuid, "imageUuid should be different for each entry")
-
 }
 
 func verifyHistoryFile(t *testing.T, expectedEntries int, expectedUuid string, expectedVersion string, expectedDate string, config imagecustomizerapi.Config, historyFilePath string) (allHistory []ImageHistory) {
@@ -81,16 +80,16 @@ func verifyHistoryFile(t *testing.T, expectedEntries int, expectedUuid string, e
 	// Since the config is modified its entirety won't be an exact match; picking one consistent field to verify
 	assert.Equal(t, config.OS.BootLoader.ResetType, entry.Config.OS.BootLoader.ResetType, "config bootloader reset type should match")
 
-	verifyAdditionalFilesHashes(entry.Config.OS.AdditionalFiles, t)
-	verifyAdditionalDirsHashes(entry.Config.OS.AdditionalDirs, t)
-	verifyScriptsHashes(entry.Config.Scripts.PostCustomization, t)
-	verifyScriptsHashes(entry.Config.Scripts.FinalizeCustomization, t)
-	verifySshPublicKeysRedacted(entry.Config.OS.Users, t)
+	verifyAdditionalFilesHashes(t, entry.Config.OS.AdditionalFiles)
+	verifyAdditionalDirsHashes(t, entry.Config.OS.AdditionalDirs)
+	verifyScriptsHashes(t, entry.Config.Scripts.PostCustomization)
+	verifyScriptsHashes(t, entry.Config.Scripts.FinalizeCustomization)
+	verifySshPublicKeysRedacted(t, entry.Config.OS.Users)
 
 	return
 }
 
-func verifySshPublicKeysRedacted(users []imagecustomizerapi.User, t *testing.T) {
+func verifySshPublicKeysRedacted(t *testing.T, users []imagecustomizerapi.User) {
 	for _, user := range users {
 		for _, key := range user.SSHPublicKeys {
 			assert.Equal(t, redactedString, key, "SSH public keys should be redacted")
@@ -98,7 +97,7 @@ func verifySshPublicKeysRedacted(users []imagecustomizerapi.User, t *testing.T) 
 	}
 }
 
-func verifyScriptsHashes(scripts []imagecustomizerapi.Script, t *testing.T) {
+func verifyScriptsHashes(t *testing.T, scripts []imagecustomizerapi.Script) {
 	for _, script := range scripts {
 		if script.Path != "" {
 			verifyFileHash(t, script.Path, script.SHA256Hash)
@@ -107,7 +106,7 @@ func verifyScriptsHashes(scripts []imagecustomizerapi.Script, t *testing.T) {
 		}
 	}
 }
-func verifyAdditionalFilesHashes(files imagecustomizerapi.AdditionalFileList, t *testing.T) {
+func verifyAdditionalFilesHashes(t *testing.T, files imagecustomizerapi.AdditionalFileList) {
 	for _, f := range files {
 		if f.Source != "" {
 			verifyFileHash(t, f.Source, f.SHA256Hash)
@@ -117,7 +116,7 @@ func verifyAdditionalFilesHashes(files imagecustomizerapi.AdditionalFileList, t 
 	}
 }
 
-func verifyAdditionalDirsHashes(dirs imagecustomizerapi.DirConfigList, t *testing.T) {
+func verifyAdditionalDirsHashes(t *testing.T, dirs imagecustomizerapi.DirConfigList) {
 	for _, dir := range dirs {
 		assert.NotEmpty(t, dir.SHA256HashMap, "SHA256HashMap for additional directories should not be empty")
 		for relPath, hash := range dir.SHA256HashMap {

--- a/toolkit/tools/pkg/imagecustomizerlib/imagehistory_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagehistory_test.go
@@ -1,0 +1,179 @@
+package imagecustomizerlib
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/imagecustomizerapi"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/safechroot"
+	"github.com/stretchr/testify/assert"
+)
+
+func createTestConfig(configFilePath string, t *testing.T) imagecustomizerapi.Config {
+	configFile := filepath.Join(testDir, configFilePath)
+
+	var config imagecustomizerapi.Config
+	err := imagecustomizerapi.UnmarshalYamlFile(configFile, &config)
+	assert.NoError(t, err)
+	return config
+}
+
+func TestAddImageHistory(t *testing.T) {
+	tempDir := filepath.Join(tmpDir, "TestAddImageHistory")
+	chroot := safechroot.NewChroot(tempDir, false)
+	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{}, false)
+	assert.NoError(t, err)
+	defer chroot.Close(false)
+
+	historyDir := filepath.Join(tempDir, customizerLoggingDir)
+	historyFilePath := filepath.Join(historyDir, historyFileName)
+	config := createTestConfig("imagehistory-config.yaml", t)
+	expectedVersion := "0.1.0"
+	expectedDate := time.Now().Format("2006-01-02T15:04:05Z")
+	_, expectedUuid, err := createUuid()
+	assert.NoError(t, err)
+
+	// Test adding the first entry
+	err = addImageHistory(chroot, expectedUuid, testDir, expectedVersion, expectedDate, &config)
+	assert.NoError(t, err, "addImageHistory should not return an error")
+
+	verifyHistoryFile(t, 1, expectedUuid, expectedVersion, expectedDate, config, historyFilePath)
+
+	// Test adding another entry with a different uuid
+	_, expectedUuid, err = createUuid()
+	assert.NoError(t, err)
+	err = addImageHistory(chroot, expectedUuid, testDir, expectedVersion, expectedDate, &config)
+	assert.NoError(t, err, "addImageHistory should not return an error")
+
+	verifyHistoryFile(t, 2, expectedUuid, expectedVersion, expectedDate, config, historyFilePath)
+}
+
+func verifyHistoryFile(t *testing.T, expectedEntries int, expectedUuid string, expectedVersion string, expectedDate string, config imagecustomizerapi.Config, historyFilePath string) {
+	exists, err := file.PathExists(historyFilePath)
+	assert.NoError(t, err, "error checking history file existence")
+	assert.True(t, exists, "history file should exist")
+
+	historyContent, err := os.ReadFile(historyFilePath)
+	assert.NoError(t, err, "error reading history file")
+
+	var allHistory []ImageHistory
+	err = json.Unmarshal(historyContent, &allHistory)
+	assert.NoError(t, err, "error unmarshalling history content")
+	assert.Len(t, allHistory, expectedEntries, "history file should contain the expected number of entries")
+
+	// Verify the last entry content
+	entry := allHistory[expectedEntries-1]
+	assert.Equal(t, expectedUuid, entry.ImageUuid, "imageUuid should match")
+	assert.Equal(t, expectedVersion, entry.ToolVersion, "toolVersion should match")
+	assert.Equal(t, expectedDate, entry.BuildTime, "buildTime should match")
+	// Since the config is modified its entirety won't be an exact match; picking one consistent field to verify
+	assert.Equal(t, config.OS.BootLoader.ResetType, entry.Config.OS.BootLoader.ResetType, "config bootloader reset type should match")
+
+	// Verify the imageUuid is unique for each entry
+	if expectedEntries == 2 {
+		assert.NotEqual(t, allHistory[0].ImageUuid, allHistory[1].ImageUuid, "imageUuid should be different for each entry")
+	}
+}
+
+func TestDeepCopyConfig(t *testing.T) {
+	config := createTestConfig("imagehistory-config.yaml", t)
+
+	copiedConfig, err := deepCopyConfig(&config)
+
+	assert.NoError(t, err, "deepCopyConfig should not return an error")
+	assert.NotSame(t, config, copiedConfig, "deepCopyConfig should create a new instance")
+}
+
+func TestModifyConfig(t *testing.T) {
+	config := createTestConfig("imagehistory-config.yaml", t)
+
+	err := modifyConfig(&config, testDir)
+	assert.NoError(t, err, "modifyConfig should not return an error")
+
+	isNotEmptyAdditionalFilesHashes(config.OS.AdditionalFiles, t)
+
+	isNotEmptyAdditionalDirsHashes(config.OS.AdditionalDirs, t)
+
+	isNotEmptyScriptsHashes(config.Scripts.PostCustomization, t)
+	isNotEmptyScriptsHashes(config.Scripts.FinalizeCustomization, t)
+
+	verifySshPublicKeysRedacted(config.OS.Users, t)
+}
+
+func TestRedactSshPublicKeys(t *testing.T) {
+	mockUsers := []imagecustomizerapi.User{
+		{
+			SSHPublicKeys: []string{"key1", "key2"},
+		},
+	}
+
+	err := redactSshPublicKeys(mockUsers)
+	assert.NoError(t, err, "redactSshPublicKeys should not return an error")
+
+	verifySshPublicKeysRedacted(mockUsers, t)
+}
+
+func TestPopulateAdditionalDirs(t *testing.T) {
+	dirs := createTestConfig("adddirs-config.yaml", t).OS.AdditionalDirs
+
+	err := populateAdditionalDirs(dirs, testDir)
+	assert.NoError(t, err, "populateAdditionalDirs should not return an error")
+
+	isNotEmptyAdditionalDirsHashes(dirs, t)
+}
+
+func TestPopulateAdditionalFiles(t *testing.T) {
+	files := createTestConfig("addfiles-config.yaml", t).OS.AdditionalFiles
+
+	err := populateAdditionalFiles(files, testDir)
+	assert.NoError(t, err, "populateAdditionalFiles should not return an error")
+
+	isNotEmptyAdditionalFilesHashes(files, t)
+}
+
+func TestPopulateScriptsList(t *testing.T) {
+	scripts := createTestConfig("runscripts-config.yaml", t).Scripts
+
+	err := populateScriptsList(scripts, testDir)
+	assert.NoError(t, err, "populateScriptsList should not return an error")
+
+	isNotEmptyScriptsHashes(scripts.PostCustomization, t)
+	isNotEmptyScriptsHashes(scripts.FinalizeCustomization, t)
+}
+
+func verifySshPublicKeysRedacted(users []imagecustomizerapi.User, t *testing.T) {
+	for _, user := range users {
+		for _, key := range user.SSHPublicKeys {
+			assert.Equal(t, redactedString, key, "SSH public keys should be redacted")
+		}
+	}
+}
+
+func isNotEmptyScriptsHashes(scripts []imagecustomizerapi.Script, t *testing.T) {
+	for _, script := range scripts {
+		if script.Path != "" {
+			assert.NotEmpty(t, script.SHA256Hash, "script hash should not be empty")
+		} else {
+			assert.Empty(t, script.SHA256Hash, "script hash should be empty")
+		}
+	}
+}
+func isNotEmptyAdditionalFilesHashes(files imagecustomizerapi.AdditionalFileList, t *testing.T) {
+	for _, file := range files {
+		if file.Source != "" {
+			assert.NotEmpty(t, file.SHA256Hash, "SHA256Hash for additional files should not be empty")
+		} else {
+			assert.Empty(t, file.SHA256Hash, "SHA256Hash for additional files should be empty")
+		}
+	}
+}
+
+func isNotEmptyAdditionalDirsHashes(dirs imagecustomizerapi.DirConfigList, t *testing.T) {
+	for _, dir := range dirs {
+		assert.NotEmpty(t, dir.SHA256HashMap, "SHA256HashMap for additional directories should not be empty")
+	}
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/dirs/a/usr/local/bin/plants.sh
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/dirs/a/usr/local/bin/plants.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+
+echo "aloe vera and cactus"

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/imagehistory-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/imagehistory-config.yaml
@@ -75,7 +75,7 @@ os:
     resetType: hard-reset
   
   kernelCommandLine:
-    extraCommandLine: ["console=tty0 console=ttyS0"]
+    extraCommandLine: ["console=tty0", "console=ttyS0"]
 
   additionalDirs:
   - source: dirs/a

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/imagehistory-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/imagehistory-config.yaml
@@ -1,0 +1,124 @@
+storage:
+  disks:
+  - partitionTableType: gpt
+    maxSize: 4G
+    partitions:
+    - id: esp
+      type: esp
+      start: 1M
+      end: 9M
+
+    - id: boot
+      start: 9M
+      end: 108M
+
+    - id: rootfs
+      label: rootfs
+      size: 1G
+
+    - id: var
+      start: 2G
+      size: grow
+      
+  bootType: efi
+
+  filesystems:
+  - deviceId: esp
+    type: fat32
+    mountPoint:
+      path: /boot/efi
+      options: umask=0077
+
+  - deviceId: boot
+    type: ext4
+    mountPoint:
+      path: /boot
+
+  - deviceId: rootfs
+    type: xfs
+    mountPoint:
+      path: /
+
+  - deviceId: var
+    type: xfs
+    mountPoint:
+      path: /var
+
+os:
+  packages:
+      remove:
+      - which
+
+      install:
+      - jq
+
+      installLists:
+      - lists/golang.yaml
+
+      update:
+      - jq
+  users:
+    - name: mariner_user
+      sshPublicKeys:
+        - ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQDQ
+        - /home/test/.ssh/authorized_keys
+        - "test"
+        - ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAnotvalidAAIFyWtgGE06d/uBFQm70fRDoh06bWQQwC6Qkm test@test-machine
+      secondaryGroups:
+      - sudo
+
+    - name: test
+      secondaryGroups:
+      - sudo
+  
+  bootloader:
+    resetType: hard-reset
+  
+  kernelCommandLine:
+    extraCommandLine: ["console=tty0 console=ttyS0"]
+
+  additionalDirs:
+  - source: dirs/a
+    destination: /
+  - source: dirs/b
+    destination: /
+
+  
+  additionalFiles:
+  - source: files/a.txt
+    destination: /a.txt
+
+  - source: files/helloworld.sh
+    destination: /usr/local/bin/helloworld.sh
+    permissions: 755
+
+  - content: |
+      cat
+      dog
+    destination: /animals.txt
+
+  - content: |-
+      abcdefghijklmnopqrstuvwxyz
+    destination: /alphabet.txt
+    permissions: 644
+
+  - content: ""
+    destination: /empty.txt
+
+scripts:
+  postCustomization:
+  - path: scripts/postcustomizationscript.sh
+  - content: |
+      echo "This is an postCustomization inline script"
+      echo "$1 $2"
+      echo "$fruit and $vegetable"
+      echo "Working dir: $(pwd)"
+    arguments:
+    - hello
+    - world
+    environmentVariables:
+      fruit: bananas
+      vegetable: carrots
+
+  finalizeCustomization:
+  - path: scripts/finalizecustomizationscript.sh


### PR DESCRIPTION
Added tests for image history.

Test cases:
- Adding an entry to image history
- Adding another entry to image history with a different uuid
- Deep copying config
- Modifying config
- Populate / redact functions

Moved redactedString to a constant so it can be reused in the tests.
Added another file in additional dirs for good measure (I found that it helped while locally testing image history).
Added a config for image history that contains several different fields.

Possible future tests:
Test custom MarshalJSON functions that were added for image history
Test omitting JSON fields as selected

---

### **Checklist**
- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
