### PR TITLE
Ensure additionalFiles parent directory is created.

### DIFF
--- a/toolkit/tools/internal/file/file.go
+++ b/toolkit/tools/internal/file/file.go
@@ -357,7 +357,7 @@ func IsDirEmpty(path string) (bool, error) {
 	return false, nil
 }
 
-func createDestinationDir(dst string, dirmode os.FileMode) (err error) {
+func CreateDestinationDir(dst string, dirmode os.FileMode) (err error) {
 	isDstExist, err := PathExists(dst)
 	if err != nil {
 		return err
@@ -389,7 +389,7 @@ func createDestinationDir(dst string, dirmode os.FileMode) (err error) {
 func CopyResourceFile(srcFS fs.FS, srcFile, dst string, dirmode os.FileMode, filemode os.FileMode) error {
 	logger.Log.Debugf("Copying resource (%s) -> (%s)", srcFile, dst)
 
-	err := createDestinationDir(dst, dirmode)
+	err := CreateDestinationDir(dst, dirmode)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/internal/file/filecopybuilder.go
+++ b/toolkit/tools/internal/file/filecopybuilder.go
@@ -73,7 +73,7 @@ func (b FileCopyBuilder) Run() (err error) {
 		}
 	}
 
-	err = createDestinationDir(b.Dst, b.DirFileMode)
+	err = CreateDestinationDir(b.Dst, b.DirFileMode)
 	if err != nil {
 		return fmt.Errorf("failed to create destination directory (%s):\n%w", b.Dst, err)
 	}

--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -379,7 +379,13 @@ func copyFile(destDir string, f FileToCopy) error {
 
 func writeFile(destDir string, f FileToCopy) error {
 	dest := filepath.Join(destDir, f.Dest)
-	err := file.Write(*f.Content, dest)
+
+	err := file.CreateDestinationDir(dest, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("failed to create destination directory (%s):\n%w", dest, err)
+	}
+
+	err = file.Write(*f.Content, dest)
 	if err != nil {
 		return fmt.Errorf("failed to write file (%s):\n%w", f.Dest, err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizefiles_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizefiles_test.go
@@ -97,14 +97,14 @@ func TestCustomizeImageAdditionalFiles(t *testing.T) {
 
 	// Verify the files were copied correctly.
 	a_path := filepath.Join(testDir, "files/a.txt")
-	a_copy_path := filepath.Join(imageConnection.Chroot().RootDir(), "/a.txt")
+	a_copy_path := filepath.Join(imageConnection.Chroot().RootDir(), "/mnt/a/a.txt")
 
 	helloworld_path := filepath.Join(testDir, "files/helloworld.sh")
 	helloworld_copy_path := filepath.Join(imageConnection.Chroot().RootDir(), "/usr/local/bin/helloworld.sh")
 
-	animals_copy_path := filepath.Join(imageConnection.Chroot().RootDir(), "/animals.txt")
-	alphabet_copy_path := filepath.Join(imageConnection.Chroot().RootDir(), "/alphabet.txt")
-	empty_copy_path := filepath.Join(imageConnection.Chroot().RootDir(), "/empty.txt")
+	animals_copy_path := filepath.Join(imageConnection.Chroot().RootDir(), "/mnt/b/animals.txt")
+	alphabet_copy_path := filepath.Join(imageConnection.Chroot().RootDir(), "/mnt/c/alphabet.txt")
+	empty_copy_path := filepath.Join(imageConnection.Chroot().RootDir(), "/mnt/d/empty.txt")
 
 	verifyFileContentsSame(t, a_path, a_copy_path)
 	verifyFileContentsSame(t, helloworld_path, helloworld_copy_path)

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
@@ -259,7 +259,7 @@ func TestCustomizeImageLiveCd2(t *testing.T) {
 
 	// Check that a.txt is in the squashfs file.
 	aOrigPath := filepath.Join(testDir, "files/a.txt")
-	aIsoPath := filepath.Join(squashfsMountDir, "a.txt")
+	aIsoPath := filepath.Join(squashfsMountDir, "/mnt/a/a.txt")
 	verifyFileContentsSame(t, aOrigPath, aIsoPath)
 }
 

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/addfiles-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/addfiles-config.yaml
@@ -1,7 +1,7 @@
 os:
   additionalFiles:
   - source: files/a.txt
-    destination: /a.txt
+    destination: /mnt/a/a.txt
 
   - source: files/helloworld.sh
     destination: /usr/local/bin/helloworld.sh
@@ -10,12 +10,12 @@ os:
   - content: |
       cat
       dog
-    destination: /animals.txt
+    destination: /mnt/b/animals.txt
 
   - content: |-
       abcdefghijklmnopqrstuvwxyz
-    destination: /alphabet.txt
+    destination: /mnt/c/alphabet.txt
     permissions: 644
 
   - content: ""
-    destination: /empty.txt
+    destination: /mnt/d/empty.txt


### PR DESCRIPTION
For `additionalFiles`, currently when `source` is used, then the destination's parent directory is created if it doesn't yet exist. But this doesn't happen when `content` is used. This change fixes this.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
