### PR TITLE
Set overlay workdir SELinux label to no_access_t.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/overlays-selinux.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/overlays-selinux.yaml
@@ -1,0 +1,20 @@
+os:
+  bootloader:
+    resetType: hard-reset
+
+  selinux:
+    mode: enforcing
+
+  packages:
+    install:
+    - selinux-policy
+    - selinux-policy-modules
+    - setools-console
+    - policycoreutils-python-utils
+
+  overlays:
+  - mountPoint: /var
+    lowerDirs:
+    - /var
+    upperDir: /mnt/overlays/var/upper
+    workDir: /mnt/overlays/var/work


### PR DESCRIPTION
For SELinux enabled images, ensure the overlay's working directory's SELinux label is set to `no_access_t`, since only the kernel should be accessing that directory.

In addition, the current overlays test doesn't properly test SELinux since it doesn't enable SELinux in the image. So, add a new test specifically to test overlays + SELinux.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
