### PR TITLE
Add multi-kernel support.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer.go
@@ -65,7 +65,7 @@ func (b *BootCustomizer) AddKernelCommandLine(extraCommandLine []string) error {
 		b.defaultGrubFileContent = defaultGrubFileContent
 	} else {
 		// Add the args directly to the /boot/grub2/grub.cfg file.
-		grubCfgContent, err := appendKernelCommandLineArgs(b.grubCfgContent, combinedArgs)
+		grubCfgContent, err := appendKernelCommandLineArgsAll(b.grubCfgContent, combinedArgs)
 		if err != nil {
 			return err
 		}
@@ -88,7 +88,7 @@ func (b *BootCustomizer) getSELinuxModeFromGrub() (imagecustomizerapi.SELinuxMod
 			return "", err
 		}
 	} else {
-		args, _, err = getLinuxCommandLineArgs(b.grubCfgContent, true /*requireKernelOpts*/)
+		args, _, err = getLinuxCommandLineArgs(b.grubCfgContent)
 		if err != nil {
 			return imagecustomizerapi.SELinuxModeDefault, err
 		}
@@ -163,7 +163,7 @@ func (b *BootCustomizer) UpdateKernelCommandLineArgs(defaultGrubFileVarName defa
 
 		b.defaultGrubFileContent = defaultGrubFileContent
 	} else {
-		grubCfgContent, err := updateKernelCommandLineArgs(b.grubCfgContent, argsToRemove, newArgs)
+		grubCfgContent, err := updateKernelCommandLineArgsAll(b.grubCfgContent, argsToRemove, newArgs)
 		if err != nil {
 			return err
 		}
@@ -184,34 +184,10 @@ func (b *BootCustomizer) PrepareForVerity() error {
 			return err
 		}
 
-		// Disable recovery menu entry, to avoid having more than 1 linux command in the grub.cfg file.
-		// This will make it easier to modify the grub.cfg file to add the verity args.
-		defaultGrubFileContent, err = UpdateDefaultGrubFileVariable(defaultGrubFileContent, "GRUB_DISABLE_RECOVERY",
-			"true")
-		if err != nil {
-			return err
-		}
-
 		// For rootfs verity, the root device will always be "/dev/mapper/root"
 		rootDevicePath := verityDevicePathFromName(imagecustomizerapi.VerityRootDeviceName)
 		defaultGrubFileContent, err = UpdateDefaultGrubFileVariable(defaultGrubFileContent, "GRUB_DEVICE",
 			rootDevicePath)
-		if err != nil {
-			return err
-		}
-
-		b.defaultGrubFileContent = defaultGrubFileContent
-	}
-
-	return nil
-}
-
-func (b *BootCustomizer) PrepareForUsrVerity() error {
-	if b.isGrubMkconfig {
-		// Disable recovery menu entry, to avoid having more than 1 linux command in the grub.cfg file.
-		// This will make it easier to modify the grub.cfg file to add the verity args.
-		defaultGrubFileContent, err := UpdateDefaultGrubFileVariable(b.defaultGrubFileContent, "GRUB_DISABLE_RECOVERY",
-			"true")
 		if err != nil {
 			return err
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer_test.go
@@ -30,7 +30,7 @@ func TestBootCustomizerAddKernelCommandLine20(t *testing.T) {
 	expectedGrubCfdDiff := `22c22
 < 	linux $bootprefix/$mariner_linux       rd.auto=1 root=$rootdevice $mariner_cmdline lockdown=integrity sysctl.kernel.unprivileged_bpf_disabled=1 $systemd_cmdline   $kernelopts
 ---
-> 	linux $bootprefix/$mariner_linux       rd.auto=1 root=$rootdevice $mariner_cmdline lockdown=integrity sysctl.kernel.unprivileged_bpf_disabled=1 $systemd_cmdline   console=tty0 console=ttyS0 $kernelopts
+> 	linux $bootprefix/$mariner_linux       rd.auto=1 root=$rootdevice $mariner_cmdline lockdown=integrity sysctl.kernel.unprivileged_bpf_disabled=1 $systemd_cmdline    console=tty0 console=ttyS0 $kernelopts
 `
 	checkDiffs20(t, b, expectedGrubCfdDiff, "")
 }
@@ -113,7 +113,7 @@ func TestBootCustomizerSELinuxMode30(t *testing.T) {
 	expectedDefaultGrubFileDiff := `5c5
 < GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity "
 ---
-> GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity  security=selinux selinux=1 "
+> GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity security=selinux selinux=1  "
 `
 	checkDiffs30(t, b, "", expectedDefaultGrubFileDiff)
 
@@ -127,7 +127,7 @@ func TestBootCustomizerSELinuxMode30(t *testing.T) {
 	expectedDefaultGrubFileDiff = `5c5
 < GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity "
 ---
-> GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity   security=selinux selinux=1 enforcing=1 "
+> GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity  security=selinux selinux=1 enforcing=1  "
 `
 	checkDiffs30(t, b, "", expectedDefaultGrubFileDiff)
 
@@ -141,7 +141,7 @@ func TestBootCustomizerSELinuxMode30(t *testing.T) {
 	expectedDefaultGrubFileDiff = `5c5
 < GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity "
 ---
-> GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity     selinux=0 "
+> GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity    selinux=0  "
 `
 	checkDiffs30(t, b, "", expectedDefaultGrubFileDiff)
 }
@@ -161,9 +161,8 @@ func TestBootCustomizerVerity30(t *testing.T) {
 	err := b.PrepareForVerity()
 	assert.NoError(t, err)
 
-	expectedDefaultGrubFileDiff := `6a7,9
+	expectedDefaultGrubFileDiff := `6a7,8
 > GRUB_DISABLE_UUID="true"
-> GRUB_DISABLE_RECOVERY="true"
 > GRUB_DEVICE="/dev/mapper/root"
 `
 	checkDiffs30(t, b, "", expectedDefaultGrubFileDiff)

--- a/toolkit/tools/pkg/imagecustomizerlib/customizebootloader_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizebootloader_test.go
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerlib
+
+import (
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCustomizeImageMultiKernel(t *testing.T) {
+	for _, version := range supportedAzureLinuxVersions {
+		t.Run(string(version), func(t *testing.T) {
+			testCustomizeImageMultiKernel(t, "TestCustomizeImageMultiKernel"+string(version),
+				baseImageTypeCoreEfi, version)
+		})
+	}
+}
+
+func testCustomizeImageMultiKernel(t *testing.T, testName string, imageType baseImageType,
+	imageVersion baseImageVersion,
+) {
+	baseImage := checkSkipForCustomizeImage(t, imageType, imageVersion)
+
+	testTmpDir := filepath.Join(tmpDir, testName)
+	buildDir := filepath.Join(testTmpDir, "build")
+	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
+
+	configFile := ""
+	switch imageVersion {
+	case baseImageVersionAzl2:
+		configFile = filepath.Join(testDir, "multikernel-azl2.yaml")
+
+	case baseImageVersionAzl3:
+		configFile = filepath.Join(testDir, "multikernel-azl3.yaml")
+	}
+
+	// Customize image.
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	imageConnection, err := connectToCoreEfiImage(buildDir, outImageFilePath)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer imageConnection.Close()
+
+	// Check that the extraCommandLine was added to the grub.cfg file.
+	grubCfgFilePath := filepath.Join(imageConnection.Chroot().RootDir(), "/boot/grub2/grub.cfg")
+	grubCfgContents, err := file.Read(grubCfgFilePath)
+	assert.NoError(t, err, "read grub.cfg file")
+
+	linuxCommandRegex := regexp.MustCompile(`linux.* console=tty0 console=ttyS0 `)
+	matches := linuxCommandRegex.FindAllString(grubCfgContents, -1)
+
+	switch imageVersion {
+	case baseImageVersionAzl2:
+		// AZL2's default grub.cfg file doesn't support multiple kernels.
+		assert.GreaterOrEqual(t, len(matches), 1, "grub.cfg:\n%s", grubCfgContents)
+
+	case baseImageVersionAzl3:
+		// There should be multiple matching linux kernels, one for each installed kernel.
+		assert.GreaterOrEqual(t, len(matches), 2, "grub.cfg:\n%s", grubCfgContents)
+	}
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
@@ -92,10 +92,6 @@ func prepareGrubConfigForVerity(verityList []imagecustomizerapi.Verity, imageChr
 			if err := bootCustomizer.PrepareForVerity(); err != nil {
 				return err
 			}
-		} else if mountPath == "/usr" {
-			if err := bootCustomizer.PrepareForUsrVerity(); err != nil {
-				return err
-			}
 		}
 	}
 
@@ -126,7 +122,7 @@ func updateGrubConfigForVerity(verityMetadata map[string]verityDeviceMetadata, g
 	// So, instead we just modify the /boot/grub2/grub.cfg file directly.
 	grubMkconfigEnabled := isGrubMkconfigConfig(grub2Config)
 
-	grub2Config, err = updateKernelCommandLineArgs(grub2Config, []string{
+	grub2Config, err = updateKernelCommandLineArgsAll(grub2Config, []string{
 		"rd.systemd.verity", "roothash", "systemd.verity_root_data",
 		"systemd.verity_root_hash", "systemd.verity_root_options",
 		"usrhash", "systemd.verity_usr_data", "systemd.verity_usr_hash",
@@ -140,7 +136,7 @@ func updateGrubConfigForVerity(verityMetadata map[string]verityDeviceMetadata, g
 		rootDevicePath := verityDevicePathFromName(imagecustomizerapi.VerityRootDeviceName)
 
 		if grubMkconfigEnabled {
-			grub2Config, err = updateKernelCommandLineArgs(grub2Config, []string{"root"},
+			grub2Config, err = updateKernelCommandLineArgsAll(grub2Config, []string{"root"},
 				[]string{"root=" + rootDevicePath})
 			if err != nil {
 				return fmt.Errorf("failed to set verity root command-line arg:\n%w", err)

--- a/toolkit/tools/pkg/imagecustomizerlib/defaultgrubutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/defaultgrubutils.go
@@ -160,18 +160,10 @@ func GetDefaultGrubFileLinuxArgs(defaultGrubFileContent string, varName defaultG
 		return defaultGrubFileVarAssign{}, nil, 0, err
 	}
 
-	var insertAt int
-	if varName == defaultGrubFileVarNameCmdlineLinuxDefault {
-		// GRUB_CMDLINE_LINUX_DEFAULT variable has the $kernelopts arg.
-		// Any args inserted should be inserted before $kernelopts.
-		insertAt, err = findCommandLineInsertAt(grubTokens, true /*requireKernelOpts*/)
-		if err != nil {
-			err = fmt.Errorf("failed to parse %s's value args:\n%w", varName, err)
-			return defaultGrubFileVarAssign{}, nil, 0, err
-		}
-	} else {
-		// Insert args at the end of the string.
-		insertAt = len(argsString)
+	insertAt, err := findCommandLineInsertAt(grubTokens, len(argsString))
+	if err != nil {
+		err = fmt.Errorf("failed to parse %s's value args:\n%w", varName, err)
+		return defaultGrubFileVarAssign{}, nil, 0, err
 	}
 
 	args, err := ParseCommandLineArgs(grubTokens)

--- a/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
@@ -240,8 +240,8 @@ func setInitrdPath(inputGrubCfgContent string, initrdPath string) (outputGrubCfg
 // If $kernelopts is present, extraCommandLine is inserted before $kernelopts.
 // If $kernelopts is not present, extraCommandLine is appended at the end.
 func appendKernelCommandLineArgsAll(inputGrubCfgContent string, extraCommandLine string,
-	allowMultiple bool, requireKernelOpts bool) (outputGrubCfgContent string, err error) {
-	lines, err := findLinuxOrInitrdLineAll(inputGrubCfgContent, linuxCommand, allowMultiple)
+) (outputGrubCfgContent string, err error) {
+	lines, err := findLinuxOrInitrdLineAll(inputGrubCfgContent, linuxCommand, true /*allowMultiple*/)
 	if err != nil {
 		return "", err
 	}
@@ -256,26 +256,15 @@ func appendKernelCommandLineArgsAll(inputGrubCfgContent string, extraCommandLine
 		// Skip the "linux" command and the kernel binary path arg.
 		argTokens := line.Tokens[2:]
 
-		insertAt, err := findCommandLineInsertAt(argTokens, requireKernelOpts)
+		insertAt, err := findCommandLineInsertAt(argTokens, line.Tokens[1].Loc.End.Index)
 		if err != nil {
 			return "", err
 		}
 
-		leadingSpace := " "
-		if requireKernelOpts {
-			// When requireKernelOpts is true, we are inserting right before
-			// kernelOpts, and there is already an empty space.
-			leadingSpace = ""
-		}
-		outputGrubCfgContent = outputGrubCfgContent[:insertAt] + leadingSpace + extraCommandLine + " " + outputGrubCfgContent[insertAt:]
+		outputGrubCfgContent = outputGrubCfgContent[:insertAt] + " " + extraCommandLine + " " + outputGrubCfgContent[insertAt:]
 	}
 
 	return outputGrubCfgContent, nil
-}
-
-// Appends kernel command-line args to the linux command within a grub config file.
-func appendKernelCommandLineArgs(inputGrubCfgContent string, extraCommandLine string) (outputGrubCfgContent string, err error) {
-	return appendKernelCommandLineArgsAll(inputGrubCfgContent, extraCommandLine, false /*allow multiple*/, true /*requireKernelOpts*/)
 }
 
 type grubConfigLinuxArg struct {
@@ -295,16 +284,17 @@ type grubConfigLinuxArg struct {
 //   - args: A list of kernel command-line arguments.
 //   - insertAt: An index that represents an appropriate insert point for any new args.
 //     For Azure Linux 2.0 images, this points to the index of the $kernelopts token.
-func getLinuxCommandLineArgs(grub2Config string, requireKernelOpts bool) ([]grubConfigLinuxArg, int, error) {
-	linuxLine, err := findLinuxOrInitrdLineAll(grub2Config, linuxCommand, false /*allowMultiple*/)
+func getLinuxCommandLineArgs(grub2Config string) ([]grubConfigLinuxArg, int, error) {
+	linuxLines, err := findLinuxOrInitrdLineAll(grub2Config, linuxCommand, false /*allowMultiple*/)
 	if err != nil {
 		return nil, 0, err
 	}
 
 	// Skip the "linux" command and the kernel binary path arg.
-	argTokens := linuxLine[0].Tokens[2:]
+	linuxLine := linuxLines[0]
+	argTokens := linuxLine.Tokens[2:]
 
-	insertAt, err := findCommandLineInsertAt(argTokens, requireKernelOpts)
+	insertAt, err := findCommandLineInsertAt(argTokens, linuxLine.Tokens[1].Loc.End.Index)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -319,10 +309,12 @@ func getLinuxCommandLineArgs(grub2Config string, requireKernelOpts bool) ([]grub
 
 // Takes a tokenized grub.cfg file and looks for an appropriate place to insert new args.
 // If $kernelopts is present, it returns its location for insertion.
-// If $kernelopts is absent,
-// - If requireKernelOpts is true, it fails (could not find required $kernelopts).
-// - If requireKernelOpts is false, it returns the location after the last token.
-func findCommandLineInsertAt(argTokens []grub.Token, requireKernelOpts bool) (int, error) {
+// If $kernelopts is absent, it returns the location after the last token.
+func findCommandLineInsertAt(argTokens []grub.Token, defaultValue int) (int, error) {
+	if len(argTokens) <= 0 {
+		return defaultValue, nil
+	}
+
 	insertAtTokens := []grub.Token(nil)
 	for i := range argTokens {
 		argToken := argTokens[i]
@@ -341,13 +333,9 @@ func findCommandLineInsertAt(argTokens []grub.Token, requireKernelOpts bool) (in
 	}
 
 	if len(insertAtTokens) < 1 {
-		// Could not find the grubKernelOpts
-		if !requireKernelOpts && len(argTokens) > 0 {
-			// Try to insert at the very end as long as there are other tokens.
-			return argTokens[len(argTokens)-1].Loc.End.Index, nil
-		} else {
-			return 0, fmt.Errorf("failed to find $%s in linux command line", grubKernelOpts)
-		}
+		// Could not find the grubKernelOpts.
+		// So, insert at the end.
+		return argTokens[len(argTokens)-1].Loc.End.Index, nil
 	}
 	if len(insertAtTokens) > 1 {
 		return 0, fmt.Errorf("too many $%s tokens found in linux command line", grubKernelOpts)
@@ -444,14 +432,14 @@ func findKernelCommandLineArgValue(args []grubConfigLinuxArg, name string) (stri
 	return lastArg.Value, nil
 }
 
-func replaceKernelCommandLineArgValueAll(inputGrubCfgContent string, name string, value string, allowMultiple bool,
-) (outputGrubCfgContent string, oldValues []string, err error) {
+func replaceKernelCommandLineArgValueAll(inputGrubCfgContent string, name string, value string,
+) (outputGrubCfgContent string, err error) {
 	newArg := fmt.Sprintf("%s=%s", name, value)
 	quotedNewArg := grub.QuoteString(newArg)
 
-	lines, err := findLinuxOrInitrdLineAll(inputGrubCfgContent, linuxCommand, allowMultiple)
+	lines, err := findLinuxOrInitrdLineAll(inputGrubCfgContent, linuxCommand, true /*allowMultiple*/)
 	if err != nil {
-		return "", nil, err
+		return "", err
 	}
 
 	outputGrubCfgContent = inputGrubCfgContent
@@ -466,31 +454,29 @@ func replaceKernelCommandLineArgValueAll(inputGrubCfgContent string, name string
 
 		args, err := ParseCommandLineArgs(argTokens)
 		if err != nil {
-			return "", nil, err
+			return "", err
 		}
 
 		foundArgs := findMatchingCommandLineArgs(args, []string{name})
 		if len(foundArgs) < 1 {
-			return "", nil, fmt.Errorf("failed to find kernel arg (%s)", name)
+			return "", fmt.Errorf("failed to find kernel arg (%s)", name)
 		}
 		if len(foundArgs) > 1 {
-			return "", nil, fmt.Errorf("too many instances of kernel arg found (%s)", name)
+			return "", fmt.Errorf("too many instances of kernel arg found (%s)", name)
 		}
 
 		arg := foundArgs[0]
 		start := arg.Token.Loc.Start.Index
 		end := arg.Token.Loc.End.Index
 
-		oldValues = append(oldValues, inputGrubCfgContent[start:end])
 		outputGrubCfgContent = outputGrubCfgContent[:start] + quotedNewArg + outputGrubCfgContent[end:]
 	}
 
-	return outputGrubCfgContent, oldValues, nil
+	return outputGrubCfgContent, nil
 }
 
-func updateKernelCommandLineArgsAll(grub2Config string, argsToRemove []string, newArgs []string,
-	allowMultiple bool, requireKernelOpts bool) (string, error) {
-	lines, err := findLinuxOrInitrdLineAll(grub2Config, linuxCommand, allowMultiple /*allowMultiple*/)
+func updateKernelCommandLineArgsAll(grub2Config string, argsToRemove []string, newArgs []string) (string, error) {
+	lines, err := findLinuxOrInitrdLineAll(grub2Config, linuxCommand, true /*allowMultiple*/)
 	if err != nil {
 		return "", err
 	}
@@ -504,7 +490,7 @@ func updateKernelCommandLineArgsAll(grub2Config string, argsToRemove []string, n
 		// Skip the "linux" command and the kernel binary path arg.
 		argTokens := line.Tokens[2:]
 
-		insertAtToken, err := findCommandLineInsertAt(argTokens, requireKernelOpts)
+		insertAtToken, err := findCommandLineInsertAt(argTokens, line.Tokens[1].Loc.End.Index)
 		if err != nil {
 			return "", err
 		}
@@ -520,19 +506,6 @@ func updateKernelCommandLineArgsAll(grub2Config string, argsToRemove []string, n
 		}
 	}
 	return grub2Config, nil
-}
-
-// Finds all the kernel command-line args that match the provided names, then insert replacement arg(s).
-//
-// Params:
-// - grub2Config: The string contents of the grub.cfg file.
-// - argsToRemove: A list of arg names to remove from the command-line args.
-// - newArgs: A list of new arg values to add to the command-line args.
-//
-// Output:
-// - grub2Config: The new string contents of the grub.cfg file.
-func updateKernelCommandLineArgs(grub2Config string, argsToRemove []string, newArgs []string) (string, error) {
-	return updateKernelCommandLineArgsAll(grub2Config, argsToRemove, newArgs, false /*allowMultiple*/, true /*requireKernelOpts*/)
 }
 
 func updateKernelCommandLineArgsHelper(value string, args []grubConfigLinuxArg, insertAt int,
@@ -625,13 +598,13 @@ func selinuxModeToArgsWithPermissiveFlag(selinuxMode imagecustomizerapi.SELinuxM
 }
 
 // Update the SELinux kernel command-line args.
-func updateSELinuxCommandLineHelperAll(grub2Config string, selinuxMode imagecustomizerapi.SELinuxMode, allowMultiple bool, requireKernelOpts bool) (string, error) {
+func updateSELinuxCommandLineHelperAll(grub2Config string, selinuxMode imagecustomizerapi.SELinuxMode) (string, error) {
 	newSELinuxArgs, err := selinuxModeToArgs(selinuxMode)
 	if err != nil {
 		return "", err
 	}
 
-	grub2Config, err = updateKernelCommandLineArgsAll(grub2Config, selinuxArgNames, newSELinuxArgs, allowMultiple, requireKernelOpts)
+	grub2Config, err = updateKernelCommandLineArgsAll(grub2Config, selinuxArgNames, newSELinuxArgs)
 	if err != nil {
 		return "", err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -445,14 +445,14 @@ func (b *LiveOSIsoBuilder) updateGrubCfg(isoGrubCfgFileName string, pxeGrubCfgFi
 	}
 
 	rootValue := fmt.Sprintf(rootValueLiveOSTemplate, isomakerlib.DefaultVolumeId)
-	inputContentString, _, err = replaceKernelCommandLineArgValueAll(inputContentString, "root", rootValue, true /*allowMultiple*/)
+	inputContentString, err = replaceKernelCommandLineArgValueAll(inputContentString, "root", rootValue)
 	if err != nil {
 		return fmt.Errorf("failed to update the root kernel argument in the iso grub.cfg:\n%w", err)
 	}
 
 	if disableSELinux {
-		inputContentString, err = updateSELinuxCommandLineHelperAll(inputContentString, imagecustomizerapi.SELinuxModeDisabled,
-			true /*allowMultiple*/, false /*requireKernelOpts*/)
+		inputContentString, err = updateSELinuxCommandLineHelperAll(inputContentString,
+			imagecustomizerapi.SELinuxModeDisabled)
 		if err != nil {
 			return fmt.Errorf("failed to set SELinux mode:\n%w", err)
 		}
@@ -462,8 +462,7 @@ func (b *LiveOSIsoBuilder) updateGrubCfg(isoGrubCfgFileName string, pxeGrubCfgFi
 	savedArgs := GrubArgsToString(savedConfigs.Iso.KernelCommandLine.ExtraCommandLine)
 	additionalKernelCommandline := liveosKernelArgs + " " + savedArgs
 
-	inputContentString, err = appendKernelCommandLineArgsAll(inputContentString, additionalKernelCommandline,
-		true /*allowMultiple*/, false /*requireKernelOpts*/)
+	inputContentString, err = appendKernelCommandLineArgsAll(inputContentString, additionalKernelCommandline)
 	if err != nil {
 		return fmt.Errorf("failed to update the kernel arguments with the LiveOS configuration and user configuration in the iso grub.cfg:\n%w", err)
 	}
@@ -528,7 +527,7 @@ func (b *LiveOSIsoBuilder) updateGrubCfg(isoGrubCfgFileName string, pxeGrubCfgFi
 func generatePxeGrubCfg(inputContentString string, pxeIsoImageBaseUrl string, pxeIsoImageFileUrl string,
 	outputImageBase string, pxeGrubCfgFileName string) error {
 	if pxeIsoImageBaseUrl != "" && pxeIsoImageFileUrl != "" {
-		return fmt.Errorf("cannot set both iso image base url and full image url at the same time.")
+		return fmt.Errorf("cannot set both iso image base url and full image url at the same time")
 	}
 
 	// remove 'search' commands from PXE grub.cfg because it is not needed.
@@ -546,13 +545,12 @@ func generatePxeGrubCfg(inputContentString string, pxeIsoImageBaseUrl string, px
 		}
 	}
 	rootValue := fmt.Sprintf(rootValuePxeTemplate, pxeIsoImageFileUrl)
-	inputContentString, _, err = replaceKernelCommandLineArgValueAll(inputContentString, "root", rootValue, true /*allowMultiple*/)
+	inputContentString, err = replaceKernelCommandLineArgValueAll(inputContentString, "root", rootValue)
 	if err != nil {
 		return fmt.Errorf("failed to update the root kernel argument with the PXE iso image url in the PXE grub.cfg:\n%w", err)
 	}
 
-	inputContentString, err = appendKernelCommandLineArgsAll(inputContentString, pxeKernelsArgs,
-		true /*allowMultiple*/, false /*requireKernelOpts*/)
+	inputContentString, err = appendKernelCommandLineArgsAll(inputContentString, pxeKernelsArgs)
 	if err != nil {
 		return fmt.Errorf("failed to append the kernel arguments (%s) in the PXE grub.cfg:\n%w", pxeKernelsArgs, err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
@@ -488,7 +488,7 @@ func extractKernelCmdlineFromGrub(bootPartition *diskutils.PartitionInfo,
 		return nil, fmt.Errorf("failed to read grub.cfg:\n%w", err)
 	}
 
-	args, _, err := getLinuxCommandLineArgs(string(grubCfgContent), true)
+	args, _, err := getLinuxCommandLineArgs(string(grubCfgContent))
 	if err != nil {
 		return nil, fmt.Errorf("failed to extract kernel command-line arguments: %w", err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/multikernel-azl2.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/multikernel-azl2.yaml
@@ -1,0 +1,10 @@
+os:
+  packages:
+    install:
+    - kernel-5.15.167.1-2.cm2
+    - kernel-5.15.173.1-1.cm2
+
+  kernelCommandLine:
+    extraCommandLine:
+    - console=tty0
+    - console=ttyS0

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/multikernel-azl3.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/multikernel-azl3.yaml
@@ -1,0 +1,10 @@
+os:
+  packages:
+    install:
+    - kernel-6.6.57.1-7.azl3
+    - kernel-6.6.64.2-1.azl3
+
+  kernelCommandLine:
+    extraCommandLine:
+    - console=tty0
+    - console=ttyS0


### PR DESCRIPTION
Remove the arbitary restrictions to allow the kernel args to be updated when multiple kernels are installed.

In addition, remove the logic that sets `"GRUB_DISABLE_RECOVERY"` when verity is enabled, since the logic can now handle multiple boot entries in the grub.cfg file when a single kernel is installed.

Also, remove the requirement for `$kernelopts` to exist in the grub.cfg file, since this logic just complicates the code.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
