### PR TITLE
Add Phase 2 COSI Support

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/cosimetadata.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/cosimetadata.go
@@ -9,18 +9,17 @@ type MetadataJson struct {
 }
 
 type Image struct {
-	Image            ImageFile `json:"image"`
-	MountPoint       string    `json:"mountPoint"`
-	FsType           string    `json:"fsType"`
-	FsUuid           string    `json:"fsUuid"`
-	PartType         string    `json:"partType"`
-	Verity           *Verity   `json:"verity"`
-	UncompressedSize uint64    `json:"uncompressedSize"`
+	Image      ImageFile `json:"image"`
+	MountPoint string    `json:"mountPoint"`
+	FsType     string    `json:"fsType"`
+	FsUuid     string    `json:"fsUuid"`
+	PartType   string    `json:"partType"`
+	Verity     *Verity   `json:"verity"`
 }
 
 type Verity struct {
-	Image    ImageFile `json:"image"`
-	Roothash string    `json:"roothash"`
+	Image ImageFile `json:"image"`
+	Hash  string    `json:"hash"`
 }
 
 type ImageFile struct {


### PR DESCRIPTION
<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

PR summary:

This is a phase 2 COSI support, we should now be able to generate cosi file from a **_non-verity_** base image with a verity config, and the verity information will be included in the cosi metadata file, so it will align with expected sample format

local test:
tested with command `sudo ./imagecustomizer --log-level debug  --build-dir ./build  --image-file core-3.0.20241220.vhdx --output-image-file ./output-image-test.cosi --output-image-format cosi --config-file ../pkg/imagecustomizerlib/testdata/verity-config.yaml`
unpacked the .cosi file
![image](https://github.com/user-attachments/assets/9c69f926-56af-4167-bbe0-1dbcc3374827)
and obtained output/metadata.json

```
{
  "version": "1.0",
  "osArch": "amd64",
  "images": [
    {
      "image": {
        "path": "images/output-image-test_1.raw.zst",
        "compressedSize": 988946,
        "uncompressedSize": 8388608,
        "sha384": "6c2a78a9bc84624d90fdf2b0be7e33dd4abd305f8ae2467a4868bdf3ed8114cbe72c8512e5836e0a806e932732f79585"
      },
      "mountPoint": "",
      "fsType": "vfat",
      "fsUuid": "1163-42B5",
      "partType": "c12a7328-f81f-11d2-ba4b-00a0c93ec93b",
      "verity": null
    },
    {
      "image": {
        "path": "images/output-image-test_2.raw.zst",
        "compressedSize": 51437979,
        "uncompressedSize": 1064304640,
        "sha384": "f6594fa455d3feffd002dddd32afc843856e09bb850c6a3a6ec84366a00c8dde92e28f68a464ca62e8160bb5ad6a50e2"
      },
      "mountPoint": "",
      "fsType": "ext4",
      "fsUuid": "14e039a8-61d2-4d43-85b2-f26c92326c03",
      "partType": "0fc63daf-8483-4772-8e79-3d69d8477de4",
      "verity": null
    },
    {
      "image": {
        "path": "images/output-image-test_3.raw.zst",
        "compressedSize": 115309290,
        "uncompressedSize": 2147483648,
        "sha384": "29d8663dbd8f320ad9bba8169173837213eb973842f52ec774af8840f130c596b118cef88c2a4c38bc8820cfba482637"
      },
      "mountPoint": "",
      "fsType": "ext4",
      "fsUuid": "393703a2-b8a9-4574-8fd0-d961674c3efa",
      "partType": "0fc63daf-8483-4772-8e79-3d69d8477de4",
      "verity": {
        "image": {
          "path": "images/output-image-test_4.raw.zst",
          "compressedSize": 2908417,
          "uncompressedSize": 134217728,
          "sha384": "d4c8dd1357868b9aab271af8f74c52f05c8e4378d53637644cec43fc7a20adbb0aa1f0b01d701555cfda0490205d11ab"
        },
        "hash": "d5ff43f8d03a738b1e25f4eeb1b1f71441fa456daf60a664f64a2e95316ec65f"
      }
    },
    {
      "image": {
        "path": "images/output-image-test_5.raw.zst",
        "compressedSize": 28775661,
        "uncompressedSize": 2012217344,
        "sha384": "9a69d82c2e1c0b6681191cbcc6847ba8db2b54f15671b0b9a00e1649ce753038a8f2cb2b6d7e1bc36bdcc9cc8d0dbbf1"
      },
      "mountPoint": "",
      "fsType": "ext4",
      "fsUuid": "8fee3677-b8ba-432b-8add-3f336d11575f",
      "partType": "0fc63daf-8483-4772-8e79-3d69d8477de4",
      "verity": null
    }
  ],
  "osRelease": "",
  "id": "85e18600-1160-1b53-bcea-d93a3f0d848b"
```

Note: 
A verity base image currently is not supported, will wait customizations on verity images to be enabled. Also, will have a follow-up pr to fix the missing mountpoints.

---

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] Code conforms to style guidelines
