### PR TITLE
Support usr Verity.

### DIFF
--- a/docs/imagecustomizer/api/configuration/verity.md
+++ b/docs/imagecustomizer/api/configuration/verity.md
@@ -6,7 +6,7 @@ parent: Configuration
 
 Specifies the configuration for dm-verity integrity verification.
 
-Note: Currently root partition (`/`) and usr partition are supported.
+Note: Currently root partition (`/`) and usr partition (`/usr`) are supported.
 
 Note: The [filesystem](./filesystem.md) item pointing to this verity device, must
 include the `ro` option in the [mountPoint.options](./mountpoint.md#options-string).
@@ -14,7 +14,7 @@ include the `ro` option in the [mountPoint.options](./mountpoint.md#options-stri
 There are multiple ways to configure a verity enabled image. For
 recommendations, see [Verity Image Recommendations](../../concepts/verity.md).
 
-Example:
+Example of enabling root Verity:
 
 ```yaml
 storage:
@@ -38,23 +38,11 @@ storage:
     - id: var
       size: 2G
 
-    - id: usr
-      size: 1G
-
-    - id: usrhash
-      size: 100M
-
   verity:
   - id: verityroot
     name: root
     dataDeviceId: root
     hashDeviceId: roothash
-    corruptionOption: panic
-
-  - id: verityusr
-    name: usr
-    dataDeviceId: usr
-    hashDeviceId: usrhash
     corruptionOption: panic
 
   filesystems:
@@ -74,15 +62,66 @@ storage:
       path: /
       options: ro
 
+  - deviceId: var
+    type: ext4
+    mountPoint: /var
+
+os:
+  bootloader:
+    resetType: hard-reset
+```
+
+Example of enabling usr Verity:
+
+```yaml
+storage:
+  bootType: efi
+  disks:
+  - partitionTableType: gpt
+    partitions:
+    - id: esp
+      type: esp
+      size: 8M
+
+    - id: boot
+      size: 1G
+
+    - id: root
+      size: 2G
+
+    - id: usr
+      size: 2G
+
+    - id: usrhash
+      size: 100M
+
+  verity:
+  - id: verityusr
+    name: usr
+    dataDeviceId: usr
+    hashDeviceId: usrhash
+    corruptionOption: panic
+
+  filesystems:
+  - deviceId: esp
+    type: fat32
+    mountPoint:
+      path: /boot/efi
+      options: umask=0077
+
+  - deviceId: boot
+    type: ext4
+    mountPoint: /boot
+
+  - deviceId: root
+    type: ext4
+    mountPoint: /
+
   - deviceId: verityusr
     type: ext4
     mountPoint:
       path: /usr
       options: ro
-
-  - deviceId: var
-    type: ext4
-    mountPoint: /var
 
 os:
   bootloader:

--- a/docs/imagecustomizer/api/configuration/verity.md
+++ b/docs/imagecustomizer/api/configuration/verity.md
@@ -6,8 +6,7 @@ parent: Configuration
 
 Specifies the configuration for dm-verity integrity verification.
 
-Note: Currently only root partition (`/`) is supported. Support for other partitions
-(e.g. `/usr`) may be added in the future.
+Note: Currently root partition (`/`) and usr partition are supported.
 
 Note: The [filesystem](./filesystem.md) item pointing to this verity device, must
 include the `ro` option in the [mountPoint.options](./mountpoint.md#options-string).
@@ -39,11 +38,23 @@ storage:
     - id: var
       size: 2G
 
+    - id: usr
+      size: 1G
+
+    - id: usrhash
+      size: 100M
+
   verity:
   - id: verityroot
     name: root
     dataDeviceId: root
     hashDeviceId: roothash
+    corruptionOption: panic
+
+  - id: verityusr
+    name: usr
+    dataDeviceId: usr
+    hashDeviceId: usrhash
     corruptionOption: panic
 
   filesystems:
@@ -61,6 +72,12 @@ storage:
     type: ext4
     mountPoint:
       path: /
+      options: ro
+
+  - deviceId: verityusr
+    type: ext4
+    mountPoint:
+      path: /usr
       options: ro
 
   - deviceId: var

--- a/toolkit/tools/imagecustomizerapi/storage.go
+++ b/toolkit/tools/imagecustomizerapi/storage.go
@@ -169,15 +169,13 @@ func (s *Storage) IsValid() error {
 			verity.FileSystem = filesystem
 		}
 
-		if !hasFileSystem || filesystem.MountPoint == nil || filesystem.MountPoint.Path != "/" {
-			return fmt.Errorf("defining non-root verity devices is not currently supported:\n"+
-				"filesystems[].mountPoint.path' of verity device (%s) must be set to '/'",
-				verity.Id)
+		if !hasFileSystem || filesystem.MountPoint == nil || filesystem.MountPoint.Path != "/" && filesystem.MountPoint.Path != "/usr" {
+			return fmt.Errorf("filesystems[].mountPoint.path of verity device (%s) must be set to '/' or '/usr'", verity.Id)
 		}
 
-		if verity.Name != VerityRootDeviceName {
-			return fmt.Errorf("verity 'name' (%s) must be \"%s\" for filesystem (%s) partition (%s)", verity.Name,
-				VerityRootDeviceName, filesystem.MountPoint.Path, verity.DataDeviceId)
+		if verity.Name != VerityRootDeviceName && verity.Name != VerityUsrDeviceName {
+			return fmt.Errorf("verity 'name' (%s) must be \"%s\" or \"%s\"",
+				verity.Name, VerityRootDeviceName, VerityUsrDeviceName)
 		}
 
 		mountOptions := strings.Split(filesystem.MountPoint.Options, ",")

--- a/toolkit/tools/imagecustomizerapi/storage.go
+++ b/toolkit/tools/imagecustomizerapi/storage.go
@@ -173,9 +173,11 @@ func (s *Storage) IsValid() error {
 			return fmt.Errorf("filesystems[].mountPoint.path of verity device (%s) must be set to '/' or '/usr'", verity.Id)
 		}
 
-		if verity.Name != VerityRootDeviceName && verity.Name != VerityUsrDeviceName {
-			return fmt.Errorf("verity 'name' (%s) must be \"%s\" or \"%s\"",
-				verity.Name, VerityRootDeviceName, VerityUsrDeviceName)
+		if filesystem.MountPoint.Path == "/" && verity.Name != VerityRootDeviceName ||
+			filesystem.MountPoint.Path == "/usr" && verity.Name != VerityUsrDeviceName {
+			return fmt.Errorf("filesystems[].mountPoint.path of verity device (%s) ('%s') must match verity name: '%s' for '/', '%s' for '/usr'",
+				verity.Id, filesystem.MountPoint.Path, VerityRootDeviceName, VerityUsrDeviceName,
+			)
 		}
 
 		mountOptions := strings.Split(filesystem.MountPoint.Options, ",")

--- a/toolkit/tools/imagecustomizerapi/storage.go
+++ b/toolkit/tools/imagecustomizerapi/storage.go
@@ -169,14 +169,15 @@ func (s *Storage) IsValid() error {
 			verity.FileSystem = filesystem
 		}
 
-		if !hasFileSystem || filesystem.MountPoint == nil || filesystem.MountPoint.Path != "/" && filesystem.MountPoint.Path != "/usr" {
+		if !hasFileSystem || filesystem.MountPoint == nil || (filesystem.MountPoint.Path != "/" && filesystem.MountPoint.Path != "/usr") {
 			return fmt.Errorf("filesystems[].mountPoint.path of verity device (%s) must be set to '/' or '/usr'", verity.Id)
 		}
 
-		if filesystem.MountPoint.Path == "/" && verity.Name != VerityRootDeviceName ||
-			filesystem.MountPoint.Path == "/usr" && verity.Name != VerityUsrDeviceName {
-			return fmt.Errorf("filesystems[].mountPoint.path of verity device (%s) ('%s') must match verity name: '%s' for '/', '%s' for '/usr'",
-				verity.Id, filesystem.MountPoint.Path, VerityRootDeviceName, VerityUsrDeviceName,
+		expectedVerityName, validMount := verityMountMap[filesystem.MountPoint.Path]
+		if !validMount || verity.Name != expectedVerityName {
+			return fmt.Errorf(
+				"filesystems[].mountPoint.path of verity device (%s) ('%s') must match verity name: '%s' for '%s'",
+				verity.Id, filesystem.MountPoint.Path, expectedVerityName, filesystem.MountPoint.Path,
 			)
 		}
 

--- a/toolkit/tools/imagecustomizerapi/storage.go
+++ b/toolkit/tools/imagecustomizerapi/storage.go
@@ -176,8 +176,8 @@ func (s *Storage) IsValid() error {
 		expectedVerityName, validMount := verityMountMap[filesystem.MountPoint.Path]
 		if !validMount || verity.Name != expectedVerityName {
 			return fmt.Errorf(
-				"filesystems[].mountPoint.path of verity device (%s) ('%s') must match verity name: '%s' for '%s'",
-				verity.Id, filesystem.MountPoint.Path, expectedVerityName, filesystem.MountPoint.Path,
+				"filesystems[].mountPoint.path of verity device (%s) must match verity name: '%s' for '%s'",
+				verity.Id, expectedVerityName, filesystem.MountPoint.Path,
 			)
 		}
 

--- a/toolkit/tools/imagecustomizerapi/storage_test.go
+++ b/toolkit/tools/imagecustomizerapi/storage_test.go
@@ -998,7 +998,7 @@ func TestStorageIsValidVerityWrongDeviceName(t *testing.T) {
 	}
 
 	err := value.IsValid()
-	assert.ErrorContains(t, err, "filesystems[].mountPoint.path of verity device (rootverity) ('/') must match verity name: 'root' for '/'")
+	assert.ErrorContains(t, err, "filesystems[].mountPoint.path of verity device (rootverity) must match verity name: 'root' for '/'")
 }
 
 func TestStorageIsValidVerityHashFileSystem(t *testing.T) {

--- a/toolkit/tools/imagecustomizerapi/storage_test.go
+++ b/toolkit/tools/imagecustomizerapi/storage_test.go
@@ -690,8 +690,7 @@ func TestStorageIsValidVerityUsr(t *testing.T) {
 	}
 
 	err := value.IsValid()
-	assert.ErrorContains(t, err, "defining non-root verity devices is not currently supported")
-	assert.ErrorContains(t, err, "filesystems[].mountPoint.path' of verity device (usrverity) must be set to '/'")
+	assert.NoError(t, err)
 }
 
 func TestStorageIsValidVerityInvalidName(t *testing.T) {
@@ -991,7 +990,7 @@ func TestStorageIsValidVerityWrongDeviceName(t *testing.T) {
 		Verity: []Verity{
 			{
 				Id:           "rootverity",
-				Name:         "usr",
+				Name:         "user",
 				DataDeviceId: "root",
 				HashDeviceId: "roothash",
 			},
@@ -999,7 +998,7 @@ func TestStorageIsValidVerityWrongDeviceName(t *testing.T) {
 	}
 
 	err := value.IsValid()
-	assert.ErrorContains(t, err, "verity 'name' (usr) must be \"root\" for filesystem (/) partition (root)")
+	assert.ErrorContains(t, err, "verity 'name' (user) must be \"root\" or \"usr\"")
 }
 
 func TestStorageIsValidVerityHashFileSystem(t *testing.T) {

--- a/toolkit/tools/imagecustomizerapi/storage_test.go
+++ b/toolkit/tools/imagecustomizerapi/storage_test.go
@@ -998,7 +998,7 @@ func TestStorageIsValidVerityWrongDeviceName(t *testing.T) {
 	}
 
 	err := value.IsValid()
-	assert.ErrorContains(t, err, "filesystems[].mountPoint.path of verity device (rootverity) ('/') must match verity name: 'root' for '/', 'usr' for '/usr'")
+	assert.ErrorContains(t, err, "filesystems[].mountPoint.path of verity device (rootverity) ('/') must match verity name: 'root' for '/'")
 }
 
 func TestStorageIsValidVerityHashFileSystem(t *testing.T) {

--- a/toolkit/tools/imagecustomizerapi/storage_test.go
+++ b/toolkit/tools/imagecustomizerapi/storage_test.go
@@ -998,7 +998,7 @@ func TestStorageIsValidVerityWrongDeviceName(t *testing.T) {
 	}
 
 	err := value.IsValid()
-	assert.ErrorContains(t, err, "verity 'name' (user) must be \"root\" or \"usr\"")
+	assert.ErrorContains(t, err, "filesystems[].mountPoint.path of verity device (rootverity) ('/') must match verity name: 'root' for '/', 'usr' for '/usr'")
 }
 
 func TestStorageIsValidVerityHashFileSystem(t *testing.T) {

--- a/toolkit/tools/imagecustomizerapi/storage_test.go
+++ b/toolkit/tools/imagecustomizerapi/storage_test.go
@@ -1180,8 +1180,7 @@ func TestStorageIsValidVerityFileSystemMissing(t *testing.T) {
 	}
 
 	err := value.IsValid()
-	assert.ErrorContains(t, err, "defining non-root verity devices is not currently supported:\n"+
-		"filesystems[].mountPoint.path' of verity device (rootverity) must be set to '/'")
+	assert.ErrorContains(t, err, "filesystems[].mountPoint.path of verity device (rootverity) must be set to '/' or '/usr'")
 }
 
 func TestStorageIsValidVerityTwoVerity(t *testing.T) {

--- a/toolkit/tools/imagecustomizerapi/verity.go
+++ b/toolkit/tools/imagecustomizerapi/verity.go
@@ -12,6 +12,7 @@ const (
 	DeviceMapperPath = "/dev/mapper"
 
 	VerityRootDeviceName = "root"
+	VerityUsrDeviceName  = "usr"
 )
 
 var (

--- a/toolkit/tools/imagecustomizerapi/verity.go
+++ b/toolkit/tools/imagecustomizerapi/verity.go
@@ -19,6 +19,11 @@ var (
 	verityNameRegex = regexp.MustCompile("^[a-z]+$")
 )
 
+var verityMountMap = map[string]string{
+	"/":    VerityRootDeviceName,
+	"/usr": VerityUsrDeviceName,
+}
+
 type Verity struct {
 	// ID is used to correlate `Verity` objects with `FileSystem` objects.
 	Id string `yaml:"id" json:"id,omitempty"`

--- a/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer.go
@@ -206,6 +206,22 @@ func (b *BootCustomizer) PrepareForVerity() error {
 	return nil
 }
 
+func (b *BootCustomizer) PrepareForUsrVerity() error {
+	if b.isGrubMkconfig {
+		// Disable recovery menu entry, to avoid having more than 1 linux command in the grub.cfg file.
+		// This will make it easier to modify the grub.cfg file to add the verity args.
+		defaultGrubFileContent, err := UpdateDefaultGrubFileVariable(b.defaultGrubFileContent, "GRUB_DISABLE_RECOVERY",
+			"true")
+		if err != nil {
+			return err
+		}
+
+		b.defaultGrubFileContent = defaultGrubFileContent
+	}
+
+	return nil
+}
+
 func (b *BootCustomizer) WriteToFile(imageChroot safechroot.ChrootInterface) error {
 	if b.isGrubMkconfig {
 		// Update /etc/defaukt/grub file.

--- a/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
@@ -532,7 +532,7 @@ func updateKernelCommandLineArgsAll(grub2Config string, argsToRemove []string, n
 // Output:
 // - grub2Config: The new string contents of the grub.cfg file.
 func updateKernelCommandLineArgs(grub2Config string, argsToRemove []string, newArgs []string) (string, error) {
-	return updateKernelCommandLineArgsAll(grub2Config, argsToRemove, newArgs, true /*allowMultiple*/, false /*requireKernelOpts*/)
+	return updateKernelCommandLineArgsAll(grub2Config, argsToRemove, newArgs, false /*allowMultiple*/, true /*requireKernelOpts*/)
 }
 
 func updateKernelCommandLineArgsHelper(value string, args []grubConfigLinuxArg, insertAt int,

--- a/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
@@ -532,7 +532,7 @@ func updateKernelCommandLineArgsAll(grub2Config string, argsToRemove []string, n
 // Output:
 // - grub2Config: The new string contents of the grub.cfg file.
 func updateKernelCommandLineArgs(grub2Config string, argsToRemove []string, newArgs []string) (string, error) {
-	return updateKernelCommandLineArgsAll(grub2Config, argsToRemove, newArgs, false /*allowMultiple*/, true /*requireKernelOpts*/)
+	return updateKernelCommandLineArgsAll(grub2Config, argsToRemove, newArgs, true /*allowMultiple*/, false /*requireKernelOpts*/)
 }
 
 func updateKernelCommandLineArgsHelper(value string, args []grubConfigLinuxArg, insertAt int,

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -90,9 +90,11 @@ type ImageCustomizerParameters struct {
 }
 
 type verityDeviceMetadata struct {
-	rootHash     string
-	dataPartUuid string
-	hashPartUuid string
+	rootHash              string
+	dataPartUuid          string
+	hashPartUuid          string
+	dataDeviceMountIdType imagecustomizerapi.MountIdentifierType
+	hashDeviceMountIdType imagecustomizerapi.MountIdentifierType
 }
 
 func createImageCustomizerParameters(buildDir string,
@@ -909,9 +911,11 @@ func customizeVerityImageHelper(buildDir string, config *imagecustomizerapi.Conf
 		}
 
 		verityMetadata[verityConfig.FileSystem.MountPoint.Path] = verityDeviceMetadata{
-			rootHash:     rootHashMatches[1],
-			dataPartUuid: dataPartUuid,
-			hashPartUuid: hashPartUuid,
+			rootHash:              rootHashMatches[1],
+			dataPartUuid:          dataPartUuid,
+			hashPartUuid:          hashPartUuid,
+			dataDeviceMountIdType: verityConfig.DataDeviceMountIdType,
+			hashDeviceMountIdType: verityConfig.HashDeviceMountIdType,
 		}
 	}
 
@@ -939,13 +943,13 @@ func customizeVerityImageHelper(buildDir string, config *imagecustomizerapi.Conf
 
 	if config.OS.Uki != nil {
 		// UKI is enabled, update kernel cmdline args file instead of grub.cfg.
-		err = updateUkiKernelArgsForVerity(verityMetadata, partIdToPartUuid, diskPartitions, buildDir)
+		err = updateUkiKernelArgsForVerity(verityMetadata, diskPartitions, buildDir)
 		if err != nil {
 			return nil, fmt.Errorf("failed to update kernel cmdline arguments for verity:\n%w", err)
 		}
 	} else {
 		// UKI is not enabled, update grub.cfg as usual.
-		err = updateGrubConfigForVerity(verityMetadata, grubCfgFullPath, partIdToPartUuid, diskPartitions, buildDir)
+		err = updateGrubConfigForVerity(verityMetadata, grubCfgFullPath, diskPartitions, buildDir)
 		if err != nil {
 			return nil, fmt.Errorf("failed to update grub config for verity:\n%w", err)
 		}


### PR DESCRIPTION
<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

---

### **Checklist**
- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines

The code has been verified locally with these test cases:

- core -> root + grub
- core -> root + uki
- core -> usr + grub
- core -> usr + uki
- core -> root + usr + grub
- core -> root + usr + uki
- usr + grub -> usr + grub
- usr + grub -> usr + uki

Example output:

```
root [ /home/test ]# dmsetup info
Name:              root
State:             ACTIVE (READ-ONLY)
Read Ahead:        256
Tables present:    LIVE
Open count:        1
Event number:      0
Major, minor:      254, 0
Number of targets: 1
UUID: CRYPT-VERITY-bb1ebee9b36648059288e7ca77c55d32-root

Name:              usr
State:             ACTIVE (READ-ONLY)
Read Ahead:        256
Tables present:    LIVE
Open count:        1
Event number:      0
Major, minor:      254, 1
Number of targets: 1
UUID: CRYPT-VERITY-801076ddc8c7437686f02f8d7620e4f1-usr
```
