### PR TITLE
Add `lvm2` as package to verity examples and configs.

### DIFF
--- a/docs/imagecustomizer/how-to/verity-and-uki.md
+++ b/docs/imagecustomizer/how-to/verity-and-uki.md
@@ -92,6 +92,7 @@ the future.
        - systemd-ukify
        - systemd-boot
        - efibootmgr
+       - lvm2
     ```
 
 2. Run Image Customizer to create the image file.

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-config.yaml
@@ -65,6 +65,7 @@ os:
     - openssh-server
     - veritysetup
     - vim
+    - lvm2
 
   additionalFiles:
     # Change the directory that the sshd-keygen service writes the SSH host keys to.

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-partition-labels.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-partition-labels.yaml
@@ -69,6 +69,7 @@ os:
     - openssh-server
     - veritysetup
     - vim
+    - lvm2
 
   additionalFiles:
     # Change the directory that the sshd-keygen service writes the SSH host keys to.

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-config.yaml
@@ -65,6 +65,7 @@ os:
     - openssh-server
     - veritysetup
     - vim
+    - lvm2
 
   services:
     enable:

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-uki.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-uki.yaml
@@ -70,3 +70,4 @@ os:
     - systemd-ukify
     - systemd-boot
     - efibootmgr
+    - lvm2


### PR DESCRIPTION
The `lvm2` package is required to be installed when using verity. This package is installed by default in the 'core-efi' image but not the 'baremetal' image. So, include the package in the example configs for verity.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
