### PR TITLE
Fix partition type tests.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
@@ -112,10 +112,12 @@ func testCustomizeImagePartitionsToEfi(t *testing.T, testName string, imageType 
 		imageVersion)
 
 	// Check the partition types.
-	assert.Equal(t, partitions[1].PartitionTypeUuid, "c12a7328-f81f-11d2-ba4b-00a0c93ec93b") // esp
-	assert.Equal(t, partitions[2].PartitionTypeUuid, "bc13c2ff-59e6-4262-a352-b275fd6f7172") // xbootldr
-	assert.Equal(t, partitions[3].PartitionTypeUuid, "4f68bce3-e8cd-4db1-96e7-fbcaf984b709") // root (x64)
-	assert.Equal(t, partitions[4].PartitionTypeUuid, "4d21b016-b534-45c2-a9fb-5c16e091fd2d") // var
+	if typeSupported, _ := diskutils.PartedSupportsTypeCommand(); typeSupported {
+		assert.Equal(t, "c12a7328-f81f-11d2-ba4b-00a0c93ec93b", partitions[1].PartitionTypeUuid) // esp
+		assert.Equal(t, "bc13c2ff-59e6-4262-a352-b275fd6f7172", partitions[2].PartitionTypeUuid) // xbootldr
+		assert.Equal(t, "4f68bce3-e8cd-4db1-96e7-fbcaf984b709", partitions[3].PartitionTypeUuid) // root (x64)
+		assert.Equal(t, "4d21b016-b534-45c2-a9fb-5c16e091fd2d", partitions[4].PartitionTypeUuid) // var
+	}
 }
 
 func TestCustomizeImagePartitionsSizeOnly(t *testing.T) {
@@ -178,9 +180,11 @@ func TestCustomizeImagePartitionsSizeOnly(t *testing.T) {
 		baseImageVersionDefault)
 
 	// Check the partition types.
-	assert.Equal(t, partitions[1].PartitionTypeUuid, "c12a7328-f81f-11d2-ba4b-00a0c93ec93b") // esp
-	assert.Equal(t, partitions[2].PartitionTypeUuid, "0fc63daf-8483-4772-8e79-3d69d8477de4") // linux generic
-	assert.Equal(t, partitions[3].PartitionTypeUuid, "0fc63daf-8483-4772-8e79-3d69d8477de4") // linux generic
+	if typeSupported, _ := diskutils.PartedSupportsTypeCommand(); typeSupported {
+		assert.Equal(t, "c12a7328-f81f-11d2-ba4b-00a0c93ec93b", partitions[1].PartitionTypeUuid) // esp
+		assert.Equal(t, "0fc63daf-8483-4772-8e79-3d69d8477de4", partitions[2].PartitionTypeUuid) // linux generic
+		assert.Equal(t, "0fc63daf-8483-4772-8e79-3d69d8477de4", partitions[3].PartitionTypeUuid) // linux generic
+	}
 }
 
 func TestCustomizeImagePartitionsEfiToLegacy(t *testing.T) {
@@ -239,8 +243,10 @@ func testCustomizeImagePartitionsToLegacy(t *testing.T, testName string, imageTy
 		imageVersion)
 
 	// Check the partition types.
-	assert.Equal(t, partitions[1].PartitionTypeUuid, "21686148-6449-6e6f-744e-656564454649") // BIOS boot
-	assert.Equal(t, partitions[2].PartitionTypeUuid, "0fc63daf-8483-4772-8e79-3d69d8477de4") // linux generic
+	if typeSupported, _ := diskutils.PartedSupportsTypeCommand(); typeSupported {
+		assert.Equal(t, "21686148-6449-6e6f-744e-656564454649", partitions[1].PartitionTypeUuid) // BIOS boot
+		assert.Equal(t, "0fc63daf-8483-4772-8e79-3d69d8477de4", partitions[2].PartitionTypeUuid) // linux generic
+	}
 }
 
 func TestCustomizeImageKernelCommandLine(t *testing.T) {


### PR DESCRIPTION
It turns out the `parted type` command is relatively new and isn't included in either Ubuntu 22.04 or Mariner 2.0. So, the tests need to account for this.

In addition, only report warning logs for the missing `parted type` command when the user specifies a partition type.

---

### **Checklist**
- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
