### PR TITLE
Update container base to Azure Linux 3.0.

### DIFF
--- a/toolkit/tools/imagecustomizer/container/Dockerfile.mic-container
+++ b/toolkit/tools/imagecustomizer/container/Dockerfile.mic-container
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
+FROM mcr.microsoft.com/azurelinux/base/core:3.0
 RUN tdnf update -y && \
    tdnf install -y qemu-img rpm coreutils util-linux systemd openssl \
       sed createrepo_c squashfs-tools cdrkit parted e2fsprogs dosfstools \


### PR DESCRIPTION
This ensures that Image Customizer has access to the latest versions of tools like `mkfs`.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
