### PR TITLE
Remove shrink verity hash partition check.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
@@ -116,10 +116,6 @@ func testCustomizeImageVerityShrinkExtractHelper(t *testing.T, testName string, 
 	rootPartitionNum := 3
 	hashPartitionNum := 4
 
-	// Change the hash partition's filesystem type to ext4.
-	// This tests the logic that skips the hash partition when looking for partitions to shrink.
-	config.Storage.FileSystems[hashPartitionNum-1].Type = "ext4"
-
 	// Customize image, shrink partitions, and split the partitions into individual files.
 	err = CustomizeImage(buildDir, testDir, &config, baseImage, nil, outImageFilePath, "", "raw",
 		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, true /*enableShrinkFilesystems*/)

--- a/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
@@ -54,14 +54,6 @@ func shrinkFilesystems(imageLoopDevice string, verity []imagecustomizerapi.Verit
 			continue
 		}
 
-		// Don't try to shrink verity hash partitions.
-		for _, verityItem := range verity {
-			if partitionMatchesDeviceId(verityItem.HashDeviceId, diskPartition, partIdToPartUuid) {
-				logger.Log.Infof("Shrinking partition (%s): skipping verity hash partition", partitionLoopDevice)
-				continue
-			}
-		}
-
 		logger.Log.Infof("Shrinking partition (%s)", partitionLoopDevice)
 
 		startSector, foundStartSector := startSectors[partitionLoopDevice]


### PR DESCRIPTION
In an older version of the API, a user would be forced to specify a dummy filesystem type for the verity hash partition. This filesystem would be overridden when the verity hash tree was calculated. However, not only is the dummy filesystem type not required anymore, it is impossible for a user to specify one. Therefore, we no longer need the check that ensures we don't try to shrink the verity hash partition.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
