### PR TITLE
Add additional partition types.

### DIFF
--- a/docs/imagecustomizer/api/configuration/partition.md
+++ b/docs/imagecustomizer/api/configuration/partition.md
@@ -90,8 +90,12 @@ Supported options:
 
 - `usr-verity`: The verity hash partition for `/usr`.
 
+  Note: Image Customizer does not yet support `/usr` verity partitions.
+
 - `var`: The `/var` partition.
 
 - `xbootldr`: The `/boot` partition.
 
-In addition, a UUID string may be specified.
+- A UUID string.
+
+  For example: `c12a7328-f81f-11d2-ba4b-00a0c93ec93b`

--- a/docs/imagecustomizer/api/configuration/partition.md
+++ b/docs/imagecustomizer/api/configuration/partition.md
@@ -69,3 +69,29 @@ Supported options:
   This flag is only supported on GPT formatted disks.
 
   For further details, see: https://en.wikipedia.org/wiki/BIOS_boot_partition
+
+- `home`: A `/home` partition.
+
+- `linux-generic`: A generic Linux partition.
+
+  This is the default value.
+
+- `root`: The `/` partition.
+
+- `root-verity`: The verity hash partition for `/`.
+
+- `srv`: The `/srv` partition.
+
+- `swap`: A swap partition.
+
+- `tmp`: The `/var/tmp` partition.
+
+- `usr`: The `/usr` partition.
+
+- `usr-verity`: The verity hash partition for `/usr`.
+
+- `var`: The `/var` partition.
+
+- `xbootldr`: The `/boot` partition.
+
+In addition, a UUID string may be specified.

--- a/docs/imagecustomizer/api/configuration/partition.md
+++ b/docs/imagecustomizer/api/configuration/partition.md
@@ -68,7 +68,7 @@ Supported options:
 
   This flag is only supported on GPT formatted disks.
 
