### PR TITLE
Add support for COSI to have shrunk filesystems

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -446,7 +446,7 @@ func customizeOSContents(ic *ImageCustomizerParameters) error {
 	ic.partUuidToMountPath = partUuidToMountPath
 
 	// For COSI, always shrink the filesystems.
-	if ic.outputImageFormat == ImageFormatCosi {
+	if ic.outputImageFormat == ImageFormatCosi || ic.enableShrinkFilesystems {
 		err = shrinkFilesystemsHelper(ic.rawImageFile, ic.config.Storage.Verity, partIdToPartUuid)
 		if err != nil {
 			return fmt.Errorf("failed to shrink filesystems:\n%w", err)

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -445,8 +445,8 @@ func customizeOSContents(ic *ImageCustomizerParameters) error {
 	// Set partition to mountpath mapping for COSI.
 	ic.partUuidToMountPath = partUuidToMountPath
 
-	// Shrink the filesystems.
-	if ic.enableShrinkFilesystems {
+	// For COSI, always shrink the filesystems.
+	if ic.outputImageFormat == ImageFormatCosi {
 		err = shrinkFilesystemsHelper(ic.rawImageFile, ic.config.Storage.Verity, partIdToPartUuid)
 		if err != nil {
 			return fmt.Errorf("failed to shrink filesystems:\n%w", err)


### PR DESCRIPTION
COSI partitions should have shrunk filesystems by default 

---

### **Checklist**
- [x] Tests added/updated
- [] Documentation updated (if needed)
- [x] Code conforms to style guidelines
