### PR TITLE
Remove script capability restrictions.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/runscripts.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/runscripts.go
@@ -20,23 +20,6 @@ const (
 	configDirMountPathInChroot = "/_imageconfigs"
 )
 
-var (
-	// The set of Linux capabilities given to custom scripts.
-	// For the most part, the capabilities given are those related to configuring filesystems and files.
-	scriptsCapabilities = []uintptr{
-		// Change file ownership,
-		unix.CAP_CHOWN,
-		// Ignore file permissions.
-		unix.CAP_DAC_OVERRIDE,
-		// Ignore read-only file permissions.
-		unix.CAP_DAC_READ_SEARCH,
-		// Set file permissions and extended attributes.
-		unix.CAP_FOWNER,
-		// Set capabilities on files.
-		unix.CAP_SETFCAP,
-	}
-)
-
 func runUserScripts(baseConfigPath string, scripts []imagecustomizerapi.Script, listName string,
 	imageChroot *safechroot.Chroot,
 ) error {
@@ -123,7 +106,6 @@ func runUserScript(scriptIndex int, script imagecustomizerapi.Script, listName s
 	err = shell.NewExecBuilder(process, args...).
 		Chroot(imageChroot.RootDir()).
 		EnvironmentVariables(envVars).
-		Capabilities(scriptsCapabilities).
 		WorkingDirectory("/").
 		ErrorStderrLines(1).
 		Execute()

--- a/toolkit/tools/pkg/imagecustomizerlib/runscripts_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/runscripts_test.go
@@ -66,37 +66,3 @@ resolv.conf exists
 
 	verifyFileContentsSame(t, aOrigFilePath, aNewFilePath)
 }
-
-func TestCustomizeImageRunScriptsIptables(t *testing.T) {
-	var err error
-
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
-
-	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageRunScriptsIptables")
-	buildDir := filepath.Join(testTmpDir, "build")
-	configFile := filepath.Join(testDir, "runscripts-iptables.yaml")
-	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
-
-	// Customize image.
-	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
-	assert.ErrorContains(t, err, "failed to customize raw image")
-	assert.ErrorContains(t, err, "script (postCustomization[0]) failed")
-}
-
-func TestCustomizeImageRunScriptsModprobe(t *testing.T) {
-	var err error
-
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
-
-	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageRunScriptsModprobe")
-	buildDir := filepath.Join(testTmpDir, "build")
-	configFile := filepath.Join(testDir, "runscripts-modprobe.yaml")
-	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
-
-	// Customize image.
-	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
-	assert.ErrorContains(t, err, "failed to customize raw image")
-	assert.ErrorContains(t, err, "script (postCustomization[0]) failed")
-}

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/runscripts-iptables.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/runscripts-iptables.yaml
@@ -1,7 +1,0 @@
-os:
-
-scripts:
-  postCustomization:
-  - content: |
-      set -eux
-      iptables -L

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/runscripts-modprobe.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/runscripts-modprobe.yaml
@@ -1,7 +1,0 @@
-os:
-
-scripts:
-  postCustomization:
-  - content: |
-      set -eux
-      modprobe nbd


### PR DESCRIPTION
In change [d60055e](https://github.com/microsoft/azure-linux-image-tools/commit/d60055ea36b4131ecc6626c8bbaaca6a9381fe08), user scripts were given a restricted set of capabilities. However, it seems that the capabilities given were not enough for some legitimate scenarios. So, remove this restriction for now while we re-think the design.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