-  For further details, see: https://en.wikipedia.org/wiki/BIOS_boot_partition
+  For further details, see: [Wikipedia's BIOS boot partition article](https://en.wikipedia.org/wiki/BIOS_boot_partition)
 
 - `home`: A `/home` partition.
 
@@ -96,6 +96,11 @@ Supported options:
 
 - `xbootldr`: The `/boot` partition.
 
-- A UUID string.
+- A partition type UUID string.
+
+  A list of well-known UUID values can be found in:
+  
+  - [Wikipedia's GUID Partition Table article](https://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs)
+  - [The Discoverable Partitions Specification (DPS)](https://uapi-group.org/specifications/specs/discoverable_partitions_specification/#defined-partition-type-uuids)
 
   For example: `c12a7328-f81f-11d2-ba4b-00a0c93ec93b`

--- a/toolkit/tools/imagecustomizerapi/main_test.go
+++ b/toolkit/tools/imagecustomizerapi/main_test.go
@@ -12,12 +12,17 @@ import (
 
 var (
 	workingDir string
+
+	logMessagesHook *logger.MemoryLogHook
 )
 
 func TestMain(m *testing.M) {
 	var err error
 
 	logger.InitStderrLog()
+
+	logMessagesHook = logger.NewMemoryLogHook()
+	logger.Log.Hooks.Add(logMessagesHook)
 
 	workingDir, err = os.Getwd()
 	if err != nil {

--- a/toolkit/tools/imagecustomizerapi/partition.go
+++ b/toolkit/tools/imagecustomizerapi/partition.go
@@ -20,7 +20,7 @@ type Partition struct {
 	End *DiskSize `yaml:"end" json:"end,omitempty"`
 	// Size is the size of the partition.
 	Size PartitionSize `yaml:"size" json:"size,omitempty"`
-	// Type specifies the type of partition the partition is.
+	// Type specifies the type of the partition.
 	Type PartitionType `yaml:"type" json:"type,omitempty"`
 }
 

--- a/toolkit/tools/imagecustomizerapi/partition_test.go
+++ b/toolkit/tools/imagecustomizerapi/partition_test.go
@@ -165,5 +165,29 @@ func TestPartitionIsValidBadType(t *testing.T) {
 
 	err := partition.IsValid()
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "unknown partition type")
+	assert.ErrorContains(t, err, "partition type is unknown and is not a UUID (a)")
+}
+
+func TestPartitionIsValidTypeUuid(t *testing.T) {
+	partition := Partition{
+		Id:    "a",
+		Start: ptrutils.PtrTo(DiskSize(0)),
+		End:   nil,
+		Type:  "c12a7328-f81f-11d2-ba4b-00a0c93ec93b",
+	}
+
+	err := partition.IsValid()
+	assert.NoError(t, err)
+}
+
+func TestPartitionIsValidTypeUuidInvalid(t *testing.T) {
+	partition := Partition{
+		Id:    "a",
+		Start: ptrutils.PtrTo(DiskSize(0)),
+		End:   nil,
+		Type:  "c12a7328-f81f-11d2-ba4b-00a0c93ec93",
+	}
+
+	err := partition.IsValid()
+	assert.ErrorContains(t, err, "partition type is unknown and is not a UUID (c12a7328-f81f-11d2-ba4b-00a0c93ec93)")
 }

--- a/toolkit/tools/imagecustomizerapi/partitiontype.go
+++ b/toolkit/tools/imagecustomizerapi/partitiontype.go
@@ -38,7 +38,7 @@ const (
 )
 
 var (
-	// UUUIs come from:
+	// UUIDs come from:
 	// - https://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
 	// - https://uapi-group.org/specifications/specs/discoverable_partitions_specification/
 	partitionTypeToUuidArchIndependent = map[PartitionType]string{

--- a/toolkit/tools/imagecustomizerapi/partitiontype.go
+++ b/toolkit/tools/imagecustomizerapi/partitiontype.go
@@ -38,6 +38,9 @@ const (
 )
 
 var (
+	// UUUIs come from:
+	// - https://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
+	// - https://uapi-group.org/specifications/specs/discoverable_partitions_specification/
 	partitionTypeToUuidArchIndependent = map[PartitionType]string{
 		PartitionTypeESP:      "c12a7328-f81f-11d2-ba4b-00a0c93ec93b",
 		PartitionTypeBiosGrub: "21686148-6449-6E6F-744E-656564454649",

--- a/toolkit/tools/imagecustomizerapi/partitiontype.go
+++ b/toolkit/tools/imagecustomizerapi/partitiontype.go
@@ -23,15 +23,96 @@ const (
 	//
 	// See, https://en.wikipedia.org/wiki/BIOS_boot_partition
 	PartitionTypeBiosGrub PartitionType = "bios-grub"
+
+	PartitionTypeHome         = "home"
+	PartitionTypeLinuxGeneric = "linux-generic"
+	PartitionTypeRoot         = "root"
+	PartitionTypeRootVerity   = "root-verity"
+	PartitionTypeSrv          = "srv"
+	PartitionTypeSwap         = "swap"
+	PartitionTypeTmp          = "tmp"
+	PartitionTypeUsr          = "usr"
+	PartitionTypeUsrVerity    = "usr-verity"
+	PartitionTypeVar          = "var"
+	PartitionTypeXbootldr     = "xbootldr"
 )
+
+var (
+	partitionTypeToUuidArchIndependent = map[PartitionType]string{
+		PartitionTypeESP:      "c12a7328-f81f-11d2-ba4b-00a0c93ec93b",
+		PartitionTypeBiosGrub: "21686148-6449-6E6F-744E-656564454649",
+		PartitionTypeHome:     "933ac7e1-2eb4-4f13-b844-0e14e2aef915",
+		PartitionTypeSrv:      "3b8f8425-20e0-4f3b-907f-1a25a76f98e8",
+		PartitionTypeSwap:     "0657fd6d-a4ab-43c4-84e5-0933c84b4f4f",
+		PartitionTypeTmp:      "7ec6f557-3bc5-4aca-b293-16ef5df639d1",
+		PartitionTypeVar:      "4d21b016-b534-45c2-a9fb-5c16e091fd2d",
+		PartitionTypeXbootldr: "bc13c2ff-59e6-4262-a352-b275fd6f7172",
+	}
+
+	PartitionTypeToUuid map[PartitionType]string
+
+	// List of supported mount paths for each partition type.
+	// No entry means there are no associated mount paths for the partition type.
+	// Empty list means the partition type should not be mounted.
+	PartitionTypeSupportedMountPaths = map[PartitionType][]string{
+		PartitionTypeESP: {
+			"/boot/efi",
+		},
+		PartitionTypeBiosGrub: {},
+		PartitionTypeHome: {
+			"/home",
+		},
+		PartitionTypeRoot: {
+			"/",
+		},
+		PartitionTypeRootVerity: {},
+		PartitionTypeSrv: {
+			"/srv",
+		},
+		PartitionTypeSwap: {},
+		PartitionTypeTmp: {
+			"/var/tmp",
+		},
+		PartitionTypeUsr: {
+			"/usr",
+		},
+		PartitionTypeUsrVerity: {},
+		PartitionTypeVar: {
+			"/var",
+		},
+		PartitionTypeXbootldr: {
+			"/boot",
+		},
+	}
+)
+
+func init() {
+	PartitionTypeToUuid = make(map[PartitionType]string)
+
+	for k, v := range partitionTypeToUuidArchIndependent {
+		PartitionTypeToUuid[k] = v
+	}
+
+	for k, v := range partitionTypeToUuidArchDependent {
+		PartitionTypeToUuid[k] = v
+	}
+}
 
 func (p PartitionType) IsValid() (err error) {
 	switch p {
-	case PartitionTypeDefault, PartitionTypeESP, PartitionTypeBiosGrub:
-		// All good.
+	case PartitionTypeDefault, PartitionTypeESP, PartitionTypeBiosGrub, PartitionTypeHome, PartitionTypeLinuxGeneric,
+		PartitionTypeRoot, PartitionTypeRootVerity, PartitionTypeSrv, PartitionTypeSwap, PartitionTypeTmp,
+		PartitionTypeUsr, PartitionTypeUsrVerity, PartitionTypeVar, PartitionTypeXbootldr:
+		// String is a well known name.
 		return nil
 
 	default:
-		return fmt.Errorf("unknown partition type (%s)", p)
+		isUuid := uuidRegex.MatchString(string(p))
+		if isUuid {
+			// String is a UUID.
+			return nil
+		}
+
+		return fmt.Errorf("partition type is unknown and is not a UUID (%s)", p)
 	}
 }

--- a/toolkit/tools/imagecustomizerapi/partitiontype_amd64.go
+++ b/toolkit/tools/imagecustomizerapi/partitiontype_amd64.go
@@ -4,7 +4,7 @@
 package imagecustomizerapi
 
 var (
-	// UUUIs come from:
+	// UUIDs come from:
 	// - https://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
 	// - https://uapi-group.org/specifications/specs/discoverable_partitions_specification/
 	partitionTypeToUuidArchDependent = map[PartitionType]string{

--- a/toolkit/tools/imagecustomizerapi/partitiontype_amd64.go
+++ b/toolkit/tools/imagecustomizerapi/partitiontype_amd64.go
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+var (
+	partitionTypeToUuidArchDependent = map[PartitionType]string{
+		PartitionTypeRoot:       "4f68bce3-e8cd-4db1-96e7-fbcaf984b709",
+		PartitionTypeRootVerity: "2c7357ed-ebd2-46d9-aec1-23d437ec2bf5",
+		PartitionTypeUsr:        "8484680c-9521-48c6-9c11-b0720656f69e",
+		PartitionTypeUsrVerity:  "77ff5f63-e7b6-4633-acf4-1565b864c0e6",
+	}
+)

--- a/toolkit/tools/imagecustomizerapi/partitiontype_amd64.go
+++ b/toolkit/tools/imagecustomizerapi/partitiontype_amd64.go
@@ -4,6 +4,9 @@
 package imagecustomizerapi
 
 var (
+	// UUUIs come from:
+	// - https://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
+	// - https://uapi-group.org/specifications/specs/discoverable_partitions_specification/
 	partitionTypeToUuidArchDependent = map[PartitionType]string{
 		PartitionTypeRoot:       "4f68bce3-e8cd-4db1-96e7-fbcaf984b709",
 		PartitionTypeRootVerity: "2c7357ed-ebd2-46d9-aec1-23d437ec2bf5",

--- a/toolkit/tools/imagecustomizerapi/partitiontype_arm64.go
+++ b/toolkit/tools/imagecustomizerapi/partitiontype_arm64.go
@@ -4,6 +4,9 @@
 package imagecustomizerapi
 
 var (
+	// UUUIs come from:
+	// - https://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
+	// - https://uapi-group.org/specifications/specs/discoverable_partitions_specification/
 	partitionTypeToUuidArchDependent = map[PartitionType]string{
 		PartitionTypeRoot:       "b921b045-1df0-41c3-af44-4c6f280d3fae",
 		PartitionTypeRootVerity: "df3300ce-d69f-4c92-978c-9bfb0f38d820",

--- a/toolkit/tools/imagecustomizerapi/partitiontype_arm64.go
+++ b/toolkit/tools/imagecustomizerapi/partitiontype_arm64.go
@@ -4,7 +4,7 @@
 package imagecustomizerapi
 
 var (
-	// UUUIs come from:
+	// UUIDs come from:
 	// - https://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
 	// - https://uapi-group.org/specifications/specs/discoverable_partitions_specification/
 	partitionTypeToUuidArchDependent = map[PartitionType]string{

--- a/toolkit/tools/imagecustomizerapi/partitiontype_arm64.go
+++ b/toolkit/tools/imagecustomizerapi/partitiontype_arm64.go
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+var (
+	partitionTypeToUuidArchDependent = map[PartitionType]string{
+		PartitionTypeRoot:       "b921b045-1df0-41c3-af44-4c6f280d3fae",
+		PartitionTypeRootVerity: "df3300ce-d69f-4c92-978c-9bfb0f38d820",
+		PartitionTypeUsr:        "b0e01050-ee5f-4390-949a-9101b17104e9",
+		PartitionTypeUsrVerity:  "6e11a4e7-fbca-4ded-b9e9-e1a512bb664e",
+	}
+)

--- a/toolkit/tools/imagecustomizerapi/uuid.go
+++ b/toolkit/tools/imagecustomizerapi/uuid.go
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"regexp"
+)
+
+var (
+	uuidRegex = regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+)

--- a/toolkit/tools/internal/logger/memoryloghook.go
+++ b/toolkit/tools/internal/logger/memoryloghook.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 package logger
 
 // Used for storing the log messages in memory.

--- a/toolkit/tools/internal/logger/memoryloghook.go
+++ b/toolkit/tools/internal/logger/memoryloghook.go
@@ -1,0 +1,104 @@
+package logger
+
+// Used for storing the log messages in memory.
+// Useful for verifying the log messages in unit tests.
+
+import (
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+type MemoryLogHook struct {
+	subHooksLock sync.Mutex
+	subHooks     []*MemoryLogSubHook
+}
+
+type MemoryLogSubHook struct {
+	parent       *MemoryLogHook
+	messagesLock sync.Mutex
+	messages     []MemoryLogMessage
+}
+
+type MemoryLogMessage struct {
+	Message string
+	Level   logrus.Level
+}
+
+func NewMemoryLogHook() *MemoryLogHook {
+	return &MemoryLogHook{}
+}
+
+func (h *MemoryLogHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+func (h *MemoryLogHook) Fire(entry *logrus.Entry) error {
+	subhooks := h.getSubHooks()
+	for _, subhook := range subhooks {
+		subhook.addEntry(entry)
+	}
+
+	return nil
+}
+
+func (h *MemoryLogHook) AddSubHook() *MemoryLogSubHook {
+	subhook := &MemoryLogSubHook{
+		parent: h,
+	}
+
+	h.subHooksLock.Lock()
+	defer h.subHooksLock.Unlock()
+
+	newSubHooks := append([]*MemoryLogSubHook(nil), h.subHooks...)
+	newSubHooks = append(newSubHooks, subhook)
+	h.subHooks = newSubHooks
+
+	return subhook
+}
+
+func (h *MemoryLogHook) RemoveSubHook(subHook *MemoryLogSubHook) {
+	h.subHooksLock.Lock()
+	defer h.subHooksLock.Unlock()
+
+	newSubHooks := []*MemoryLogSubHook(nil)
+	for _, entry := range h.subHooks {
+		if entry == subHook {
+			continue
+		}
+
+		newSubHooks = append(newSubHooks, entry)
+	}
+
+	h.subHooks = newSubHooks
+}
+
+func (h *MemoryLogHook) getSubHooks() []*MemoryLogSubHook {
+	h.subHooksLock.Lock()
+	defer h.subHooksLock.Unlock()
+	return h.subHooks
+}
+
+func (h *MemoryLogSubHook) addEntry(entry *logrus.Entry) {
+	message := MemoryLogMessage{
+		Message: entry.Message,
+		Level:   entry.Level,
+	}
+
+	h.messagesLock.Lock()
+	defer h.messagesLock.Unlock()
+	h.messages = append(h.messages, message)
+}
+
+func (h *MemoryLogSubHook) Close() {
+	h.parent.RemoveSubHook(h)
+}
+
+func (h *MemoryLogSubHook) ConsumeMessages() []MemoryLogMessage {
+	h.messagesLock.Lock()
+	defer h.messagesLock.Unlock()
+
+	messages := h.messages
+	h.messages = nil
+	return messages
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
@@ -110,6 +110,12 @@ func testCustomizeImagePartitionsToEfi(t *testing.T, testName string, imageType 
 		partitions[mountPoints[1].PartitionNum],
 		partitions[mountPoints[0].PartitionNum],
 		imageVersion)
+
+	// Check the partition types.
+	assert.Equal(t, partitions[1].PartitionTypeUuid, "c12a7328-f81f-11d2-ba4b-00a0c93ec93b") // esp
+	assert.Equal(t, partitions[2].PartitionTypeUuid, "bc13c2ff-59e6-4262-a352-b275fd6f7172") // xbootldr
+	assert.Equal(t, partitions[3].PartitionTypeUuid, "4f68bce3-e8cd-4db1-96e7-fbcaf984b709") // root (x64)
+	assert.Equal(t, partitions[4].PartitionTypeUuid, "4d21b016-b534-45c2-a9fb-5c16e091fd2d") // var
 }
 
 func TestCustomizeImagePartitionsSizeOnly(t *testing.T) {
@@ -170,6 +176,11 @@ func TestCustomizeImagePartitionsSizeOnly(t *testing.T) {
 		partitions[mountPoints[0].PartitionNum],
 		partitions[mountPoints[0].PartitionNum],
 		baseImageVersionDefault)
+
+	// Check the partition types.
+	assert.Equal(t, partitions[1].PartitionTypeUuid, "c12a7328-f81f-11d2-ba4b-00a0c93ec93b") // esp
+	assert.Equal(t, partitions[2].PartitionTypeUuid, "0fc63daf-8483-4772-8e79-3d69d8477de4") // linux generic
+	assert.Equal(t, partitions[3].PartitionTypeUuid, "0fc63daf-8483-4772-8e79-3d69d8477de4") // linux generic
 }
 
 func TestCustomizeImagePartitionsEfiToLegacy(t *testing.T) {
@@ -226,6 +237,10 @@ func testCustomizeImagePartitionsToLegacy(t *testing.T, testName string, imageTy
 		partitions[coreLegacyMountPoints[0].PartitionNum],
 		partitions[coreLegacyMountPoints[0].PartitionNum],
 		imageVersion)
+
+	// Check the partition types.
+	assert.Equal(t, partitions[1].PartitionTypeUuid, "21686148-6449-6e6f-744e-656564454649") // BIOS boot
+	assert.Equal(t, partitions[2].PartitionTypeUuid, "0fc63daf-8483-4772-8e79-3d69d8477de4") // linux generic
 }
 
 func TestCustomizeImageKernelCommandLine(t *testing.T) {

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/partitions-bad-types.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/partitions-bad-types.yaml
@@ -1,27 +1,23 @@
 storage:
   disks:
   - partitionTableType: gpt
-    maxSize: 4G
     partitions:
     - id: esp
       type: esp
-      start: 1M
-      end: 9M
+      size: 8M
 
     - id: boot
-      type: xbootldr
-      start: 9M
-      end: 108M
+      type: root
+      size: 100M
 
     - id: rootfs
-      type: root
+      type: var
       label: rootfs
-      start: 108M
-      end: 2G
+      size: 2G
 
     - id: var
-      type: 4d21b016-b534-45c2-a9fb-5c16e091fd2d
-      start: 2G
+      type: xbootldr
+      size: 2G
 
   bootType: efi
 


### PR DESCRIPTION
Extend the partition `type` field so that it supports other values. e.g. `root`, `var`, etc. These new values map to well-known partition type UUIDs. In addition, allow the user to specify a UUID string in the `type` field in case we don't yet have a friendly name for that UUID.

Also, add check to ensure the ESP is mounted at `/boot/efi`.

---

### **Checklist**
- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
