### PR TITLE
Rev up minimum required Dracut version for LiveOS ISO

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoutils.go
@@ -16,7 +16,7 @@ const (
 
 	// Minumum dracut version required to enable SELinux.
 	LiveOsSelinuxDracutMinVersion        = 102
-	LiveOsSelinuxDracutMinPackageRelease = 8
+	LiveOsSelinuxDracutMinPackageRelease = 9
 	LiveOsSelinuxDracutDistroName        = "azl"
 	LiveOsSelinuxDracutMinDistroVersion  = 3
 


### PR DESCRIPTION
The logic in LiveOS ISO checks the Dracut version installed on the image to be customized.

If it is below a certain version, it will always disable SELinux since it knows SELinux is not supported for that version and the image will not boot.

However, if it is at or higher, it leave SELinux as-is.

The problem is that this version is not set at 102-8, which has a known bug blocking booting LiveOS ISO images when SELinux is enabled.

This change updates the version to a new Dracut package that has the fix necessary for booting LiveOS ISO image with SELinux enabled.

See corresponding dracut change here: https://github.com/microsoft/azurelinux/pull/11986

<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

---

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [x] Code conforms to style guidelines
