### PR TITLE
Restore STATUS_FLAGS_DIR in Makefile.

### DIFF
--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -11,6 +11,8 @@ PROJECT_ROOT     ?= $(realpath $(toolkit_root)/..)
 BUILD_DIR        ?= $(PROJECT_ROOT)/build
 OUT_DIR          ?= $(PROJECT_ROOT)/out
 
+STATUS_FLAGS_DIR ?= $(BUILD_DIR)/make_status
+
 ######## COMMON MAKEFILE UTILITIES ########
 
 # Misc function defines


### PR DESCRIPTION
The `STATUS_FLAGS_DIR` variable is still being used.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
