### PR TITLE
Fix extra command line args in UKIs.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki.go
@@ -6,11 +6,11 @@ package imagecustomizerlib
 import (
 	"encoding/json"
 	"fmt"
-	"gopkg.in/ini.v1"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
+
+	"gopkg.in/ini.v1"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
@@ -359,23 +359,38 @@ func extractKernelToArgsFromGrub(grubCfgPath string) (map[string]string, error) 
 		return nil, fmt.Errorf("failed to read grub.cfg file at (%s):\n%w", grubCfgPath, err)
 	}
 
-	linuxLineRegex := regexp.MustCompile(`^linux\s+(/vmlinuz-[^\s]+)\s+(.*)`)
-
-	lines := strings.Split(string(grubCfgContent), "\n")
-	kernelToArgs := make(map[string]string)
-
-	for _, line := range lines {
-		trimmedLine := strings.TrimSpace(line)
-		matches := linuxLineRegex.FindStringSubmatch(trimmedLine)
-		if len(matches) == 3 {
-			kernel := strings.TrimPrefix(matches[1], "/")
-			args := matches[2]
-			kernelToArgs[kernel] = strings.TrimSpace(args)
-		}
+	lines, err := FindNonRecoveryLinuxLine(grubCfgContent)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find linux command lines in grub.cfg:\n%w", err)
 	}
 
-	if len(kernelToArgs) == 0 {
-		return nil, fmt.Errorf("failed to find any valid 'linux /vmlinuz-*' lines in grub.cfg file at (%s)", grubCfgPath)
+	kernelToArgs := make(map[string]string)
+	for _, line := range lines {
+		if len(line.Tokens) < 3 {
+			return nil, fmt.Errorf("linux line in grub.cfg file has less than 3 args")
+		}
+
+		kernel := line.Tokens[1].RawContent
+		kernel = strings.TrimPrefix(kernel, "/")
+
+		argTokens := line.Tokens[2:]
+		args, err := ParseCommandLineArgs(argTokens)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse linux command lines args (%s):\n%w", kernel, err)
+		}
+
+		filteredArgs := []string(nil)
+		for _, arg := range args {
+			if arg.ValueHasVarExpansion {
+				// Ignore tokens with $ vars.
+				continue
+			}
+
+			filteredArgs = append(filteredArgs, arg.Arg)
+		}
+
+		filteredArgsString := GrubArgsToString(filteredArgs)
+		kernelToArgs[kernel] = filteredArgsString
 	}
 
 	return kernelToArgs, nil

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
@@ -1,0 +1,71 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerlib
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/sys/unix"
+)
+
+func TestCustomizeImageVerityUsrUki(t *testing.T) {
+	imageType := baseImageTypeCoreEfi
+	imageVersion := baseImageVersionAzl3
+	baseImage := checkSkipForCustomizeImage(t, imageType, imageVersion)
+
+	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageUsrVerityUki")
+	buildDir := filepath.Join(testTempDir, "build")
+	outImageFilePath := filepath.Join(testTempDir, "image.raw")
+	configFile := filepath.Join(testDir, "verity-usr-uki.yaml")
+
+	// Customize image.
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// Connect to customized image.
+	mountPoints := []mountPoint{
+		{
+			PartitionNum:   5,
+			Path:           "/",
+			FileSystemType: "ext4",
+		},
+		{
+			PartitionNum:   2,
+			Path:           "/boot",
+			FileSystemType: "ext4",
+		},
+		{
+			PartitionNum:   1,
+			Path:           "/boot/efi",
+			FileSystemType: "vfat",
+		},
+		{
+			PartitionNum:   3,
+			Path:           "/usr",
+			FileSystemType: "ext4",
+			Flags:          unix.MS_RDONLY,
+		},
+	}
+
+	imageConnection, err := connectToImage(buildDir, outImageFilePath, false /*includeDefaultMounts*/, mountPoints)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer imageConnection.Close()
+
+	partitions, err := getDiskPartitionsMap(imageConnection.Loopback().DevicePath())
+	assert.NoError(t, err, "get disk partitions")
+
+	// Verify that verity is configured correctly.
+	espPath := filepath.Join(imageConnection.chroot.RootDir(), "/boot/efi")
+	usrDevice := partitionDevPath(imageConnection, 3)
+	usrHashDevice := partitionDevPath(imageConnection, 4)
+	verifyVerityUki(t, espPath, usrDevice, usrHashDevice, "PARTUUID="+partitions[3].PartUuid,
+		"PARTUUID="+partitions[4].PartUuid, "usr", buildDir, "rd.info")
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
@@ -270,6 +270,8 @@ func appendKernelCommandLineArgsAll(inputGrubCfgContent string, extraCommandLine
 type grubConfigLinuxArg struct {
 	// The tokenizer token for the arg.
 	Token grub.Token
+	// The full arg string.
+	Arg string
 	// The name of the argument.
 	Name string
 	// The value of the argument.
@@ -390,6 +392,7 @@ func ParseCommandLineArgs(argTokens []grub.Token) ([]grubConfigLinuxArg, error) 
 
 		arg := grubConfigLinuxArg{
 			Token:                argToken,
+			Arg:                  argString,
 			Name:                 name,
 			Value:                value,
 			ValueHasVarExpansion: hasVarExpansion,

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-uki.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-uki.yaml
@@ -61,12 +61,6 @@ os:
   uki:
     kernels: auto
 
-  users:
-  - name: root
-    password:
-      type: plain-text
-      value: hello
-
   packages:
     remove:
     - grub2-efi-binary

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-uki.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-uki.yaml
@@ -1,0 +1,78 @@
+previewFeatures:
+- uki
+
+storage:
+  bootType: efi
+  disks:
+  - partitionTableType: gpt
+    partitions:
+    - id: esp
+      type: esp
+      size: 250M
+
+    - id: boot
+      size: 250M
+
+    - id: usr
+      size: 1G
+
+    - id: usrhash
+      size: 100M
+
+    - id: root
+      size: 2G
+
+  verity:
+  - id: verityusr
+    name: usr
+    dataDeviceId: usr
+    hashDeviceId: usrhash
+    corruptionOption: panic
+
+  filesystems:
+  - deviceId: esp
+    type: fat32
+    mountPoint:
+      path: /boot/efi
+      options: umask=0077
+
+  - deviceId: boot
+    type: ext4
+    mountPoint: /boot
+
+  - deviceId: root
+    type: ext4
+    mountPoint: /
+
+  - deviceId: verityusr
+    type: ext4
+    mountPoint:
+      path: /usr
+      options: ro
+
+os:
+  bootloader:
+    resetType: hard-reset
+
+  kernelCommandLine:
+    extraCommandLine:
+    - rd.info
+
+  uki:
+    kernels: auto
+
+  users:
+  - name: root
+    password:
+      type: plain-text
+      value: hello
+
+  packages:
+    remove:
+    - grub2-efi-binary
+
+    install:
+    - veritysetup
+    - systemd-ukify
+    - systemd-boot
+    - efibootmgr


### PR DESCRIPTION
When generating a UKI, the extra commnand line args are missing from the UKI. This was caused by the change (#109) that stopped setting `GRUB_DISABLE_RECOVERY` in the `/etc/default/grub` file. That change means there are now "recovery mode" entries for each kernel in the `grub.cfg` file. So, when extracting the kernel args for UKI, we need to ensure we ignore the "recovery mode" entries.

In addition, add a test that verifies the behavior of `/usr` verity + UKI. This includes verifying the extra command-line args are present in the UKI.

Also, update the existing verity tests so that they also check that the extra command-line args are present (in the grub.cfg file).

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
