### PR TITLE
Switch from 'parted' to 'sfdisk'.

### DIFF
--- a/docs/imagecustomizer/how-to/quick-start.md
+++ b/docs/imagecustomizer/how-to/quick-start.md
@@ -21,8 +21,8 @@ nav_order: 6
    [Supported configuration](../api/configuration.md)
 
 3. Install prerequisites: `qemu-img`, `rpm`, `dd`, `lsblk`, `losetup`, `sfdisk`,
-   `udevadm`, `flock`, `blkid`, `openssl`, `sed`, `createrepo`, `mksquashfs`,
-   `genisoimage`, `parted`, `mkfs`, `mkfs.ext4`, `mkfs.vfat`, `mkfs.xfs`, `fsck`,
+   `blockdev` `udevadm`, `flock`, `blkid`, `openssl`, `sed`, `createrepo`, `mksquashfs`,
+   `genisoimage`, `mkfs`, `mkfs.ext4`, `mkfs.vfat`, `mkfs.xfs`, `fsck`,
    `e2fsck`, `xfs_repair`, `resize2fs`, `tune2fs`, `xfs_admin`, `fatlabel`, `zstd`,
    `veritysetup`, `grub2-install` (or `grub-install`).
 
@@ -30,7 +30,7 @@ nav_order: 6
 
      ```bash
      sudo apt -y install qemu-utils rpm coreutils util-linux mount fdisk udev openssl \
-        sed createrepo-c squashfs-tools genisoimage parted e2fsprogs dosfstools \
+        sed createrepo-c squashfs-tools genisoimage e2fsprogs dosfstools \
         xfsprogs zstd cryptsetup-bin grub2-common
      ```
 
@@ -38,7 +38,7 @@ nav_order: 6
 
      ```bash
      sudo tdnf install -y qemu-img rpm coreutils util-linux systemd openssl \
-        sed createrepo_c squashfs-tools cdrkit parted e2fsprogs dosfstools \
+        sed createrepo_c squashfs-tools cdrkit e2fsprogs dosfstools \
         xfsprogs zstd veritysetup grub2 grub2-pc
      ```
 

--- a/toolkit/tools/imagecustomizerapi/disk.go
+++ b/toolkit/tools/imagecustomizerapi/disk.go
@@ -116,7 +116,7 @@ func (d *Disk) IsValid() error {
 		}
 
 		// Verify MaxSize value.
-		lastPartition := d.Partitions[len(d.Partitions)-1]
+		lastPartition := &d.Partitions[len(d.Partitions)-1]
 		lastPartitionEnd, lastPartitionHasEnd := lastPartition.GetEnd()
 
 		switch {
@@ -143,6 +143,14 @@ func (d *Disk) IsValid() error {
 			if requiredSize > *d.MaxSize {
 				return fmt.Errorf("disk's partitions need %s but maxSize is only %s:\nGPT footer size is %s",
 					requiredSize.HumanReadable(), d.MaxSize.HumanReadable(), gptFooterSize.HumanReadable())
+			}
+
+			if !lastPartitionHasEnd {
+				// Explicitly set the size of the last partition.
+				// This allows us to control the alignment of the GPT footer instead of relying on the behavior of the
+				// partitioning tool (e.g. sfdisk).
+				lastPartitionEnd := *d.MaxSize - gptFooterSize
+				lastPartition.End = &lastPartitionEnd
 			}
 		}
 	}

--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -24,13 +24,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var (
-	partedVersionRegex = regexp.MustCompile(`^parted \(GNU parted\) (\d+)\.(\d+)`)
-
-	// The default partition name used when the version of `parted` is too old (<3.5).
-	LegacyDefaultParitionName = "primary"
-)
-
 type blockDevicesOutput struct {
 	Devices []blockDeviceInfo `json:"blockdevices"`
 }
