### PR TITLE
Docs: Ensure all example versions are consistent.

### DIFF
--- a/docs/imagecustomizer/how-to/azure-vm.md
+++ b/docs/imagecustomizer/how-to/azure-vm.md
@@ -151,7 +151,7 @@ in front of any HTTP endpoints.
 5. Run Image Customizer to create the new image:
 
    ```bash
-   IMG_CUSTOMIZER_TAG="mcr.microsoft.com/azurelinux/imagecustomizer:0.10.0"
+   IMG_CUSTOMIZER_TAG="mcr.microsoft.com/azurelinux/imagecustomizer:0.11.0"
    docker run \
      --rm \
      --privileged=true \

--- a/docs/imagecustomizer/how-to/vscode-schema-validation.md
+++ b/docs/imagecustomizer/how-to/vscode-schema-validation.md
@@ -30,7 +30,7 @@ Add the following to your `settings.json` file after updating `<RELEASE>` and
 `<SPECIFIC-FOLDER>`:
 
 - `<SPECIFIC-FOLDER>` is the directory containing your image configs.
-- `<RELEASE>` is the version of Image Customizer that you are using (e.g.: v0.8).
+- `<RELEASE>` is the version of Image Customizer that you are using (e.g.: v0.11).
 
 ```json
 "yaml.schemas": {
@@ -44,7 +44,7 @@ For example:
 
 ```json
 "yaml.schemas": {
-    "https://raw.githubusercontent.com/microsoft/azure-linux-image-tools/release/v0.9/toolkit/tools/imagecustomizerapi/schema.json": [
+    "https://raw.githubusercontent.com/microsoft/azure-linux-image-tools/release/v0.11/toolkit/tools/imagecustomizerapi/schema.json": [
         "/home/test/image-configs/**/*.yaml"
     ]
 }


### PR DESCRIPTION
In the docs, ensure that all of the example versions of imagecustomizer use `v0.11`.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
