### PR TITLE
Remove --output-split-partitions-format API

### DIFF
--- a/docs/imagecustomizer/api/cli.md
+++ b/docs/imagecustomizer/api/cli.md
@@ -45,12 +45,11 @@ Added in v0.3.
 
 ## --output-image-format=FORMAT
 
+Required
+
 The image format of the the final customized image.
 
 Options: vhd, vhd-fixed, vhdx, qcow2, raw, iso, and [cosi](./cosi.md).
-
-At least one of `--output-image-format` and `--output-split-partitions-format` is
-required.
 
 The vhd-fixed option outputs a fixed size VHD image. This is the required format for
 VMs in Azure.
@@ -58,29 +57,6 @@ VMs in Azure.
 When the output image format is set to iso, the generated image is a LiveOS
 iso image. For more details on this format, see:
 [Image Customizer ISO Support](../concepts/iso.md).
-
-Added in v0.3.
-
-## --output-split-partitions-format=FORMAT
-
-Format of partition files. If specified, disk partitions will be extracted as separate
-files and a json file with partition metadata will be produced. For more details on
-the json file format, see: [Partition Metadata JSON Format](./partitionmetadatajson.md).
-
-Options: raw, raw-zst.
-
-Added in v0.3.
-
-## --shrink-filesystems
-
-Enable shrinking of partition filesystems to their minimum size.
-
-Currently only supports ext2/ext3/ext4 filesystems.
-
-Can only be specified if `--output-split-partitions-format` is, and
-cannot be specified with `--output-image-format`.
-
-Added in v0.3.
 
 ## --config-file=FILE-PATH
 

