### PR TITLE
Ensure there is only single call to IsValid().

### DIFF
--- a/toolkit/tools/imagecustomizerapi/disksize_test.go
+++ b/toolkit/tools/imagecustomizerapi/disksize_test.go
@@ -12,65 +12,65 @@ import (
 
 func TestDiskSizeNum(t *testing.T) {
 	var diskSize DiskSize
-	err := UnmarshalYaml([]byte("1048576"), &diskSize)
+	err := UnmarshalAndValidateYaml([]byte("1048576"), &diskSize)
 	assert.ErrorContains(t, err, "must have a unit suffix (K, M, G, or T)")
 }
 
 func TestDiskSizeNumTooLarge(t *testing.T) {
 	var diskSize DiskSize
-	err := UnmarshalYaml([]byte("18446744073709551616M"), &diskSize)
+	err := UnmarshalAndValidateYaml([]byte("18446744073709551616M"), &diskSize)
 	assert.ErrorContains(t, err, "value out of range")
 }
 
 func TestDiskSizeKiB(t *testing.T) {
 	var diskSize DiskSize
-	err := UnmarshalYaml([]byte("1024K"), &diskSize)
+	err := UnmarshalAndValidateYaml([]byte("1024K"), &diskSize)
 	assert.NoError(t, err)
 	assert.Equal(t, DiskSize(1024)*diskutils.KiB, diskSize)
 }
 
 func TestDiskSizeMiB(t *testing.T) {
 	var diskSize DiskSize
-	err := UnmarshalYaml([]byte("1M"), &diskSize)
+	err := UnmarshalAndValidateYaml([]byte("1M"), &diskSize)
 	assert.NoError(t, err)
 	assert.Equal(t, DiskSize(1)*diskutils.MiB, diskSize)
 }
 
 func TestDiskSizeGiB(t *testing.T) {
 	var diskSize DiskSize
-	err := UnmarshalYaml([]byte("2G"), &diskSize)
+	err := UnmarshalAndValidateYaml([]byte("2G"), &diskSize)
 	assert.NoError(t, err)
 	assert.Equal(t, DiskSize(2)*diskutils.GiB, diskSize)
 }
 
 func TestDiskSizeTiB(t *testing.T) {
 	var diskSize DiskSize
-	err := UnmarshalYaml([]byte("3T"), &diskSize)
+	err := UnmarshalAndValidateYaml([]byte("3T"), &diskSize)
 	assert.NoError(t, err)
 	assert.Equal(t, DiskSize(3)*diskutils.TiB, diskSize)
 }
 
 func TestDiskSizeAlpha(t *testing.T) {
 	var diskSize DiskSize
-	err := UnmarshalYaml([]byte("T"), &diskSize)
+	err := UnmarshalAndValidateYaml([]byte("T"), &diskSize)
 	assert.ErrorContains(t, err, "incorrect format")
 }
 
 func TestDiskSizeList(t *testing.T) {
 	var diskSize DiskSize
-	err := UnmarshalYaml([]byte("- 12"), &diskSize)
+	err := UnmarshalAndValidateYaml([]byte("- 12"), &diskSize)
 	assert.ErrorContains(t, err, "failed to parse disk size")
 }
 
 func TestDiskSizeNotMultipleOf1Mib(t *testing.T) {
 	var diskSize DiskSize
-	err := UnmarshalYaml([]byte("512K"), &diskSize)
+	err := UnmarshalAndValidateYaml([]byte("512K"), &diskSize)
 	assert.ErrorContains(t, err, "must be a multiple of 1 MiB")
 }
 
 func TestDiskSizeBadFormat(t *testing.T) {
 	var diskSize DiskSize
-	err := UnmarshalYaml([]byte("2M2"), &diskSize)
+	err := UnmarshalAndValidateYaml([]byte("2M2"), &diskSize)
 	assert.ErrorContains(t, err, "has incorrect format")
 }
 

--- a/toolkit/tools/imagecustomizerapi/partitionsize_test.go
+++ b/toolkit/tools/imagecustomizerapi/partitionsize_test.go
@@ -12,25 +12,25 @@ import (
 
 func TestParitionSizeGrow(t *testing.T) {
 	var size PartitionSize
-	err := UnmarshalYaml([]byte("grow"), &size)
+	err := UnmarshalAndValidateYaml([]byte("grow"), &size)
 	assert.NoError(t, err)
 }
 
 func TestParitionSizeMiB(t *testing.T) {
 	var size PartitionSize
-	err := UnmarshalYaml([]byte("1M"), &size)
+	err := UnmarshalAndValidateYaml([]byte("1M"), &size)
 	assert.NoError(t, err)
 	assert.Equal(t, PartitionSize{PartitionSizeTypeExplicit, 1 * diskutils.MiB}, size)
 }
 
 func TestParitionInvalidNotString(t *testing.T) {
 	var size PartitionSize
-	err := UnmarshalYaml([]byte("[]"), &size)
+	err := UnmarshalAndValidateYaml([]byte("[]"), &size)
 	assert.ErrorContains(t, err, "failed to parse partition size")
 }
 
 func TestParitionInvalidValue(t *testing.T) {
 	var size PartitionSize
-	err := UnmarshalYaml([]byte("cat"), &size)
+	err := UnmarshalAndValidateYaml([]byte("cat"), &size)
 	assert.ErrorContains(t, err, "(cat) has incorrect format")
 }

--- a/toolkit/tools/imagecustomizerapi/utils.go
+++ b/toolkit/tools/imagecustomizerapi/utils.go
@@ -15,6 +15,22 @@ type HasIsValid interface {
 	IsValid() error
 }
 
+func UnmarshalAndValidateYamlFile[ValueType HasIsValid](yamlFilePath string, value ValueType) error {
+	var err error
+
+	yamlFile, err := os.ReadFile(yamlFilePath)
+	if err != nil {
+		return err
+	}
+
+	err = UnmarshalAndValidateYaml(yamlFile, value)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func UnmarshalYamlFile[ValueType HasIsValid](yamlFilePath string, value ValueType) error {
 	var err error
 
@@ -31,7 +47,23 @@ func UnmarshalYamlFile[ValueType HasIsValid](yamlFilePath string, value ValueTyp
 	return nil
 }
 
-func UnmarshalYaml[ValueType HasIsValid](yamlData []byte, value ValueType) error {
+func UnmarshalAndValidateYaml[ValueType HasIsValid](yamlData []byte, value ValueType) error {
+	var err error
+
+	err = UnmarshalYaml(yamlData, value)
+	if err != nil {
+		return err
+	}
+
+	err = value.IsValid()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func UnmarshalYaml[ValueType any](yamlData []byte, value ValueType) error {
 	var err error
 
 	reader := bytes.NewReader(yamlData)
@@ -45,15 +77,10 @@ func UnmarshalYaml[ValueType HasIsValid](yamlData []byte, value ValueType) error
 		return err
 	}
 
-	err = value.IsValid()
-	if err != nil {
-		return err
-	}
-
 	return nil
 }
 
-func MarshalYamlFile[ValueType HasIsValid](yamlfilePath string, value ValueType) (err error) {
+func MarshalYamlFile[ValueType any](yamlfilePath string, value ValueType) (err error) {
 	yamlString, err := MarshalYaml(value)
 	if err != nil {
 		return err
@@ -82,7 +109,7 @@ func MarshalYamlFile[ValueType HasIsValid](yamlfilePath string, value ValueType)
 	return nil
 }
 
-func MarshalYaml[ValueType HasIsValid](value ValueType) (string, error) {
+func MarshalYaml[ValueType any](value ValueType) (string, error) {
 	yamlData, err := yaml.Marshal(value)
 	if err != nil {
 		return "", err

--- a/toolkit/tools/imagecustomizerapi/utils_test.go
+++ b/toolkit/tools/imagecustomizerapi/utils_test.go
@@ -11,23 +11,23 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestUnmarshalYamlFile(t *testing.T) {
+func TestUnmarshalAndValidateYamlFile(t *testing.T) {
 	var config Config
-	err := UnmarshalYamlFile(filepath.Join(workingDir, "../pkg/imagecustomizerlib/testdata/nochange-config.yaml"),
+	err := UnmarshalAndValidateYamlFile(filepath.Join(workingDir, "../pkg/imagecustomizerlib/testdata/nochange-config.yaml"),
 		&config)
 	assert.NoError(t, err)
 }
 
-func TestUnmarshalYamlFileDoesNotExist(t *testing.T) {
+func TestUnmarshalAndValidateYamlFileDoesNotExist(t *testing.T) {
 	var config Config
-	err := UnmarshalYamlFile(filepath.Join(workingDir, "../pkg/imagecustomizerlib/testdata/no-such-file.yaml"),
+	err := UnmarshalAndValidateYamlFile(filepath.Join(workingDir, "../pkg/imagecustomizerlib/testdata/no-such-file.yaml"),
 		&config)
 	assert.ErrorContains(t, err, "no such file or directory")
 }
 
-func TestUnmarshalYamlInvalidFile(t *testing.T) {
+func TestUnmarshalAndValidateYamlInvalidFile(t *testing.T) {
 	var config Config
-	err := UnmarshalYamlFile(filepath.Join(workingDir, "../pkg/imagecustomizerlib/testdata/lists/dracut-fips.yaml"),
+	err := UnmarshalAndValidateYamlFile(filepath.Join(workingDir, "../pkg/imagecustomizerlib/testdata/lists/dracut-fips.yaml"),
 		&config)
 	assert.ErrorContains(t, err, "yaml: unmarshal errors")
 }
@@ -35,14 +35,14 @@ func TestUnmarshalYamlInvalidFile(t *testing.T) {
 func testValidYamlValue[DataType HasIsValid](t *testing.T, yamlString string, expectedValue DataType) {
 	value := makeValue[DataType]()
 
-	err := UnmarshalYaml([]byte(yamlString), value)
+	err := UnmarshalAndValidateYaml([]byte(yamlString), value)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedValue, value)
 }
 
 func testInvalidYamlValue[DataType HasIsValid](t *testing.T, yamlString string) {
 	value := makeValue[DataType]()
-	err := UnmarshalYaml([]byte(yamlString), value)
+	err := UnmarshalAndValidateYaml([]byte(yamlString), value)
 	assert.Errorf(t, err, "value: %v", value)
 }
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages.go
@@ -119,7 +119,7 @@ func collectPackagesList(baseConfigPath string, packageLists []string, packages 
 		packageListFilePath := file.GetAbsPathWithBase(baseConfigPath, packageListRelativePath)
 
 		var packageList imagecustomizerapi.PackageList
-		err = imagecustomizerapi.UnmarshalYamlFile(packageListFilePath, &packageList)
+		err = imagecustomizerapi.UnmarshalAndValidateYamlFile(packageListFilePath, &packageList)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read package list file (%s):\n%w", packageListFilePath, err)
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
@@ -106,7 +106,7 @@ func testCustomizeImageVerityShrinkExtractHelper(t *testing.T, testName string, 
 	configFile := filepath.Join(testDir, "verity-partition-labels.yaml")
 
 	var config imagecustomizerapi.Config
-	err := imagecustomizerapi.UnmarshalYamlFile(configFile, &config)
+	err := imagecustomizerapi.UnmarshalAndValidateYamlFile(configFile, &config)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -198,8 +198,6 @@ func CustomizeImageWithConfigFile(buildDir string, configFile string, imageFile 
 ) error {
 	var err error
 
-	logVersionsOfToolDeps()
-
 	var config imagecustomizerapi.Config
 	err = imagecustomizerapi.UnmarshalYamlFile(configFile, &config)
 	if err != nil {
@@ -262,6 +260,8 @@ func CustomizeImage(buildDir string, baseConfigPath string, config *imagecustomi
 	if err != nil {
 		return err
 	}
+
+	logVersionsOfToolDeps()
 
 	// ensure build and output folders are created up front
 	err = os.MkdirAll(imageCustomizerParameters.buildDirAbs, os.ModePerm)
@@ -527,8 +527,6 @@ func validateSplitPartitionsFormat(partitionFormat string) error {
 func validateConfig(baseConfigPath string, config *imagecustomizerapi.Config, rpmsSources []string,
 	useBaseImageRpmRepos bool,
 ) error {
-	// Note: This IsValid() check does duplicate the one in UnmarshalYamlFile().
-	// But it is useful for functions that call CustomizeImage() directly. For example, test code.
 	err := config.IsValid()
 	if err != nil {
 		return err

--- a/toolkit/tools/pkg/imagecustomizerlib/imagehistory_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagehistory_test.go
@@ -17,7 +17,7 @@ func createTestConfig(configFilePath string, t *testing.T) imagecustomizerapi.Co
 	configFile := filepath.Join(testDir, configFilePath)
 
 	var config imagecustomizerapi.Config
-	err := imagecustomizerapi.UnmarshalYamlFile(configFile, &config)
+	err := imagecustomizerapi.UnmarshalAndValidateYamlFile(configFile, &config)
 	assert.NoError(t, err)
 	return config
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
@@ -79,7 +79,7 @@ func TestCustomizeImageLiveCd1(t *testing.T) {
 	// Check the saved-configs.yaml file.
 	savedConfigsFilePath := filepath.Join(isoMountDir, savedConfigsDir, savedConfigsFileName)
 	savedConfigs := &SavedConfigs{}
-	err = imagecustomizerapi.UnmarshalYamlFile(savedConfigsFilePath, savedConfigs)
+	err = imagecustomizerapi.UnmarshalAndValidateYamlFile(savedConfigsFilePath, savedConfigs)
 	assert.NoErrorf(t, err, "read (%s) file", savedConfigsFilePath)
 	expectedKernelArgs := []string{"rd.info"}
 	assert.Equal(t, expectedKernelArgs, savedConfigs.Iso.KernelCommandLine.ExtraCommandLine)
@@ -164,7 +164,7 @@ func TestCustomizeImageLiveCd1(t *testing.T) {
 
 	// Check the iso-kernel-args.txt file.
 	savedConfigs = &SavedConfigs{}
-	err = imagecustomizerapi.UnmarshalYamlFile(savedConfigsFilePath, savedConfigs)
+	err = imagecustomizerapi.UnmarshalAndValidateYamlFile(savedConfigsFilePath, savedConfigs)
 	assert.NoErrorf(t, err, "read (%s) file", savedConfigsFilePath)
 	assert.Equal(t, []string{"rd.info", "rd.debug"}, savedConfigs.Iso.KernelCommandLine.ExtraCommandLine)
 

--- a/toolkit/tools/pkg/imagecustomizerlib/savedconfigs.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/savedconfigs.go
@@ -120,7 +120,7 @@ func loadSavedConfigs(savedConfigsFilePath string) (savedConfigs *SavedConfigs, 
 	}
 
 	savedConfigs = &SavedConfigs{}
-	err = imagecustomizerapi.UnmarshalYamlFile(savedConfigsFilePath, savedConfigs)
+	err = imagecustomizerapi.UnmarshalAndValidateYamlFile(savedConfigsFilePath, savedConfigs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load saved configs file (%s):\n%w", savedConfigsFilePath, err)
 	}

--- a/toolkit/tools/pkg/osmodifierlib/osmodifier.go
+++ b/toolkit/tools/pkg/osmodifierlib/osmodifier.go
@@ -15,7 +15,7 @@ func ModifyOSWithConfigFile(configFile string) error {
 	var err error
 
 	var osConfig osmodifierapi.OS
-	err = imagecustomizerapi.UnmarshalYamlFile(configFile, &osConfig)
+	err = imagecustomizerapi.UnmarshalAndValidateYamlFile(configFile, &osConfig)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently, there are two calls made to the `Config.IsValid()` function. This change ensures there is only a single call to `IsValid`. This will prevent warning messages from being duplicated.

This change also moves the logging of host tool versions to be after all the validation steps.

---

### **Checklist**
- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
