### PR TITLE
use rootdir instead of chroot for image release file

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
@@ -59,7 +59,7 @@ func doOsCustomizations(buildDir string, baseConfigPath string, config *imagecus
 		return err
 	}
 
-	err = addCustomizerRelease(imageChroot, ToolVersion, buildTime, imageUuid)
+	err = addCustomizerRelease(imageChroot.RootDir(), ToolVersion, buildTime, imageUuid)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/releasefile.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/releasefile.go
@@ -9,15 +9,14 @@ import (
 
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
-	"github.com/microsoft/azurelinux/toolkit/tools/internal/safechroot"
 )
 
-func addCustomizerRelease(imageChroot *safechroot.Chroot, toolVersion string, buildTime string, imageUuid string) error {
+func addCustomizerRelease(rootDir string, toolVersion string, buildTime string, imageUuid string) error {
 	var err error
 
 	logger.Log.Infof("Creating image customizer release file")
 
-	customizerReleaseFilePath := filepath.Join(imageChroot.RootDir(), "/etc/image-customizer-release")
+	customizerReleaseFilePath := filepath.Join(rootDir, "/etc/image-customizer-release")
 	lines := []string{
 		fmt.Sprintf("%s=\"%s\"", "TOOL_VERSION", toolVersion),
 		fmt.Sprintf("%s=\"%s\"", "BUILD_DATE", buildTime),

--- a/toolkit/tools/pkg/imagecustomizerlib/releasefile_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/releasefile_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/microsoft/azurelinux/toolkit/tools/internal/safechroot"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -21,12 +20,8 @@ func TestAddCustomizerRelease(t *testing.T) {
 	}
 
 	proposedDir := filepath.Join(tmpDir, "TestAddCustomizerRelease")
-	chroot := safechroot.NewChroot(proposedDir, false)
-	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{}, false)
-	assert.NoError(t, err)
-	defer chroot.Close(false)
 
-	err = os.MkdirAll(filepath.Join(chroot.RootDir(), "etc"), os.ModePerm)
+	err := os.MkdirAll(filepath.Join(proposedDir, "etc"), os.ModePerm)
 	assert.NoError(t, err)
 
 	expectedVersion := "0.1.0"
@@ -34,10 +29,10 @@ func TestAddCustomizerRelease(t *testing.T) {
 	_, expectedUuid, err := createUuid()
 	assert.NoError(t, err)
 
-	err = addCustomizerRelease(chroot, expectedVersion, expectedDate, expectedUuid)
+	err = addCustomizerRelease(proposedDir, expectedVersion, expectedDate, expectedUuid)
 	assert.NoError(t, err)
 
-	releaseFilePath := filepath.Join(chroot.RootDir(), "etc/image-customizer-release")
+	releaseFilePath := filepath.Join(proposedDir, "etc/image-customizer-release")
 
 	file, err := os.Open(releaseFilePath)
 	if err != nil {


### PR DESCRIPTION
In the function to add release file, we pass in chroot and find its root dir, which consequently requires us to initialize a chroot in its test. Since the only purpose of passing in chroot is to get its root dir, we can simplify the function (and test) by passing in the root dir directly.

---

### **Checklist**
- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
