### PR TITLE
Fix recustomizing AZL3 image with verity enabled.

### DIFF
--- a/toolkit/tools/imagecustomizerapi/verity.go
+++ b/toolkit/tools/imagecustomizerapi/verity.go
@@ -13,6 +13,9 @@ const (
 
 	VerityRootDeviceName = "root"
 	VerityUsrDeviceName  = "usr"
+
+	VerityRootDevicePath = DeviceMapperPath + "/" + VerityRootDeviceName
+	VerityUsrDevicePath  = DeviceMapperPath + "/" + VerityUsrDeviceName
 )
 
 var (

--- a/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer.go
@@ -185,7 +185,7 @@ func (b *BootCustomizer) PrepareForVerity() error {
 		}
 
 		// For rootfs verity, the root device will always be "/dev/mapper/root"
-		rootDevicePath := verityDevicePathFromName(imagecustomizerapi.VerityRootDeviceName)
+		rootDevicePath := imagecustomizerapi.VerityRootDevicePath
 		defaultGrubFileContent, err = UpdateDefaultGrubFileVariable(defaultGrubFileContent, "GRUB_DEVICE",
 			rootDevicePath)
 		if err != nil {

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
@@ -133,7 +133,7 @@ func updateGrubConfigForVerity(verityMetadata map[string]verityDeviceMetadata, g
 	}
 
 	if _, exists := verityMetadata["/"]; exists {
-		rootDevicePath := verityDevicePathFromName(imagecustomizerapi.VerityRootDeviceName)
+		rootDevicePath := imagecustomizerapi.VerityRootDevicePath
 
 		if grubMkconfigEnabled {
 			grub2Config, err = updateKernelCommandLineArgsAll(grub2Config, []string{"root"},


### PR DESCRIPTION
When trying to recustomize an Azure Linux 3.0 image that has verity enabled, a "more than one 'linux' command in grub config" error occurs. This problem was caused by #109, which removed `GRUB_DISABLE_RECOVERY` from the `/etc/default/grub` file, which results in more than 1 menu item in the `grub.cfg` file.

This change also adds a regression test for this bug.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
