### PR TITLE
Skip UKI test if the 'ukify' command is not available.

### DIFF
--- a/docs/imagecustomizer/how-to/quick-start.md
+++ b/docs/imagecustomizer/how-to/quick-start.md
@@ -24,7 +24,7 @@ nav_order: 1
    `udevadm`, `flock`, `blkid`, `openssl`, `sed`, `createrepo`, `mksquashfs`,
    `genisoimage`, `parted`, `mkfs`, `mkfs.ext4`, `mkfs.vfat`, `mkfs.xfs`, `fsck`,
    `e2fsck`, `xfs_repair`, `resize2fs`, `tune2fs`, `xfs_admin`, `fatlabel`, `zstd`,
-   `veritysetup`, `grub2-install` (or `grub-install`).
+   `veritysetup`, `grub2-install` (or `grub-install`), `ukify`.
 
    - For Ubuntu 22.04 images, run:
 
@@ -34,7 +34,7 @@ nav_order: 1
         xfsprogs zstd cryptsetup-bin grub2-common
      ```
 
-   - For Azure Linux 2.0 and 3.0, run:
+   - For Azure Linux 2.0, run:
 
      ```bash
      sudo tdnf install -y qemu-img rpm coreutils util-linux systemd openssl \
@@ -42,9 +42,22 @@ nav_order: 1
         xfsprogs zstd veritysetup grub2 grub2-pc
      ```
 
-     Note: There are known issues with trying to use Image Customizer in WSL (Windows
-     Subsystem for Linux). It is recommended that use the Image Customizer tool in a
-     Linux OS running on a bare-metal host or a virtual machine.
+   - For Azure Linux 3.0, run:
+
+     ```bash
+     sudo tdnf install -y qemu-img rpm coreutils util-linux systemd openssl \
+        sed createrepo_c squashfs-tools cdrkit parted e2fsprogs dosfstools \
+        xfsprogs zstd veritysetup grub2 grub2-pc systemd-ukify
+     ```
+
+   Note: The `ukify` tool is not available in Ubuntu 22.04 or Azure Linux 2.0. So, you
+   will not be able to use the [UKI API](../api/configuration/uki.md) when running
+   Image Customizer directly on those distros. However, using the
+   [Image Customizer container](../how-to/container.md) on those distros should work.
+
+   Note: There are known issues with trying to use Image Customizer in WSL (Windows
+   Subsystem for Linux). It is recommended that use the Image Customizer tool in a
+   Linux OS running on a bare-metal host or a virtual machine.
 
 4. Run the Image Customizer tool.
 

--- a/toolkit/tools/imagecustomizer/container/Dockerfile.mic-container
+++ b/toolkit/tools/imagecustomizer/container/Dockerfile.mic-container
@@ -2,6 +2,6 @@ FROM mcr.microsoft.com/azurelinux/base/core:3.0
 RUN tdnf update -y && \
    tdnf install -y qemu-img rpm coreutils util-linux systemd openssl \
       sed createrepo_c squashfs-tools cdrkit parted e2fsprogs dosfstools \
-      xfsprogs zstd veritysetup grub2 grub2-pc
+      xfsprogs zstd veritysetup grub2 grub2-pc systemd-ukify
 
 COPY . /

--- a/toolkit/tools/imagecustomizer/container/build-mic-container.sh
+++ b/toolkit/tools/imagecustomizer/container/build-mic-container.sh
@@ -80,8 +80,8 @@ fi
 
 # azl doesn't support grub2-pc for arm64, hence remove it from dockerfile
 if [ "$ARCH" == "arm64" ]; then
-    echo "Removing grub2-pc from Dockerfile for arm64"
-    sed -i 's/\<grub2-pc\>//g' Dockerfile.mic-container
+    echo "Removing grub2-pc and systemd-ukify from Dockerfile for arm64"
+    sed -i 's/\<grub2-pc systemd-ukify\>//g' Dockerfile.mic-container
 fi
 
 # build the container

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/unix"
 )
@@ -16,13 +17,19 @@ func TestCustomizeImageVerityUsrUki(t *testing.T) {
 	imageVersion := baseImageVersionAzl3
 	baseImage := checkSkipForCustomizeImage(t, imageType, imageVersion)
 
+	ukifyExists, err := file.CommandExists("ukify")
+	assert.NoError(t, err)
+	if !ukifyExists {
+		t.Skip("The 'ukify' command is not available")
+	}
+
 	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageUsrVerityUki")
 	buildDir := filepath.Join(testTempDir, "build")
 	outImageFilePath := filepath.Join(testTempDir, "image.raw")
 	configFile := filepath.Join(testDir, "verity-usr-uki.yaml")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
+	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw", "",
 		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
 	if !assert.NoError(t, err) {
 		return


### PR DESCRIPTION
The `ukify` command is relatively new. So, it isn't available except on fairly recent ditro versions. It isn't available in either Ubuntu 22.04 or AZL2, which is what our build/test pipelines use. So, skip the UKI test if the `ukify` command isn't available.

Also, fix up the requirements section of the Quick Start guide.

Also, add the `ukify` command to the container.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