@@ -63,6 +56,7 @@ type PartitionInfo struct {
 	Mountpoint        string `json:"mountpoint"` // Example: /mnt/os/boot
 	PartLabel         string `json:"partlabel"`  // Example: boot
 	Type              string `json:"type"`       // Example: part
+	Size              uint64 `json:"size"`       // Example: 4096
 }
 
 type loopbackListOutput struct {
@@ -78,8 +72,9 @@ const (
 	// AutoEndSize is used as the disk's "End" value to indicate it should be picked automatically
 	AutoEndSize = 0
 
-	EfiSystemPartitionTypeUuid = "c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
-	BiosBootPartitionTypeUuid  = "21686148-6449-6e6f-744e-656564454649"
+	EfiSystemPartitionTypeUuid    = "c12a7328-f81f-11d2-ba4b-00a0c93ec93b"
+	BiosBootPartitionTypeUuid     = "21686148-6449-6e6f-744e-656564454649"
+	GenericLinuxPartitionTypeUuid = "0FC63DAF-8483-4772-8E79-3D69D8477DE4"
 )
 
 const (
@@ -97,7 +92,6 @@ const (
 )
 
 // Unit to byte conversion values
-// See https://www.gnu.org/software/parted/manual/parted.html#unit
 const (
 	B  = 1
 	KB = 1000
@@ -426,7 +420,6 @@ func WaitForDevicesToSettle() error {
 func CreatePartitions(targetOs targetos.TargetOs, diskDevPath string, disk configuration.Disk, rootEncryption configuration.RootEncryption,
 	diskKnownToBeEmpty bool,
 ) (partDevPathMap map[string]string, partIDToFsTypeMap map[string]string, encryptedRoot EncryptedRootDevice, err error) {
-	const timeoutInSeconds = "5"
 	partDevPathMap = make(map[string]string)
 	partIDToFsTypeMap = make(map[string]string)
 
@@ -438,26 +431,15 @@ func CreatePartitions(targetOs targetos.TargetOs, diskDevPath string, disk confi
 		}
 	}
 
-	// Create new partition table
 	partitionTableType := disk.PartitionTableType
-	logger.Log.Debugf("Converting partition table type (%v) to parted argument", partitionTableType)
-	partedArgument, err := partitionTableType.ConvertToPartedArgument()
+
+	// Create new partition table
+	err = createPartitionTable(diskDevPath, partitionTableType)
 	if err != nil {
-		err = fmt.Errorf("failed to convert partition table type (%v) to parted argument:\n%w", partitionTableType, err)
-		return
-	}
-	_, stderr, err := shell.Execute("flock", "--timeout", timeoutInSeconds, diskDevPath, "parted", diskDevPath, "--script", "mklabel", partedArgument)
-	if err != nil {
-		err = fmt.Errorf("failed to set partition table type using parted:\n%v\n%w", stderr, err)
 		return
 	}
 
 	usingExtendedPartition := (len(disk.Partitions) > maxPrimaryPartitionsForMBR) && (partitionTableType == configuration.PartitionTableTypeMbr)
-
-	partedSupportsEmptyStringArgs, err := PartedSupportsEmptyString()
-	if err != nil {
-		return
-	}
 
 	// Partitions assumed to be defined in sorted order
 	for idx, partition := range disk.Partitions {
@@ -465,7 +447,7 @@ func CreatePartitions(targetOs targetos.TargetOs, diskDevPath string, disk confi
 		// Insert an extended partition
 		if partType == extendedPartitionType {
 			err = createExtendedPartition(diskDevPath, partitionTableType, disk.Partitions, partIDToFsTypeMap,
-				partDevPathMap, partedSupportsEmptyStringArgs)
+				partDevPathMap)
 			if err != nil {
 				return
 			}
@@ -475,14 +457,13 @@ func CreatePartitions(targetOs targetos.TargetOs, diskDevPath string, disk confi
 			partitionNumber = partitionNumber + 1
 		}
 
-		partDevPath, err := createSinglePartition(diskDevPath, partitionNumber, partitionTableType, partition, partType,
-			partedSupportsEmptyStringArgs)
+		partDevPath, err := createSinglePartition(diskDevPath, partitionNumber, partitionTableType, partition, partType)
 		if err != nil {
 			err = fmt.Errorf("failed to create single partition:\n%w", err)
 			return partDevPathMap, partIDToFsTypeMap, encryptedRoot, err
 		}
 
-		partFsType, err := formatSinglePartition(targetOs, partDevPath, partition)
+		partFsType, err := formatSinglePartition(targetOs, diskDevPath, partDevPath, partition)
 		if err != nil {
 			err = fmt.Errorf("failed to format partition:\n%w", err)
 			return partDevPathMap, partIDToFsTypeMap, encryptedRoot, err
@@ -501,16 +482,47 @@ func CreatePartitions(targetOs targetos.TargetOs, diskDevPath string, disk confi
 
 		partIDToFsTypeMap[partition.ID] = partFsType
 	}
+
+	// Refresh partition entries under /dev.
+	// This ensures the new filesystems are found by udev.
+	err = refreshPartitions(diskDevPath)
+	if err != nil {
+		return
+	}
+
 	return
+}
+
+func createPartitionTable(diskDevPath string, partitionTableType configuration.PartitionTableType) error {
+	const (
+		timeoutInSeconds = "5"
+	)
+
+	if partitionTableType != configuration.PartitionTableTypeGpt {
+		// When switching from "parted" to "sfdisk", MBR support was omitted.
+		return fmt.Errorf("only support for GPT disks is implemented")
+	}
+
+	sfdiskScript := "label: gpt"
+
+	err := shell.NewExecBuilder("flock", "--timeout", timeoutInSeconds, diskDevPath, "sfdisk", "--lock=no",
+		diskDevPath).
+		Stdin(sfdiskScript).
+		LogLevel(logrus.DebugLevel, logrus.WarnLevel).
+		ErrorStderrLines(1).
+		Execute()
+	if err != nil {
+		return fmt.Errorf("failed to create partition table using sfdisk:\n%w", err)
+	}
+
+	return nil
 }
 
 // createSinglePartition creates a single partition based on the partition config
 func createSinglePartition(diskDevPath string, partitionNumber int, partitionTableType configuration.PartitionTableType,
-	partition configuration.Partition, partType string, partedSupportsEmptyStringArgs bool,
+	partition configuration.Partition, partType string,
 ) (partDevPath string, err error) {
 	const (
-		fillToEndOption  = "100%"
-		sFmt             = "%ds"
 		timeoutInSeconds = "5"
 	)
 
@@ -519,7 +531,12 @@ func createSinglePartition(diskDevPath string, partitionNumber int, partitionTab
 		return
 	}
 
+	if partition.End != 0 && partition.Start >= partition.End {
+		return "", fmt.Errorf("invalid partition: start (%d) >= end (%d)", partition.Start, partition.End)
+	}
+
 	start := partition.Start * MiB / logicalSectorSize
+
 	end := partition.End*MiB/logicalSectorSize - 1
 	if partition.End == 0 {
 		end = 0
@@ -535,127 +552,104 @@ func createSinglePartition(diskDevPath string, partitionNumber int, partitionTab
 	// Check whether the start sector is 4K-aligned
 	start = alignSectorAddress(start, logicalSectorSize, physicalSectorSize)
 
+	sizeArg := ""
+	if end > 0 {
+		size := end - start + 1
+		sizeArg = fmt.Sprintf(", size=%d", size)
+	}
+
 	logger.Log.Debugf("Input partition start: %d, aligned start sector: %d", partition.Start, start)
 	logger.Log.Debugf("Input partition end: %d, end sector: %d", partition.End, end)
 
-	mkpartArgs := []string{"--timeout", timeoutInSeconds, diskDevPath, "parted", diskDevPath, "--script", "mkpart"}
-
+	name := ""
+	typeId := ""
 	switch partitionTableType {
 	case configuration.PartitionTableTypeMbr:
-		// Part type.
-		mkpartArgs = append(mkpartArgs, partType)
+		// When switching from "parted" to "sfdisk", MBR support was omitted.
+		return "", fmt.Errorf("MBR support is not implemented")
 
 	case configuration.PartitionTableTypeGpt:
-		// Partition label.
-		if partition.Name == "" {
-			if partedSupportsEmptyStringArgs {
-				// For parted, you have to specify "" to represent an empty string.
-				mkpartArgs = append(mkpartArgs, `""`)
-			} else {
-				// This version of parted has no way to specify an empty partition name. :-(
-				// So, use the legacy label of "primary" (which was used in Azure Linux 2.0) instead.
-				logger.Log.Warnf("parted version <3.5 does not support empty partition names: using partition name '%s' instead",
-					LegacyDefaultParitionName)
-				mkpartArgs = append(mkpartArgs, LegacyDefaultParitionName)
+		name = escapeSfdiskString(partition.Name)
+		typeId = GenericLinuxPartitionTypeUuid
+
+		for _, flag := range partition.Flags {
+			switch flag {
+			case configuration.PartitionFlagESP, configuration.PartitionFlagBoot:
+				typeId = EfiSystemPartitionTypeUuid
+
+			case configuration.PartitionFlagGrub, configuration.PartitionFlagBiosGrub, configuration.PartitionFlagBiosGrubLegacy:
+				typeId = BiosBootPartitionTypeUuid
+
+			case configuration.PartitionFlagDeviceMapperRoot:
+				//Ignore, only used for internal tooling
+
+			default:
+				return partDevPath, fmt.Errorf("unknown partition (%d) flag (%v)", partitionNumber, flag)
 			}
-		} else {
-			mkpartArgs = append(mkpartArgs, partition.Name)
+		}
+
+		switch {
+		case partition.TypeUUID != "":
+			typeId = partition.TypeUUID
+
+		case partition.Type != "":
+			typeId = configuration.PartitionTypeNameToUUID[partition.Type]
 		}
 	}
 
-	fsType := partition.FsType
-	if fsType == "vfat" {
-		// 'parted mkpart' requires value of either 'fat16' or 'fat32'.
-		fsType = "fat32"
-	}
+	sfdiskScript := fmt.Sprintf("unit: sectors\nstart=%d, type=%s, name=%s%s", start, typeId, name, sizeArg)
+	logger.Log.Debugf("sfdisk script:\n%s", sfdiskScript)
 
-	if fsType != "" {
-		mkpartArgs = append(mkpartArgs, fsType)
-	}
-
-	mkpartArgs = append(mkpartArgs, fmt.Sprintf(sFmt, start))
-
-	if end == 0 {
-		mkpartArgs = append(mkpartArgs, fillToEndOption)
-	} else {
-		mkpartArgs = append(mkpartArgs, fmt.Sprintf(sFmt, end))
-	}
-
-	_, stderr, err := shell.Execute("flock", mkpartArgs...)
+	err = shell.NewExecBuilder("flock", "--timeout", timeoutInSeconds, diskDevPath, "sfdisk", "--lock=no",
+		"--append", diskDevPath).
+		Stdin(sfdiskScript).
+		LogLevel(logrus.DebugLevel, logrus.WarnLevel).
+		ErrorStderrLines(1).
+		Execute()
 	if err != nil {
-		err = fmt.Errorf("failed to create partition using parted:\n%v\n%w", stderr, err)
+		return "", fmt.Errorf("failed to create partition using sfdisk:\n%w", err)
+	}
+
+	partDevPath, err = waitForPartitionCreation(diskDevPath, partitionNumber)
+	if err != nil {
 		return "", err
 	}
 
-	// Update kernel partition table information
-	//
-	// There can be a timing issue where partition creation finishes but the
-	// devtmpfs files are not populated in time for partition initialization.
-	// So to deal with this, we call partprobe here to query and flush the
-	// partition table information, which should enforce that the devtmpfs
-	// files are created when partprobe returns control.
-	//
-	// Added flock because "partprobe -s" apparently doesn't always block.
-	// flock is part of the util-linux package and helps to synchronize access
-	// with other cooperating processes. The important part is it will block
-	// if the fd is busy, and then execute the command. Adding a timeout
-	// to prevent us from possibly waiting forever.
-	stdout, stderr, err := shell.Execute("flock", "--timeout", timeoutInSeconds, diskDevPath, "partprobe", "-s", diskDevPath)
-	if err != nil {
-		err = fmt.Errorf("failed to execute partprobe:\n%v\n%w", stderr, err)
-		return "", err
-	}
-	logger.Log.Debugf("Partprobe -s returned: %s", stdout)
-	return InitializeSinglePartition(diskDevPath, partitionNumber, partitionTableType, partition)
+	return partDevPath, nil
 }
 
-// Returns true if the version of 'parted' supports the 'type' session command.
-// Since v3.6
-func PartedSupportsTypeCommand() (bool, error) {
-	major, minor, err := getPartedVersion()
-	if err != nil {
-		return false, err
+// Adds escaping of string values for sfdisk scripts.
+//
+// Note: Support string escaping was only added in util-linux v2.32.1 (commits: 75ef5a1, 810b313)
+//
+// util-linux versions:
+// - Ubuntu 20.04: v2.34.0
+// - Azure Linux 2.0: v2.37.4
+//
+// So, it should be fine to assume that it is supported.
+func escapeSfdiskString(value string) string {
+	builder := strings.Builder{}
+	builder.WriteString("\"")
+
+	for _, c := range value {
+		switch c {
+		case '"':
+			builder.WriteString("\\x22")
+
+		case '\\':
+			builder.WriteString("\\x5c")
+
+		default:
+			builder.WriteRune(c)
+		}
 	}
 
-	supports := major >= 4 || (major == 3 && minor >= 6)
-	return supports, nil
-}
-
-// Returns if the version of 'parted' supports empty (quoted) string parameters.
-// Specifically, parted v3.5+.
-func PartedSupportsEmptyString() (bool, error) {
-	major, minor, err := getPartedVersion()
-	if err != nil {
-		return false, err
-	}
-
-	supports := major >= 4 || (major == 3 && minor >= 5)
-	return supports, nil
-}
-
-func getPartedVersion() (int, int, error) {
-	stdout, _, err := shell.Execute("parted", "--version")
-	if err != nil {
-		err = fmt.Errorf("failed to get 'parted' version:\n%w", err)
-		return 0, 0, err
-	}
-
-	matches := partedVersionRegex.FindStringSubmatch(stdout)
-	if matches == nil {
-		err = fmt.Errorf("failed to parse 'parted' version:\n%w", err)
-		return 0, 0, err
-	}
-
-	major, _ := strconv.Atoi(matches[1])
-	minor, _ := strconv.Atoi(matches[2])
-
-	return major, minor, nil
+	builder.WriteString("\"")
+	return builder.String()
 }
 
 // InitializeSinglePartition initializes a single partition based on the given partition configuration
-func InitializeSinglePartition(diskDevPath string, partitionNumber int,
-	partitionTableType configuration.PartitionTableType, partition configuration.Partition,
-) (partDevPath string, err error) {
+func waitForPartitionCreation(diskDevPath string, partitionNumber int) (partDevPath string, err error) {
 	const (
 		retryDuration    = time.Second
 		timeoutInSeconds = "5"
@@ -694,56 +688,12 @@ func InitializeSinglePartition(diskDevPath string, partitionNumber int,
 			logger.Log.Debugf("Could not find partition path (%s). Checking other naming convention", testPartDevPath)
 		}
 		logger.Log.Warnf("Could not find any valid partition paths. Will retry up to %d times", totalAttempts)
-		err = fmt.Errorf("could not find partition to initialize in /dev")
+		err = fmt.Errorf("could not find partition (%d) in /dev", partitionNumber)
 		return err
 	}, totalAttempts, retryDuration)
-
 	if err != nil {
 		return
 	}
-
-	logger.Log.Debugf("Initializing partition device path: %v", partDevPath)
-
-	// Set partition friendly name and partition type UUID (only for gpt)
-	if partitionTableType == configuration.PartitionTableTypeGpt {
-		setGptPartitionType(partition, timeoutInSeconds, diskDevPath, partitionNumberStr)
-	}
-
-	// Set partition flags if necessary
-	for _, flag := range partition.Flags {
-		args := []string{diskDevPath, "--script", "set", partitionNumberStr}
-		var flagToSet string
-		switch flag {
-		case configuration.PartitionFlagESP:
-			flagToSet = "esp"
-		case configuration.PartitionFlagGrub, configuration.PartitionFlagBiosGrub, configuration.PartitionFlagBiosGrubLegacy:
-			flagToSet = "bios_grub"
-		case configuration.PartitionFlagBoot:
-			flagToSet = "boot"
-		case configuration.PartitionFlagDeviceMapperRoot:
-			//Ignore, only used for internal tooling
-		default:
-			return partDevPath, fmt.Errorf("partition %v - Unknown partition flag: %v", partitionNumber, flag)
-		}
-		if flagToSet != "" {
-			args = append(args, flagToSet, "on")
-			// Golang does not allow mixing of variadic and regular arguments. So add all of the flock args to
-			// the overall arg slice and pass that to execute
-			args = append([]string{"--timeout", timeoutInSeconds, diskDevPath, "parted"}, args...)
-			_, stderr, err := shell.Execute("flock", args...)
-			if err != nil {
-				logger.Log.Warnf("Failed to set flag (%s) using parted: %v", flagToSet, stderr)
-			}
-		}
-	}
-
-	// Make sure all partition information is actually updated.
-	stdout, stderr, err := shell.Execute("flock", "--timeout", timeoutInSeconds, diskDevPath, "partprobe", "-s", diskDevPath)
-	if err != nil {
-		err = fmt.Errorf("failed to execute partprobe after partition initialization:\n%v\n%w", stderr, err)
-		return "", err
-	}
-	logger.Log.Debugf("Partprobe -s returned: %s", stdout)
 
 	return
 }
@@ -752,45 +702,20 @@ func isDigit(c byte) bool {
 	return c >= '0' && c <= '9'
 }
 
-func setGptPartitionType(partition configuration.Partition, timeoutInSeconds, diskDevPath, partitionNumberStr string) (err error) {
-	if partition.TypeUUID != "" || partition.Type != "" {
-		supports, err := PartedSupportsTypeCommand()
-		if err != nil {
-			return fmt.Errorf("failed to check if parted supportes 'type' command:\n%w", err)
-		}
-
-		if !supports {
-			logger.Log.Warn("parted version <3.6 does not support the 'type' session command - skipping this operation")
-			return nil
-		}
-
-		var typeUUID string
-		if partition.TypeUUID != "" {
-			typeUUID = partition.TypeUUID
-		} else {
-			typeUUID = configuration.PartitionTypeNameToUUID[partition.Type]
-		}
-		err = shell.ExecuteLiveWithErr(1, "flock", "--timeout", timeoutInSeconds, diskDevPath, "parted", diskDevPath,
-			"--script", "type", partitionNumberStr, typeUUID)
-		if err != nil {
-			return fmt.Errorf("failed to set partition type using parted:\n%w", err)
-		}
-	}
-	return
-}
-
 // formatSinglePartition formats the given partition to the type specified in the partition configuration
-func formatSinglePartition(targetOs targetos.TargetOs, partDevPath string, partition configuration.Partition,
+func formatSinglePartition(targetOs targetos.TargetOs, diskDevPath string, partDevPath string,
+	partition configuration.Partition,
 ) (fsType string, err error) {
 	const (
-		totalAttempts = 5
-		retryDuration = time.Second
+		totalAttempts    = 5
+		retryDuration    = time.Second
+		timeoutInSeconds = "5"
 	)
 
 	fsType = partition.FsType
 
 	// Note: It is possible for the format partition command to fail with error "The file does not exist and no size was specified".
-	// This is due to a possible race condition in Linux/parted where the partition may not actually be ready after being newly created.
+	// This is due to a possible race condition in Linux where the partition may not actually be ready after being newly created.
 	// To handle such cases, we can retry the command.
 	switch fsType {
 	case "fat32", "fat16", "vfat", "ext2", "ext3", "ext4", "xfs":
@@ -805,12 +730,12 @@ func formatSinglePartition(targetOs targetos.TargetOs, partDevPath string, parti
 			return fsType, err
 		}
 
-		mkfsArgs := []string{"-t", fsType}
+		mkfsArgs := []string{"--timeout", timeoutInSeconds, diskDevPath, "mkfs", "-t", fsType}
 		mkfsArgs = append(mkfsArgs, mkfsOptions...)
 		mkfsArgs = append(mkfsArgs, partDevPath)
 
 		err = retry.Run(func() error {
-			_, stderr, err := shell.Execute("mkfs", mkfsArgs...)
+			_, stderr, err := shell.Execute("flock", mkfsArgs...)
 			if err != nil {
 				logger.Log.Warnf("Failed to format partition using mkfs: %v", stderr)
 				return err
@@ -897,14 +822,9 @@ func SystemBlockDevices() (systemDevices []SystemBlockDevice, err error) {
 }
 
 func GetDiskPartitions(diskDevPath string) ([]PartitionInfo, error) {
-	// Just in case the disk was only recently connected, wait for the OS to finish processing it.
-	err := WaitForDevicesToSettle()
-	if err != nil {
-		return nil, fmt.Errorf("failed to list disk (%s) partitions:\n%w", diskDevPath, err)
-	}
-
 	// Read the disk's partitions.
-	jsonString, _, err := shell.Execute("lsblk", diskDevPath, "--output", "NAME,PATH,PARTTYPE,FSTYPE,UUID,MOUNTPOINT,PARTUUID,PARTLABEL,TYPE", "--json", "--list")
+	jsonString, _, err := shell.Execute("lsblk", diskDevPath, "--output",
+		"NAME,PATH,PARTTYPE,FSTYPE,UUID,MOUNTPOINT,PARTUUID,PARTLABEL,TYPE,SIZE", "--bytes", "--json", "--list")
 	if err != nil {
 		return nil, fmt.Errorf("failed to list disk (%s) partitions:\n%w", diskDevPath, err)
 	}
@@ -922,7 +842,6 @@ func GetDiskPartitions(diskDevPath string) ([]PartitionInfo, error) {
 
 func createExtendedPartition(diskDevPath string, partitionTableType configuration.PartitionTableType,
 	partitions []configuration.Partition, partIDToFsTypeMap, partDevPathMap map[string]string,
-	partedSupportsEmptyStringArgs bool,
 ) (err error) {
 	// Create a new partition object for extended partition
 	extendedPartition := configuration.Partition{}
@@ -931,7 +850,7 @@ func createExtendedPartition(diskDevPath string, partitionTableType configuratio
 	extendedPartition.End = partitions[len(partitions)-1].End
 
 	partDevPath, err := createSinglePartition(diskDevPath, maxPrimaryPartitionsForMBR, partitionTableType,
-		extendedPartition, extendedPartitionType, partedSupportsEmptyStringArgs)
+		extendedPartition, extendedPartitionType)
 	if err != nil {
 		err = fmt.Errorf("failed to create extended partition:\n%w", err)
 		return
@@ -1047,4 +966,19 @@ func obtainPartitionDetail(partitionIndex int, hasExtendedPartition bool) (partT
 	}
 
 	return
+}
+
+func refreshPartitions(diskDevPath string) error {
+	err := shell.ExecuteLiveWithErr(1 /*stderrLines*/, "flock", "--timeout", "5", diskDevPath,
+		"blockdev", "--rereadpt", diskDevPath)
+	if err != nil {
+		return fmt.Errorf("blockdev --rereadpt failed:\n%w", err)
+	}
+
+	err = WaitForDevicesToSettle()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
@@ -5,11 +5,13 @@ package imagecustomizerlib
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"testing"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/imagecustomizerapi"
+	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/safeloopback"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/safemount"
@@ -111,9 +113,11 @@ func testCustomizeImageVerityShrinkExtractHelper(t *testing.T, testName string, 
 		return
 	}
 
+	espPartitionNum := 1
 	bootPartitionNum := 2
 	rootPartitionNum := 3
 	hashPartitionNum := 4
+	varPartitionNum := 5
 
 	// Change the hash partition's filesystem type to ext4.
 	// This tests the logic that skips the hash partition when looking for partitions to shrink.
@@ -126,11 +130,38 @@ func testCustomizeImageVerityShrinkExtractHelper(t *testing.T, testName string, 
 		return
 	}
 
-	// Attach partition files.
+	espPartitionPath := filepath.Join(testTempDir, fmt.Sprintf("image_%d.raw", espPartitionNum))
 	bootPartitionPath := filepath.Join(testTempDir, fmt.Sprintf("image_%d.raw", bootPartitionNum))
 	rootPartitionPath := filepath.Join(testTempDir, fmt.Sprintf("image_%d.raw", rootPartitionNum))
 	hashPartitionPath := filepath.Join(testTempDir, fmt.Sprintf("image_%d.raw", hashPartitionNum))
+	varPartitionPath := filepath.Join(testTempDir, fmt.Sprintf("image_%d.raw", varPartitionNum))
 
+	espStat, err := os.Stat(espPartitionPath)
+	assert.NoError(t, err)
+
+	bootStat, err := os.Stat(bootPartitionPath)
+	assert.NoError(t, err)
+
+	rootStat, err := os.Stat(rootPartitionPath)
+	assert.NoError(t, err)
+
+	hashStat, err := os.Stat(hashPartitionPath)
+	assert.NoError(t, err)
+
+	varStat, err := os.Stat(varPartitionPath)
+	assert.NoError(t, err)
+
+	// Check partition sizes.
+	assert.Equal(t, int64(8*diskutils.MiB), espStat.Size())
+	assert.Equal(t, int64(128*diskutils.MiB), hashStat.Size())
+
+	// These partitions are shrunk.
+	// So, their size will vary slightly.
+	assert.Greater(t, int64(100*diskutils.MiB), bootStat.Size())
+	assert.Greater(t, int64(650*diskutils.MiB), rootStat.Size())
+	assert.Greater(t, int64(100*diskutils.MiB), varStat.Size())
+
+	// Attach partition files.
 	bootDevice, err := safeloopback.NewLoopback(bootPartitionPath)
 	if !assert.NoError(t, err) {
 		return

--- a/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
@@ -193,12 +193,6 @@ func createImageBoilerplate(targetOs targetos.TargetOs, imageConnection *ImageCo
 		return nil, "", fmt.Errorf("failed to create partitions on disk (%s):\n%w", imageConnection.Loopback().DevicePath(), err)
 	}
 
-	// Refresh partition entries under /dev.
-	err = refreshPartitions(imageConnection.Loopback().DevicePath())
-	if err != nil {
-		return nil, "", err
-	}
-
 	// Read the disk partitions.
 	diskPartitions, err := diskutils.GetDiskPartitions(imageConnection.Loopback().DevicePath())
 	if err != nil {

--- a/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
@@ -20,7 +20,6 @@ import (
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/safechroot"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/safemount"
-	"github.com/microsoft/azurelinux/toolkit/tools/internal/shell"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/sliceutils"
 	"golang.org/x/sys/unix"
 )
@@ -651,14 +650,4 @@ func getPartitionNum(partitionLoopDevice string) (int, error) {
 	}
 
 	return num, nil
-}
-
-func refreshPartitions(diskDevPath string) error {
-	err := shell.ExecuteLiveWithErr(1 /*stderrLines*/, "flock", "--timeout", "5", diskDevPath,
-		"partprobe", "-s", diskDevPath)
-	if err != nil {
-		return fmt.Errorf("partprobe failed:\n%w", err)
-	}
-
-	return nil
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
@@ -20,6 +20,7 @@ import (
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/safechroot"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/safemount"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/shell"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/sliceutils"
 	"golang.org/x/sys/unix"
 )

--- a/toolkit/tools/pkg/imagecustomizerlib/versionsOfToolDependencies.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/versionsOfToolDependencies.go
@@ -14,7 +14,7 @@ func logVersionsOfToolDeps() {
 	versionFlags := map[string][]string{
 		"--version": {
 			"qemu-img", "rpm", "dd", "lsblk", "losetup", "sfdisk", "udevadm",
-			"flock", "blkid", "sed", "createrepo", "genisoimage", "parted", "mkfs",
+			"flock", "blkid", "sed", "createrepo", "genisoimage", "mkfs",
 			"fsck", "fatlabel", "zstd", "veritysetup", "grub-install",
 		},
 		"-version": {


### PR DESCRIPTION
Use `sfdisk` and `blockdev` instead of `parted` and `partprobe`.

This is being done for a number of reasons:

1. There is already a dependency on `sfdisk`. So, this will remove a dependency.

2. The API of `sfdisk` is a little better structured (IMHO).

3. Feature support for some GPT features (e.g. partition types) came to `sfdisk` way sooner than they did for `parted`. So, we don't need version workarounds to use slightly older versions of `sfdisk`.

4. Ubuntu has a "fun" patch added to `parted` that adds in a `udevadm settle` call to all `parted` operations. This can cause deadlocks when `parted` is called under `flock`.

In addition, this change updates the partition customization tests so that they also verify the partition sizes.

Also, this change adds `flock` around the `mkfs` call. This will prevent udev from processing the partition while it is being formatted.

In addition, add a wait loop that ensures the kernel's view of the partitions have been actually updated.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
