### PR TITLE
fix verity roothash naming in COSI

### DIFF
--- a/toolkit/tools/osmodifierapi/verity.go
+++ b/toolkit/tools/osmodifierapi/verity.go
@@ -38,11 +38,11 @@ func (v *Verity) IsValid() error {
 	}
 
 	if v.DataDevice == "" {
-		return fmt.Errorf("'dataDeviceId' may not be empty")
+		return fmt.Errorf("'dataDevice' may not be empty")
 	}
 
 	if v.HashDevice == "" {
-		return fmt.Errorf("'hashDeviceId' may not be empty")
+		return fmt.Errorf("'hashDevice' may not be empty")
 	}
 
 	if err := v.CorruptionOption.IsValid(); err != nil {

--- a/toolkit/tools/pkg/imagecustomizerlib/cosicommon.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/cosicommon.go
@@ -107,7 +107,7 @@ func buildCosiFile(sourceDir string, outputFile string, partitions []outputParti
 				}
 
 				metadataImage.Verity = &Verity{
-					Hash: verity.hash,
+					Roothash: verity.rootHash,
 					Image: ImageFile{
 						Path:             path.Join("images", hashPartition.PartitionFilename),
 						UncompressedSize: hashPartition.UncompressedSize,

--- a/toolkit/tools/pkg/imagecustomizerlib/cosimetadata.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/cosimetadata.go
@@ -18,8 +18,8 @@ type Image struct {
 }
 
 type Verity struct {
-	Image ImageFile `json:"image"`
-	Hash  string    `json:"hash"`
+	Image    ImageFile `json:"image"`
+	Roothash string    `json:"roothash"`
 }
 
 type ImageFile struct {

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -90,7 +90,7 @@ type ImageCustomizerParameters struct {
 }
 
 type verityDeviceMetadata struct {
-	hash         string
+	rootHash     string
 	dataPartUuid string
 	hashPartUuid string
 }
@@ -416,7 +416,7 @@ func customizeOSContents(ic *ImageCustomizerParameters) error {
 		}
 
 		verityMetadata := verityDeviceMetadata{
-			hash:         rootHash,
+			rootHash:     rootHash,
 			dataPartUuid: dataPartUuid,
 			hashPartUuid: roothashPartUuid,
 		}


### PR DESCRIPTION
<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

tested locally
```
    {
      "image": {
        "path": "images/output-image-test_3.raw.zst",
        "compressedSize": 114956179,
        "uncompressedSize": 2147483648,
        "sha384": "b89f39d1f978af4c70eb32a3852a3530622fadecf03632a622edc59b711d07579e152a76294fc4daf0f4119fee249f0a"
      },
      "mountPoint": "/",
      "fsType": "ext4",
      "fsUuid": "92727108-e5fa-4ff9-a0ba-9d46b09c4e54",
      "partType": "0fc63daf-8483-4772-8e79-3d69d8477de4",
      "verity": {
        "image": {
          "path": "images/output-image-test_4.raw.zst",
          "compressedSize": 2895263,
          "uncompressedSize": 134217728,
          "sha384": "ce7d38cfe6356aa60493a8624181b3ad926493289049a9423aab974d4138c121ab08b4eb253c2ffe81cb5af215243609"
        },
        "roothash": "3374f0481ed94423be7fba7db73fb1a45912932119de0f3664dd8f9ea1dae39f"
      }
    },
```

---
### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] Code conforms to style guidelines
