### PR TITLE
Fix race condition when resetting partition UUIDs.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsuuids.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsuuids.go
@@ -64,6 +64,12 @@ func resetPartitionsUuids(buildImageFile string, buildDir string) error {
 		newPartUuids[i] = newPartUuid
 	}
 
+	// Wait for the partition table updates to be processed.
+	err = diskutils.WaitForDevicesToSettle()
+	if err != nil {
+		return err
+	}
+
 	// Fix /etc/fstab file.
 	err = fixPartitionUuidsInFstabFile(partitions, newUuids, newPartUuids, buildDir)
 	if err != nil {


### PR DESCRIPTION
Code is missing a wait after the disks partition table is changed.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
