### PR TITLE
Prevalidate the --rpm-source args.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -125,6 +125,11 @@ func createImageCustomizerParameters(buildDir string,
 	ic.useBaseImageRpmRepos = useBaseImageRpmRepos
 	ic.rpmsSources = rpmsSources
 
+	err = validateRpmSources(rpmsSources)
+	if err != nil {
+		return nil, err
+	}
+
 	ic.enableShrinkFilesystems = enableShrinkFilesystems
 	ic.outputSplitPartitionsFormat = outputSplitPartitionsFormat
 

--- a/toolkit/tools/pkg/imagecustomizerlib/rpmsourcesmounts.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/rpmsourcesmounts.go
@@ -110,9 +110,6 @@ func (m *rpmSourcesMounts) mountRpmSourcesHelper(buildDir string, imageChroot *s
 
 		case "repo":
 			err = m.createRepoFromRepoConfig(rpmSource, true, allReposConfig, imageChroot)
-
-		default:
-			return fmt.Errorf("unknown RPM source type (%s):\nmust be a .repo file or a directory", rpmSource)
 		}
 		if err != nil {
 			return err
@@ -274,6 +271,17 @@ func (m *rpmSourcesMounts) close() error {
 	return nil
 }
 
+func validateRpmSources(rpmsSources []string) error {
+	for _, rpmSource := range rpmsSources {
+		_, err := getRpmSourceFileType(rpmSource)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func getRpmSourceFileType(rpmSourcePath string) (string, error) {
 	// First, check if path points to a directory.
 	isDir, err := file.IsDir(rpmSourcePath)
@@ -297,7 +305,7 @@ func getRpmSourceFileType(rpmSourcePath string) (string, error) {
 		return "repo", nil
 
 	default:
-		return "", nil
+		return "", fmt.Errorf("unknown RPM source type (%s):\nmust be a .repo file or a directory", rpmSourcePath)
 	}
 }
 


### PR DESCRIPTION
Before starting the customization process, do some basic validation of the `--rpm-source` args.

---

### **Checklist**
- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
