### PR TITLE
Ensure partition metadata is populated in kernel.

### DIFF
--- a/toolkit/tools/internal/safeloopback/safeloopback.go
+++ b/toolkit/tools/internal/safeloopback/safeloopback.go
@@ -51,7 +51,7 @@ func (l *Loopback) newLoopbackHelper() error {
 	l.diskIdMin = min
 
 	// Ensure all the partitions have finished populating.
-	err = diskutils.WaitForDevicesToSettle()
+	err = diskutils.WaitForDiskDevice(devicePath)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsuuids.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsuuids.go
@@ -65,7 +65,7 @@ func resetPartitionsUuids(buildImageFile string, buildDir string) error {
 	}
 
 	// Wait for the partition table updates to be processed.
-	err = diskutils.WaitForDevicesToSettle()
+	err = diskutils.WaitForDiskDevice(loopback.DevicePath())
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
@@ -199,12 +199,6 @@ func createImageBoilerplate(targetOs targetos.TargetOs, imageConnection *ImageCo
 		return nil, "", fmt.Errorf("failed to create partitions on disk (%s):\n%w", imageConnection.Loopback().DevicePath(), err)
 	}
 
-	// Refresh partition entries under /dev.
-	err = refreshPartitions(imageConnection.Loopback().DevicePath())
-	if err != nil {
-		return nil, "", err
-	}
-
 	// Read the disk partitions.
 	diskPartitions, err := diskutils.GetDiskPartitions(imageConnection.Loopback().DevicePath())
 	if err != nil {

--- a/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
@@ -683,13 +683,3 @@ func getPartitionNum(partitionLoopDevice string) (int, error) {
 
 	return num, nil
 }
-
-func refreshPartitions(diskDevPath string) error {
-	err := shell.ExecuteLiveWithErr(1 /*stderrLines*/, "flock", "--timeout", "5", diskDevPath,
-		"partprobe", "-s", diskDevPath)
-	if err != nil {
-		return fmt.Errorf("partprobe failed:\n%w", err)
-	}
-
-	return nil
-}

--- a/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
@@ -101,9 +101,9 @@ func shrinkFilesystems(imageLoopDevice string, verity []imagecustomizerapi.Verit
 
 		// Changes to the partition table causes all of the disk's parition /dev nodes to be deleted and then
 		// recreated. So, wait for that to finish.
-		err = diskutils.WaitForDevicesToSettle()
+		err = diskutils.WaitForDiskDevice(imageLoopDevice)
 		if err != nil {
-			return fmt.Errorf("failed to list disk (%s) partitions:\n%w", partitionLoopDevice, err)
+			return fmt.Errorf("failed to wait for disk (%s) to update:\n%w", imageLoopDevice, err)
 		}
 	}
 	return nil


### PR DESCRIPTION
The `udevadm settle` command is commonly used to wait for udev to read a disk and populate the disk's metadata in the kernel. While this works most of the time, it is well known `udevadm settle` isn't quite enough to guarantee that the metadata population has finished. In theory, `udevadm wait` is new command that does provide that guarantee. But that command isn't widely available yet.

This change works around this problem by adding a wait loop that checks the kernel's cached disk's metadata and compares it to the expected values read directly from disk.

This change also replaces the usage of `partprobe` with a call to the `BLKRRPART` (block device read partition) IOCTL syscall. This was done because `partprobe` manually handles the partition node updates. Whereas, calling `BLKRRPART` allows the kernel to handle the update, which is more efficient and reliable.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
