### PR TITLE
Enable Image Customizer VM tests.

### DIFF
--- a/test/vmtests/Makefile
+++ b/test/vmtests/Makefile
@@ -16,7 +16,7 @@ TOOLKIT_DIR=../../toolkit
 TOOLS_BIN_DIR=${TOOLKIT_DIR}/out/tools
 IMAGE_CUSTOMIZER_BIN=${TOOLS_BIN_DIR}/imagecustomizer
 
-IMAGE_CUSTOMIZER_CONTAINER_TAG=imagecustomizer:dev
+IMAGE_CUSTOMIZER_CONTAINER_TAG?=imagecustomizer:dev
 
 SSH_PRIVATE_KEY_FILE ?= ${HOME}/.ssh/id_ed25519
 
@@ -62,11 +62,25 @@ ${IMAGE_CUSTOMIZER_BIN}:
 image-customizer-container: ${IMAGE_CUSTOMIZER_BIN}
 	${TOOLKIT_DIR}/tools/imagecustomizer/container/build-mic-container.sh -t ${IMAGE_CUSTOMIZER_CONTAINER_TAG}
 
+.PHONY: test
+test:
+	${PYTEST} \
+		--image-customizer-container-url="${IMAGE_CUSTOMIZER_CONTAINER_TAG}" \
+		--input-image="${INPUT_IMAGE}" \
+		--output-format="${OUTPUT_FORMAT}" \
+		--ssh-private-key="${SSH_PRIVATE_KEY_FILE}" \
+		$(if $(filter y,$(KEEP_ENVIRONMENT)),--keep-environment) \
+		--log-cli-level=DEBUG \
+		--show-capture=all \
+		--tb=short \
+		./vmtests
+
 .PHONY: run
 run: image-customizer-container
 	${PYTEST} \
 		--image-customizer-container-url="${IMAGE_CUSTOMIZER_CONTAINER_TAG}" \
-		--core-efi-azl2="${CORE_EFI_AZL2}" \
+		--input-image="${INPUT_IMAGE}" \
+		--output-format="${OUTPUT_FORMAT}" \
 		--ssh-private-key="${SSH_PRIVATE_KEY_FILE}" \
 		$(if $(filter y,$(KEEP_ENVIRONMENT)),--keep-environment) \
 		--log-cli-level=DEBUG \

--- a/test/vmtests/vmtests/conftest.py
+++ b/test/vmtests/vmtests/conftest.py
@@ -22,7 +22,8 @@ TEST_CONFIGS_DIR = SCRIPT_PATH.joinpath("../../../toolkit/tools/pkg/imagecustomi
 
 def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption("--keep-environment", action="store_true", help="Keep the resources created during the test")
-    parser.addoption("--core-efi-azl2", action="store", help="Path to Azure Linux 2.0 core-efi qcow2 image")
+    parser.addoption("--input-image", action="store", help="Path to input image")
+    parser.addoption("--output-format", action="store", help="Image Customizer supported format")
     parser.addoption("--image-customizer-container-url", action="store", help="Image Customizer container image URL")
     parser.addoption(
         "--ssh-private-key", action="store", help="An SSH private key file to use for authentication with the VMs"
@@ -76,12 +77,18 @@ def test_temp_dir(
 
 
 @pytest.fixture(scope="session")
-def core_efi_azl2(request: pytest.FixtureRequest) -> Generator[Path, None, None]:
-    image = request.config.getoption("--core-efi-azl2")
-    if not image:
-        raise Exception("--core-efi-azl2 is required for test")
-    yield Path(image)
+def input_image(request: pytest.FixtureRequest) -> Generator[Path, None, None]:
+    input_image = request.config.getoption("--input-image")
+    if not input_image:
+        raise Exception("--input-image is required for test")
+    yield Path(input_image)
 
+@pytest.fixture(scope="session")
+def output_format(request: pytest.FixtureRequest) -> Generator[str, None, None]:
+    output_format = request.config.getoption("--output-format")
+    if not output_format:
+        raise Exception("--output-format is required for test")
+    yield output_format
 
 @pytest.fixture(scope="session")
 def image_customizer_container_url(request: pytest.FixtureRequest) -> Generator[str, None, None]:

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/nochange-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/nochange-config.yaml
@@ -1,1 +1,5 @@
 os:
+  additionalFiles:
+    # Enable DHCP client on all of the physical NICs.
+  - source: files/89-ethernet.network
+    destination: /etc/systemd/network/89-ethernet.network

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/nochange-iso-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/nochange-iso-config.yaml
@@ -1,0 +1,18 @@
+os:
+  selinux:
+    mode: disabled
+  kernelCommandLine:
+    extraCommandLine:
+    - "selinux=0"
+  packages:
+    install:
+    # iso required packages
+    - squashfs-tools
+    - tar
+    - device-mapper
+    - curl
+
+  additionalFiles:
+    # Enable DHCP client on all of the physical NICs.
+  - source: files/89-ethernet.network
+    destination: /etc/systemd/network/89-ethernet.network


### PR DESCRIPTION
This change updates the VMTests framework to support:
- ADO pipelines.
- iso images.
- Azl2.0 hosts.

<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

---

### **Checklist**
- [x] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] Code conforms to style guidelines
