### PR TITLE
Cache fstab entries for image.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/cosicommon.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/cosicommon.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/safeloopback"
 )
@@ -42,8 +43,8 @@ func convertToCosi(ic *ImageCustomizerParameters) error {
 		return err
 	}
 
-	err = buildCosiFile(outputDir, ic.outputImageFile, partitionMetadataOutput, ic.verityMetadata, ic.partUuidToMountPath,
-		ic.imageUuidStr)
+	err = buildCosiFile(outputDir, ic.outputImageFile, partitionMetadataOutput, ic.verityMetadata,
+		ic.partUuidToFstabEntry, ic.imageUuidStr)
 	if err != nil {
 		return fmt.Errorf("failed to build COSI file:\n%w", err)
 	}
@@ -59,7 +60,7 @@ func convertToCosi(ic *ImageCustomizerParameters) error {
 }
 
 func buildCosiFile(sourceDir string, outputFile string, partitions []outputPartitionMetadata,
-	verityMetadata []verityDeviceMetadata, partUuidToMountPath map[string]string, imageUuidStr string,
+	verityMetadata []verityDeviceMetadata, partUuidToFstabEntry map[string]diskutils.FstabEntry, imageUuidStr string,
 ) error {
 	// Pre-compute a map for quick lookup of partition metadata by UUID
 	partUuidToMetadata := make(map[string]outputPartitionMetadata)
@@ -87,7 +88,7 @@ func buildCosiFile(sourceDir string, outputFile string, partitions []outputParti
 				UncompressedSize: partition.UncompressedSize,
 			},
 			PartType:   partition.PartitionTypeUuid,
-			MountPoint: partUuidToMountPath[partition.PartUuid],
+			MountPoint: partUuidToFstabEntry[partition.PartUuid].Target,
 			FsType:     partition.FileSystemType,
 			FsUuid:     partition.Uuid,
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsuuids.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsuuids.go
@@ -174,7 +174,7 @@ func fixPartitionUuidsInFstabFile(partitions []diskutils.PartitionInfo, newUuids
 		// Find the partition.
 		// Note: The 'partitions' list was collected before all the changes were made. So, the fstab entries will still
 		// match the values in the `partitions` list.
-		mountIdType, _, partitionIndex, err := findSourcePartitionHelper(fstabEntry.Source, partitions, buildDir)
+		mountIdType, _, partitionIndex, err := findSourcePartition(fstabEntry.Source, partitions, buildDir)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This change refactors some of the partitions helper functions. The main goal is to have a cache of the all the partitions' fstab entries. However, this change also takes the opportunity to do a little bit of cleanup.

This change is being done in preparation of the change to support enabling verity of pre-created partitions.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
