### PR TITLE
Remove systemd-ukify unnecessary check

### DIFF
--- a/docs/imagecustomizer/how-to/verity-and-uki.md
+++ b/docs/imagecustomizer/how-to/verity-and-uki.md
@@ -89,7 +89,6 @@ the future.
 
        install:
        - veritysetup
-       - systemd-ukify
        - systemd-boot
        - efibootmgr
        - lvm2

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki.go
@@ -118,11 +118,10 @@ func prepareUki(buildDir string, uki *imagecustomizerapi.Uki, imageChroot *safec
 
 func validateUkiDependencies(imageChroot *safechroot.Chroot) error {
 	// The following packages are required for the UKI feature:
-	// - "systemd-ukify": Required to build the Unified Kernel Image.
 	// - "systemd-boot": Checked as a package dependency here to ensure installation,
 	//    but additional configuration is handled elsewhere in the UKI workflow.
 	// - "efibootmgr": Used for managing EFI boot entries.
-	requiredRpms := []string{"systemd-ukify", "systemd-boot", "efibootmgr"}
+	requiredRpms := []string{"systemd-boot", "efibootmgr"}
 
 	// Iterate over each required package and check if it's installed.
 	for _, pkg := range requiredRpms {

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-uki.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-uki.yaml
@@ -67,7 +67,6 @@ os:
 
     install:
     - veritysetup
-    - systemd-ukify
     - systemd-boot
     - efibootmgr
     - lvm2


### PR DESCRIPTION
systemd-ukify is run from the host so no requirement to have it as an installed rpm

<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

---

### **Checklist**
- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
