### PR TITLE
bug: fix missing mountpoints in COSI

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
@@ -16,7 +16,7 @@ import (
 func customizePartitionsUsingFileCopy(buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
 	buildImageFile string, newBuildImageFile string,
 ) (map[string]string, error) {
-	existingImageConnection, err := connectToExistingImage(buildImageFile, buildDir, "imageroot", false)
+	existingImageConnection, _, err := connectToExistingImage(buildImageFile, buildDir, "imageroot", false)
 	if err != nil {
 		return nil, err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -1071,7 +1071,7 @@ func (b *LiveOSIsoBuilder) prepareArtifactsFromFullImage(inputSavedConfigsFilePa
 	logger.Log.Infof("Preparing iso artifacts")
 
 	logger.Log.Debugf("Connecting to raw image (%s)", rawImageFile)
-	rawImageConnection, err := connectToExistingImage(rawImageFile, b.workingDirs.isoBuildDir, "readonly-rootfs-mount", false /*includeDefaultMounts*/)
+	rawImageConnection, _, err := connectToExistingImage(rawImageFile, b.workingDirs.isoBuildDir, "readonly-rootfs-mount", false /*includeDefaultMounts*/)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
@@ -30,13 +30,8 @@ var (
 	partitionNumberRegex = regexp.MustCompile(`^/dev/loop\d+p(\d+)$`)
 )
 
-func findPartitions(buildDir string, diskDevice string) ([]*safechroot.MountPoint, error) {
+func findPartitions(buildDir string, diskPartitions []diskutils.PartitionInfo) ([]*safechroot.MountPoint, error) {
 	var err error
-
-	diskPartitions, err := diskutils.GetDiskPartitions(diskDevice)
-	if err != nil {
-		return nil, err
-	}
 
 	rootfsPartition, err := findRootfsPartition(diskPartitions, buildDir)
 	if err != nil {


### PR DESCRIPTION
<!-- Description: Please provide a summary of the changes and the motivation behind them. -->
PR summary:

This is a fix for missing mountpoints in COSI metadata. Created partuuid to mountpath mapping, and depending on whether we do partition customization or not, we use the mapping created during partition customization or the mapping in the existing image. 

local test:
now we are able to see the mountpoints information in COSI metadata.

tested with command `sudo ./imagecustomizer --log-level debug  --build-dir ./build  --image-file core-3.0.20241220.vhdx --output-image-file ./output-image-test.cosi --output-image-format cosi --config-file ../pkg/imagecustomizerlib/testdata/verity-config.yaml`

```
{
  "version": "1.0",
  "osArch": "amd64",
  "images": [
    {
      "image": {
        "path": "images/output-image-test_1.raw.zst",
        "compressedSize": 988959,
        "uncompressedSize": 8388608,
        "sha384": "40bc37dc53dff6194bc35b803b824b5a94f42e99235d50944125bf899bffc7e43aa7f815bfea86e1b4d0353efa11142c"
      },
      "mountPoint": "/boot/efi",
      "fsType": "vfat",
      "fsUuid": "F927-3DD3",
      "partType": "c12a7328-f81f-11d2-ba4b-00a0c93ec93b",
      "verity": null
    },
    {
      "image": {
        "path": "images/output-image-test_2.raw.zst",
        "compressedSize": 51438315,
        "uncompressedSize": 1064304640,
        "sha384": "d7e0cf15b8a13bcfd7f84345dff1e8b3769d3cb2b772a83904a61be7d091cf7da2202a3d6ee3e85a709bb0ce636151df"
      },
      "mountPoint": "/boot",
      "fsType": "ext4",
      "fsUuid": "ff2999cd-c34a-4e12-a93c-f8a97a55fbe9",
      "partType": "0fc63daf-8483-4772-8e79-3d69d8477de4",
      "verity": null
    },
    {
      "image": {
        "path": "images/output-image-test_3.raw.zst",
        "compressedSize": 114697262,
        "uncompressedSize": 2147483648,
        "sha384": "783fe87af97ac5f5ea683c1887e46d58029ee31a15c4439757337dbf5118fb1d2a95d22bd5c83fd84d6fb5936bf6ce57"
      },
      "mountPoint": "/",
      "fsType": "ext4",
      "fsUuid": "8052a630-d72d-420e-a0f5-62ce6e04eb27",
      "partType": "0fc63daf-8483-4772-8e79-3d69d8477de4",
      "verity": {
        "image": {
          "path": "images/output-image-test_4.raw.zst",
          "compressedSize": 2894248,
          "uncompressedSize": 134217728,
          "sha384": "1b0e2dc39598a5fb8b4cfaa7aa2698c0806190ae562480544ec4b82f2e182b3fa118e0c8e923f032cb7aecdc9325ce18"
        },
        "hash": "6271f33e97b7d8853b5fc685c35cdd200d9b9a0b911d4fe79e50294800ba8cd6"
      }
    },
    {
      "image": {
        "path": "images/output-image-test_5.raw.zst",
        "compressedSize": 28788772,
        "uncompressedSize": 2012217344,
        "sha384": "1452e87e66370956664b2228de28ddb3cc0f8ca0ebc91f6f555a08c61bcf9e660533d9a73c1e5a1b778c22f33ad771a8"
      },
      "mountPoint": "/var",
      "fsType": "ext4",
      "fsUuid": "960b53c3-2023-40e0-8388-0f07c31952c0",
      "partType": "0fc63daf-8483-4772-8e79-3d69d8477de4",
      "verity": null
    }
  ],
  "osRelease": "",
  "id": "601d3fac-e656-20f0-ef51-cd08c591bd84"
}
```

without partition customization, 
tested with command `sudo ./imagecustomizer --log-level debug  --build-dir ./build  --image-file core-3.0.20241220.vhdx --output-image-file ./output-image-test.cosi --output-image-format cosi --config-file ../pkg/imagecustomizerlib/testdata/users-config.yaml` 

```
{
  "version": "1.0",
  "osArch": "amd64",
  "images": [
    {
      "image": {
        "path": "images/output-image-test_1.raw.zst",
        "compressedSize": 986231,
        "uncompressedSize": 8388608,
        "sha384": "7d59ebf20375104232adffdd502f4f6e1044982e26c20c1153f7d74f407412549cdd183c9540a0c72657d21104c19fad"
      },
      "mountPoint": "/boot/efi",
      "fsType": "vfat",
      "fsUuid": "2BC1-1CF9",
      "partType": "c12a7328-f81f-11d2-ba4b-00a0c93ec93b",
      "verity": null
    },
    {
      "image": {
        "path": "images/output-image-test_2.raw.zst",
        "compressedSize": 190945452,
        "uncompressedSize": 543162368,
        "sha384": "019f5ed59258da9b9265bc77473d5ab9853c172c8ae77aaaf8a3569f91f69d601bf116a3db875e67b7d5438365e5bba6"
      },
      "mountPoint": "/",
      "fsType": "ext4",
      "fsUuid": "b8fe0f63-73ee-433f-858a-75fd3e762c79",
      "partType": "0fc63daf-8483-4772-8e79-3d69d8477de4",
      "verity": null
    }
  ],
  "osRelease": "",
  "id": "70121e96-3c8b-d76c-f3e0-eeda75fcb776"
```
---

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] Code conforms to style guidelines