--- a/docs/imagecustomizer/api/configuration.md
+++ b/docs/imagecustomizer/api/configuration.md
@@ -38,7 +38,7 @@ The top level type for the YAML file is the [config](./configuration/config.md) 
 4. Update hostname. ([hostname](./configuration/os.md#hostname-string))
 
 5. Copy additional files. ([additionalFiles](./configuration/os.md#additionalfiles-additionalfile))
-  
+
 6. Copy additional directories. ([additionalDirs](./configuration/os.md#additionaldirs-dirconfig))
 
 7. Add/update users. ([users](./configuration/os.md#users-user))
@@ -77,8 +77,7 @@ The top level type for the YAML file is the [config](./configuration/config.md) 
 
 20. Run finalize image scripts. ([finalizeCustomization](./configuration/scripts.md#finalizecustomization-script))
 
-21. If [--shrink-filesystems](./cli.md#--shrink-filesystems) is specified, then shrink
-    the file systems.
+21. If `--output-image-format` is `cosi`, then shrink the file systems.
 
 22. If a ([verity](./configuration/storage.md#verity-verity)) device is specified, then
     create the hash tree and update the grub config.

--- a/toolkit/tools/go.mod
+++ b/toolkit/tools/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/google/go-licenses v1.6.0
 	github.com/google/uuid v1.6.0
 	github.com/invopop/jsonschema v0.13.0
+	github.com/klauspost/compress v1.10.5
 	github.com/klauspost/pgzip v1.2.5
 	github.com/moby/sys/mountinfo v0.6.2
 	github.com/muesli/crunchy v0.4.0
@@ -46,7 +47,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/kevinburke/ssh_config v0.0.0-20190725054713-01f96b0aa0cd // indirect
-	github.com/klauspost/compress v1.10.5 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.0.3 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect

--- a/toolkit/tools/imagecustomizer/main.go
+++ b/toolkit/tools/imagecustomizer/main.go
@@ -17,18 +17,16 @@ import (
 var (
 	app = kingpin.New("imagecustomizer", "Customizes a pre-built Azure Linux image")
 
-	buildDir                    = app.Flag("build-dir", "Directory to run build out of.").Required().String()
-	imageFile                   = app.Flag("image-file", "Path of the base Azure Linux image which the customization will be applied to.").Required().String()
-	outputImageFile             = app.Flag("output-image-file", "Path to write the customized image to.").String()
-	outputImageFormat           = app.Flag("output-image-format", "Format of output image. Supported: vhd, vhdx, qcow2, raw, iso, cosi.").Enum("vhd", "vhd-fixed", "vhdx", "qcow2", "raw", "iso", "cosi")
-	outputSplitPartitionsFormat = app.Flag("output-split-partitions-format", "Format of partition files. Supported: raw, raw-zst").Enum("raw", "raw-zst")
-	configFile                  = app.Flag("config-file", "Path of the image customization config file.").Required().String()
-	rpmSources                  = app.Flag("rpm-source", "Path to a RPM repo config file or a directory containing RPMs.").Strings()
-	disableBaseImageRpmRepos    = app.Flag("disable-base-image-rpm-repos", "Disable the base image's RPM repos as an RPM source").Bool()
-	enableShrinkFilesystems     = app.Flag("shrink-filesystems", "Enable shrinking of filesystems to minimum size. Supports ext2, ext3, ext4 filesystem types.").Bool()
-	outputPXEArtifactsDir       = app.Flag("output-pxe-artifacts-dir", "Create a directory with customized image PXE booting artifacts. '--output-image-format' must be set to 'iso'.").String()
-	logFlags                    = exe.SetupLogFlags(app)
-	timestampFile               = app.Flag("timestamp-file", "File that stores timestamps for this program.").String()
+	buildDir                 = app.Flag("build-dir", "Directory to run build out of.").Required().String()
+	imageFile                = app.Flag("image-file", "Path of the base Azure Linux image which the customization will be applied to.").Required().String()
+	outputImageFile          = app.Flag("output-image-file", "Path to write the customized image to.").Required().String()
+	outputImageFormat        = app.Flag("output-image-format", "Format of output image. Supported: vhd, vhdx, qcow2, raw, iso, cosi.").Enum("vhd", "vhd-fixed", "vhdx", "qcow2", "raw", "iso", "cosi")
+	configFile               = app.Flag("config-file", "Path of the image customization config file.").Required().String()
+	rpmSources               = app.Flag("rpm-source", "Path to a RPM repo config file or a directory containing RPMs.").Strings()
+	disableBaseImageRpmRepos = app.Flag("disable-base-image-rpm-repos", "Disable the base image's RPM repos as an RPM source").Bool()
+	outputPXEArtifactsDir    = app.Flag("output-pxe-artifacts-dir", "Create a directory with customized image PXE booting artifacts. '--output-image-format' must be set to 'iso'.").String()
+	logFlags                 = exe.SetupLogFlags(app)
+	timestampFile            = app.Flag("timestamp-file", "File that stores timestamps for this program.").String()
 )
 
 func main() {
@@ -36,19 +34,8 @@ func main() {
 
 	app.Version(imagecustomizerlib.ToolVersion)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
-	if *outputSplitPartitionsFormat == "" && *outputImageFormat == "" {
-		kingpin.Fatalf("Either --output-image-format or --output-split-partitions-format must be specified.")
-	}
 
 	logger.InitBestEffort(logFlags)
-
-	if *enableShrinkFilesystems && *outputSplitPartitionsFormat == "" {
-		logger.Log.Fatalf("--output-split-partitions-format must be specified to use --shrink-filesystems.")
-	}
-
-	if *enableShrinkFilesystems && *outputImageFormat != "" {
-		logger.Log.Fatalf("--output-image-format cannot be used with --shrink-filesystems enabled.")
-	}
 
 	if *timestampFile != "" {
 		timestamp.BeginTiming("imagecustomizer", *timestampFile)
@@ -65,8 +52,8 @@ func customizeImage() error {
 	var err error
 
 	err = imagecustomizerlib.CustomizeImageWithConfigFile(*buildDir, *configFile, *imageFile,
-		*rpmSources, *outputImageFile, *outputImageFormat, *outputSplitPartitionsFormat, *outputPXEArtifactsDir,
-		!*disableBaseImageRpmRepos, *enableShrinkFilesystems)
+		*rpmSources, *outputImageFile, *outputImageFormat, *outputPXEArtifactsDir,
+		!*disableBaseImageRpmRepos)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/cosicommon.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/cosicommon.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"runtime"
 
-	"github.com/klauspost/compress/zstd"
 	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/safeloopback"
@@ -292,51 +291,4 @@ func populateVerityMetadata(source string, verity *Verity) error {
 	}
 
 	return nil
-}
-
-func extractPartitionsFromCosi(cosiFilePath, outputDir string) ([]string, error) {
-	var extractedParitionsPaths []string
-
-	cosiFile, err := os.Open(cosiFilePath)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open COSI file: %w", err)
-	}
-	defer cosiFile.Close()
-
-	tarReader := tar.NewReader(cosiFile)
-
-	for {
-		header, err := tarReader.Next()
-		if err == io.EOF {
-			break
-		}
-		if err != nil {
-			return nil, fmt.Errorf("error reading tar: %w", err)
-		}
-
-		// Check if the file has .raw-zst extension
-		if filepath.Ext(header.Name) == "raw-zst" {
-			outputFilePath := filepath.Join(outputDir, header.Name)
-
-			outFile, err := os.Create(outputFilePath)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create output file: %w", err)
-			}
-
-			zstReader, err := zstd.NewReader(tarReader)
-			if err != nil {
-				outFile.Close()
-				return nil, fmt.Errorf("failed to create zstd reader: %w", err)
-			}
-
-			if _, err := io.Copy(outFile, zstReader); err != nil {
-				outFile.Close()
-				return nil, fmt.Errorf("failed to decompress file: %w", err)
-			}
-			outFile.Close()
-			extractedParitionsPaths = append(extractedParitionsPaths, outputFilePath)
-		}
-	}
-
-	return extractedParitionsPaths, nil
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/customizebootloader_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizebootloader_test.go
@@ -40,8 +40,8 @@ func testCustomizeImageMultiKernel(t *testing.T, testName string, imageType base
 	}
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizefiles_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizefiles_test.go
@@ -79,8 +79,8 @@ func TestCustomizeImageAdditionalFiles(t *testing.T) {
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -125,8 +125,8 @@ func TestCustomizeImageAdditionalFilesInfiniteFile(t *testing.T) {
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	assert.ErrorContains(t, err, "failed to copy (/dev/zero)")
 	assert.ErrorContains(t, err, "No space left on device")
 }
@@ -201,8 +201,8 @@ func TestCustomizeImageAdditionalDirs(t *testing.T) {
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -257,8 +257,8 @@ func TestCustomizeImageAdditionalDirsInfiniteFile(t *testing.T) {
 	}
 
 	// Customize image.
-	err = CustomizeImage(buildDir, testTmpDir, &config, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err = CustomizeImage(buildDir, testTmpDir, &config, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	assert.ErrorContains(t, err, "failed to copy directory")
 	assert.ErrorContains(t, err, "failed to copy file")
 	assert.ErrorContains(t, err, "No space left on device")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizehostname_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizehostname_test.go
@@ -47,8 +47,8 @@ func TestCustomizeImageHostname(t *testing.T) {
 	outImageFilePath := filepath.Join(buildDir, "image.qcow2")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeoverlays_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeoverlays_test.go
@@ -23,8 +23,8 @@ func TestCustomizeImageOverlays(t *testing.T) {
 	configFile := filepath.Join(testDir, "overlays-config.yaml")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -87,8 +87,8 @@ func TestCustomizeImageOverlaysSELinux(t *testing.T) {
 	configFile := filepath.Join(testDir, "overlays-selinux.yaml")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
@@ -44,7 +44,7 @@ func TestCustomizeImagePackagesAddOfflineDir(t *testing.T) {
 	}
 
 	err = CustomizeImage(buildDir, testDir, &config, baseImage, []string{downloadedRpmsTmpDir}, outImageFilePath,
-		"raw", "", "" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+		"raw", "" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -87,7 +87,7 @@ func TestCustomizeImagePackagesAddOfflineDir(t *testing.T) {
 	}
 
 	err = CustomizeImage(buildDir, testDir, &config, outImageFilePath, []string{downloadedRpmsTmpDir}, outImageFilePath,
-		"raw", "", "" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+		"raw", "" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -145,8 +145,8 @@ func TestCustomizeImagePackagesAddOfflineLocalRepo(t *testing.T) {
 	configFile := filepath.Join(testDir, "packages-add-config.yaml")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, rpmSources, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, rpmSources, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -174,8 +174,8 @@ func TestCustomizeImagePackagesUpdate(t *testing.T) {
 	configFile := filepath.Join(testDir, "packages-update-config.yaml")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -210,8 +210,8 @@ func TestCustomizeImagePackagesDiskSpace(t *testing.T) {
 	configFile := filepath.Join(testDir, "install-package-disk-space.yaml")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
 	assert.ErrorContains(t, err, "failed to customize raw image")
 	assert.ErrorContains(t, err, "failed to install package (gcc)")
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
@@ -47,8 +47,8 @@ func testCustomizeImagePartitionsToEfi(t *testing.T, testName string, imageType 
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -136,8 +136,8 @@ func TestCustomizeImagePartitionsSizeOnly(t *testing.T) {
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -233,8 +233,8 @@ func testCustomizeImagePartitionsToLegacy(t *testing.T, testName string, imageTy
 	outImageFilePath := filepath.Join(buildDir, "image.raw")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -287,8 +287,8 @@ func testCustomizeImageKernelCommandLineHelper(t *testing.T, testName string, ba
 	outImageFilePath := filepath.Join(buildDir, "image.qcow2")
 
 	// Customize image.
-	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -356,8 +356,8 @@ func testCustomizeImageNewUUIDsHelper(t *testing.T, testName string, imageType b
 	os.Remove(tempRawBaseImage)
 
 	// Customize image.
-	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeselinux_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeselinux_test.go
@@ -34,8 +34,8 @@ func testCustomizeImageSELinuxHelper(t *testing.T, testName string, imageType ba
 	// Customize image: SELinux enforcing.
 	// This tests enabling SELinux on a non-SELinux image.
 	configFile := filepath.Join(testDir, "selinux-force-enforcing.yaml")
-	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -63,8 +63,8 @@ func testCustomizeImageSELinuxHelper(t *testing.T, testName string, imageType ba
 	// Customize image: SELinux disabled.
 	// This tests disabling (but not removing) SELinux on an SELinux enabled image.
 	configFile = filepath.Join(testDir, "selinux-disabled.yaml")
-	err = CustomizeImageWithConfigFile(buildDir, configFile, outImageFilePath, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err = CustomizeImageWithConfigFile(buildDir, configFile, outImageFilePath, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -92,8 +92,8 @@ func testCustomizeImageSELinuxHelper(t *testing.T, testName string, imageType ba
 	// Customize image: SELinux permissive.
 	// This tests enabling SELinux on an image with SELinux installed but disabled.
 	configFile = filepath.Join(testDir, "selinux-permissive.yaml")
-	err = CustomizeImageWithConfigFile(buildDir, configFile, outImageFilePath, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err = CustomizeImageWithConfigFile(buildDir, configFile, outImageFilePath, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -131,8 +131,8 @@ func testCustomizeImageSELinuxAndPartitionsHelper(t *testing.T, testName string,
 	// Customize image: SELinux enforcing.
 	// This tests enabling SELinux on a non-SELinux image.
 	configFile := filepath.Join(testDir, "partitions-selinux-enforcing.yaml")
-	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -180,8 +180,8 @@ func TestCustomizeImageSELinuxNoPolicy(t *testing.T) {
 	outImageFilePath := filepath.Join(buildDir, "image.qcow2")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	assert.ErrorContains(t, err, "SELinux is enabled but the (/etc/selinux/config) file is missing")
 	assert.ErrorContains(t, err, "please ensure an SELinux policy is installed")
 	assert.ErrorContains(t, err, "the 'selinux-policy' package provides the default policy")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeservices_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeservices_test.go
@@ -21,8 +21,8 @@ func TestCustomizeImageServicesEnableDisable(t *testing.T) {
 
 	// Customize image.
 	configFile := filepath.Join(testDir, "services-config.yaml")
-	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -62,8 +62,8 @@ func TestCustomizeImageServicesEnableUnknown(t *testing.T) {
 		},
 	}
 
-	err := CustomizeImage(buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImage(buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
 	assert.ErrorContains(t, err, "failed to enable service (chocolate-chip-muffin)")
 	assert.ErrorContains(t, err, "chocolate-chip-muffin.service does not exist")
 }
@@ -86,8 +86,8 @@ func TestCustomizeImageServicesDisableUnknown(t *testing.T) {
 		},
 	}
 
-	err := CustomizeImage(buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImage(buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
 	assert.ErrorContains(t, err, "failed to disable service (chocolate-chip-muffin)")
 	assert.ErrorContains(t, err, "No such file or directory")
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
@@ -29,8 +29,8 @@ func TestCustomizeImageVerityUsrUki(t *testing.T) {
 	configFile := filepath.Join(testDir, "verity-usr-uki.yaml")
 
 	// Customize image.
-	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeusers_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeusers_test.go
@@ -78,8 +78,8 @@ func TestCustomizeImageUsers(t *testing.T) {
 	}
 
 	// Customize image.
-	err := CustomizeImage(buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImage(buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -162,8 +162,8 @@ func TestCustomizeImageUsersExitingUserHomeDir(t *testing.T) {
 	}
 
 	// Customize image.
-	err := CustomizeImage(buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImage(buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	assert.ErrorContains(t, err, "cannot set home directory (/home/root) on a user (root) that already exists")
 }
 
@@ -186,8 +186,8 @@ func TestCustomizeImageUsersExitingUserUid(t *testing.T) {
 	}
 
 	// Customize image.
-	err := CustomizeImage(buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImage(buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	assert.ErrorContains(t, err, "cannot set UID (1) on a user (root) that already exists")
 }
 

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
 package imagecustomizerlib
 
 import (
@@ -9,7 +12,6 @@ import (
 	"strconv"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
-	"github.com/microsoft/azurelinux/toolkit/tools/internal/jsonutils"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/shell"
 )
@@ -226,17 +228,4 @@ func constructOutputPartitionMetadata(diskPartition diskutils.PartitionInfo, par
 	partitionMetadata.Mountpoint = diskPartition.Mountpoint
 
 	return partitionMetadata, nil
-}
-
-// Write partition metadata as JSON to a file.
-func writePartitionMetadataJson(outDir string, name string, output *[]outputPartitionMetadata) (err error) {
-	fullPath := filepath.Join(outDir, name)
-
-	err = jsonutils.WriteJSONFile(fullPath, output)
-	if err != nil {
-		return err
-	}
-
-	logger.Log.Infof("Partition metadata file created: %s", fullPath)
-	return nil
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -429,7 +429,7 @@ func customizeOSContents(ic *ImageCustomizerParameters) error {
 
 	// For COSI, always shrink the filesystems.
 	if ic.outputImageFormat == ImageFormatCosi {
-		err = shrinkFilesystemsHelper(ic.rawImageFile, ic.config.Storage.Verity, partIdToPartUuid)
+		err = shrinkFilesystemsHelper(ic.rawImageFile)
 		if err != nil {
 			return fmt.Errorf("failed to shrink filesystems:\n%w", err)
 		}
@@ -781,12 +781,10 @@ func customizeImageHelper(buildDir string, baseConfigPath string, config *imagec
 		return nil, "", err
 	}
 
-	return partUuidToMountPath, nil
+	return partUuidToFstabEntry, osRelease, nil
 }
 
-func shrinkFilesystemsHelper(buildImageFile string, verity []imagecustomizerapi.Verity,
-	partIdToPartUuid map[string]string,
-) error {
+func shrinkFilesystemsHelper(buildImageFile string) error {
 	imageLoopback, err := safeloopback.NewLoopback(buildImageFile)
 	if err != nil {
 		return err

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -56,8 +56,8 @@ func TestCustomizeImageEmptyConfig(t *testing.T) {
 
 	// Customize image.
 	err = CustomizeImage(buildDir, buildDir, &imagecustomizerapi.Config{}, baseImage, nil, outImageFilePath,
-		"vhd", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+		"vhd",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -79,7 +79,7 @@ func TestCustomizeImageVhd(t *testing.T) {
 
 	// Customize image to vhd.
 	err := CustomizeImageWithConfigFile(buildDir, partitionsConfigFile, baseImage, nil, vhdImageFilePath,
-		"vhd", "", "" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+		"vhd", "" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -95,7 +95,7 @@ func TestCustomizeImageVhd(t *testing.T) {
 
 	// Customize image to vhd-fixed.
 	err = CustomizeImageWithConfigFile(buildDir, noChangeConfigFile, vhdImageFilePath, nil, vhdFixedImageFilePath,
-		"vhd-fixed", "", "" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+		"vhd-fixed", "" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -113,7 +113,7 @@ func TestCustomizeImageVhd(t *testing.T) {
 
 	// Customize image to vhdx.
 	err = CustomizeImageWithConfigFile(buildDir, noChangeConfigFile, vhdFixedImageFilePath, nil, vhdxImageFilePath,
-		"vhdx", "", "" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+		"vhdx", "" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -293,8 +293,8 @@ func TestCustomizeImageKernelCommandLineAdd(t *testing.T) {
 		},
 	}
 
-	err = CustomizeImage(buildDir, buildDir, config, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err = CustomizeImage(buildDir, buildDir, config, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -188,7 +188,8 @@ func TestValidateConfigValidAdditionalFiles(t *testing.T) {
 					Destination: "/a.txt",
 				},
 			},
-		}}, nil, "./out/image.vhdx", true)
+		},
+	}, nil, "./out/image.vhdx", true)
 	assert.NoError(t, err)
 }
 
@@ -201,7 +202,8 @@ func TestValidateConfigMissingAdditionalFiles(t *testing.T) {
 					Destination: "/a.txt",
 				},
 			},
-		}}, nil, "./out/image.vhdx", true)
+		},
+	}, nil, "./out/image.vhdx", true)
 	assert.Error(t, err)
 }
 
@@ -214,7 +216,8 @@ func TestValidateConfigdditionalFilesIsDir(t *testing.T) {
 					Destination: "/a.txt",
 				},
 			},
-		}}, nil, "./out/image.vhdx", true)
+		},
+	}, nil, "./out/image.vhdx", true)
 	assert.Error(t, err)
 }
 
@@ -342,8 +345,8 @@ func TestCustomizeImage_OutputImageFileSelection(t *testing.T) {
 			Path: outImageFilePathFromConfig,
 		},
 	}
-	err := CustomizeImage(buildDir, buildDir, config, baseImage, nil, "", "raw", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImage(buildDir, buildDir, config, baseImage, nil, "", "raw",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	assert.NoError(t, err)
 	assert.FileExists(t, outImageFilePathFromConfig)
 
@@ -353,8 +356,8 @@ func TestCustomizeImage_OutputImageFileSelection(t *testing.T) {
 
 	// Pass the output image file only through the argument.
 	config.Output.Path = ""
-	err = CustomizeImage(buildDir, buildDir, config, baseImage, nil, outputImageFilePathFromArgs, "raw", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err = CustomizeImage(buildDir, buildDir, config, baseImage, nil, outputImageFilePathFromArgs, "raw",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	assert.NoError(t, err)
 	assert.NoFileExists(t, outImageFilePathFromConfig)
 	assert.FileExists(t, outputImageFilePathFromArgs)
@@ -365,8 +368,8 @@ func TestCustomizeImage_OutputImageFileSelection(t *testing.T) {
 
 	// Pass the output image file through both the config and the argument.
 	config.Output.Path = outImageFilePathFromConfig
-	err = CustomizeImage(buildDir, buildDir, config, baseImage, nil, outputImageFilePathFromArgs, "raw", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err = CustomizeImage(buildDir, buildDir, config, baseImage, nil, outputImageFilePathFromArgs, "raw",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	assert.NoError(t, err)
 	assert.NoFileExists(t, outImageFilePathFromConfig)
 	assert.FileExists(t, outputImageFilePathFromArgs)
@@ -382,8 +385,6 @@ func TestCreateImageCustomizerParameters_OutputImageFileSelection(t *testing.T) 
 	config := &imagecustomizerapi.Config{}
 	useBaseImageRpmRepos := false
 	rpmsSources := []string{}
-	enableShrinkFilesystems := false
-	outputSplitPartitionsFormat := ""
 	outputImageFormat := "raw"
 	outputImageFile := ""
 	outputPXEArtifactsDir := ""
@@ -391,7 +392,7 @@ func TestCreateImageCustomizerParameters_OutputImageFileSelection(t *testing.T) 
 	// The output image file is not specified in the config or as an
 	// argument, so the output image file will be empty.
 	ic, err := createImageCustomizerParameters(buildDir, inputImageFile, configPath, config, useBaseImageRpmRepos,
-		rpmsSources, enableShrinkFilesystems, outputSplitPartitionsFormat, outputImageFormat, outputImageFile,
+		rpmsSources, outputImageFormat, outputImageFile,
 		outputPXEArtifactsDir)
 	assert.NoError(t, err)
 	assert.Equal(t, ic.outputImageFile, "")
@@ -401,7 +402,7 @@ func TestCreateImageCustomizerParameters_OutputImageFileSelection(t *testing.T) 
 
 	// The output image file should be set to the value in the config.
 	ic, err = createImageCustomizerParameters(buildDir, inputImageFile, configPath, config, useBaseImageRpmRepos,
-		rpmsSources, enableShrinkFilesystems, outputSplitPartitionsFormat, outputImageFormat, outputImageFile,
+		rpmsSources, outputImageFormat, outputImageFile,
 		outputPXEArtifactsDir)
 	assert.NoError(t, err)
 	assert.Equal(t, ic.outputImageFile, outImageFilePathAsConfig)
@@ -414,7 +415,7 @@ func TestCreateImageCustomizerParameters_OutputImageFileSelection(t *testing.T) 
 
 	// The output image file should be set to the value passed as an argument.
 	ic, err = createImageCustomizerParameters(buildDir, inputImageFile, configPath, config, useBaseImageRpmRepos,
-		rpmsSources, enableShrinkFilesystems, outputSplitPartitionsFormat, outputImageFormat, outputImageFile,
+		rpmsSources, outputImageFormat, outputImageFile,
 		outputPXEArtifactsDir)
 	assert.NoError(t, err)
 	assert.Equal(t, ic.outputImageFile, outImageFilePathAsArg)
@@ -428,7 +429,7 @@ func TestCreateImageCustomizerParameters_OutputImageFileSelection(t *testing.T) 
 	// The output image file should be set to the value passed as an
 	// argument.
 	ic, err = createImageCustomizerParameters(buildDir, inputImageFile, configPath, config, useBaseImageRpmRepos,
-		rpmsSources, enableShrinkFilesystems, outputSplitPartitionsFormat, outputImageFormat, outputImageFile,
+		rpmsSources, outputImageFormat, outputImageFile,
 		outputPXEArtifactsDir)
 	assert.NoError(t, err)
 	assert.Equal(t, ic.outputImageFile, outImageFilePathAsArg)

--- a/toolkit/tools/pkg/imagecustomizerlib/installedkernelcheck_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/installedkernelcheck_test.go
@@ -19,7 +19,7 @@ func TestCustomizeImageMissingKernel(t *testing.T) {
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	assert.ErrorContains(t, err, "no installed kernel found")
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/kernelmoduleutils_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/kernelmoduleutils_test.go
@@ -227,8 +227,8 @@ func TestCustomizeImageKernelModules(t *testing.T) {
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
@@ -47,8 +47,8 @@ func TestCustomizeImageLiveCd1(t *testing.T) {
 	configFile := filepath.Join(testDir, "iso-files-and-args-config.yaml")
 
 	// Customize vhdx to ISO, with OS changes.
-	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "iso", "", /*outputSplitPartitionsFormat*/
-		pxeArtifactsPathVhdxToIso, true /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "iso",
+		pxeArtifactsPathVhdxToIso, true /*useBaseImageRpmRepos*/)
 	assert.NoError(t, err)
 
 	// Attach ISO.
@@ -128,8 +128,8 @@ func TestCustomizeImageLiveCd1(t *testing.T) {
 			},
 		},
 	}
-	err = CustomizeImage(buildDir, testDir, &config, outImageFilePath, nil, outImageFilePath, "iso", "", /*outputSplitPartitionsFormat*/
-		pxeArtifactsPathIsoToIso, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err = CustomizeImage(buildDir, testDir, &config, outImageFilePath, nil, outImageFilePath, "iso",
+		pxeArtifactsPathIsoToIso, false /*useBaseImageRpmRepos*/)
 	assert.NoError(t, err)
 
 	// Attach ISO.
@@ -209,22 +209,22 @@ func TestCustomizeImageLiveCd2(t *testing.T) {
 
 	// Customize vhdx with ISO prereqs.
 	configFile := filepath.Join(testDir, "iso-os-prereqs-config.yaml")
-	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
 	assert.NoError(t, err)
 
 	// Customize image to ISO, with no OS changes.
 	config := imagecustomizerapi.Config{
 		Iso: &imagecustomizerapi.Iso{},
 	}
-	err = CustomizeImage(buildDir, testDir, &config, outImageFilePath, nil, outIsoFilePath, "iso", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err = CustomizeImage(buildDir, testDir, &config, outImageFilePath, nil, outIsoFilePath, "iso",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	assert.NoError(t, err)
 
 	// Customize ISO to ISO, with OS changes.
 	configFile = filepath.Join(testDir, "addfiles-config.yaml")
-	err = CustomizeImageWithConfigFile(buildDir, configFile, outIsoFilePath, nil, outIsoFilePath, "iso", "",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err = CustomizeImageWithConfigFile(buildDir, configFile, outIsoFilePath, nil, outIsoFilePath, "iso",
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
 	assert.NoError(t, err)
 
 	// Attach ISO.
@@ -298,8 +298,8 @@ func testCustomizeImageLiveCdIsoNoShimEfi(t *testing.T, testName string, version
 	}
 
 	// Customize image.
-	err := CustomizeImage(buildDir, testDir, config, baseImage, nil, outImageFilePath, "iso", "",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImage(buildDir, testDir, config, baseImage, nil, outImageFilePath, "iso",
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "failed to find the boot efi file")
 }
@@ -321,8 +321,8 @@ func TestCustomizeImageLiveCdIsoNoGrubEfi(t *testing.T) {
 	}
 
 	// Customize image.
-	err := CustomizeImage(buildDir, testDir, config, baseImage, nil, outImageFilePath, "iso", "",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImage(buildDir, testDir, config, baseImage, nil, outImageFilePath, "iso",
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "failed to find the grub efi file")
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/resolvconf_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/resolvconf_test.go
@@ -29,8 +29,8 @@ func TestCustomizeImageResolvConfDelete(t *testing.T) {
 		},
 	}
 
-	err := CustomizeImage(buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImage(buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -92,8 +92,8 @@ func TestCustomizeImageResolvConfRestoreFile(t *testing.T) {
 		OS: &imagecustomizerapi.OS{},
 	}
 
-	err = CustomizeImage(buildDir, testDir, &config, outImageFilePath, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err = CustomizeImage(buildDir, testDir, &config, outImageFilePath, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -162,8 +162,8 @@ func TestCustomizeImageResolvConfRestoreSymlink(t *testing.T) {
 		OS: &imagecustomizerapi.OS{},
 	}
 
-	err = CustomizeImage(buildDir, testDir, &config, outImageFilePath, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err = CustomizeImage(buildDir, testDir, &config, outImageFilePath, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -200,8 +200,8 @@ func TestCustomizeImageResolvConfNewSymlink(t *testing.T) {
 		},
 	}
 
-	err := CustomizeImage(buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err := CustomizeImage(buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/runscripts_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/runscripts_test.go
@@ -22,8 +22,8 @@ func TestCustomizeImageRunScripts(t *testing.T) {
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
 	// Customize image.
-	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
@@ -82,7 +82,7 @@ func shrinkFilesystems(imageLoopDevice string) error {
 
 		// Changes to the partition table causes all of the disk's parition /dev nodes to be deleted and then
 		// recreated. So, wait for that to finish.
-		err = diskutils.WaitForDiskDevice(imageLoopDevice)
+		err = diskutils.RefreshPartitions(imageLoopDevice)
 		if err != nil {
 			return fmt.Errorf("failed to wait for disk (%s) to update:\n%w", imageLoopDevice, err)
 		}


### PR DESCRIPTION
Deprecate in favor of COSI.

---

### **Checklist**
- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
