### PR TITLE
Add partition size checks to tests.

### DIFF
--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -67,7 +67,7 @@ type PartitionInfo struct {
 	Mountpoint        string `json:"mountpoint"` // Example: /mnt/os/boot
 	PartLabel         string `json:"partlabel"`  // Example: boot
 	Type              string `json:"type"`       // Example: part
-	Size              uint64 `json:"size"`       // Example: 4096
+	SizeInBytes       uint64 `json:"size"`       // Example: 4096
 }
 
 type loopbackListOutput struct {

--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -67,6 +67,7 @@ type PartitionInfo struct {
 	Mountpoint        string `json:"mountpoint"` // Example: /mnt/os/boot
 	PartLabel         string `json:"partlabel"`  // Example: boot
 	Type              string `json:"type"`       // Example: part
+	Size              uint64 `json:"size"`       // Example: 4096
 }
 
 type loopbackListOutput struct {
@@ -1029,7 +1030,8 @@ func SystemBlockDevices() (systemDevices []SystemBlockDevice, err error) {
 // GetDiskPartitions gets the kernel's view of a disk's partitions.
 func GetDiskPartitions(diskDevPath string) ([]PartitionInfo, error) {
 	// Read the disk's partitions.
-	jsonString, _, err := shell.Execute("lsblk", diskDevPath, "--output", "NAME,PATH,PARTTYPE,FSTYPE,UUID,MOUNTPOINT,PARTUUID,PARTLABEL,TYPE", "--json", "--list")
+	jsonString, _, err := shell.Execute("lsblk", diskDevPath, "--output",
+		"NAME,PATH,PARTTYPE,FSTYPE,UUID,MOUNTPOINT,PARTUUID,PARTLABEL,TYPE,SIZE", "--bytes", "--json", "--list")
 	if err != nil {
 		return nil, fmt.Errorf("failed to list disk (%s) partitions:\n%w", diskDevPath, err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
@@ -119,6 +119,12 @@ func testCustomizeImagePartitionsToEfi(t *testing.T, testName string, imageType 
 		assert.Equal(t, "4f68bce3-e8cd-4db1-96e7-fbcaf984b709", partitions[3].PartitionTypeUuid) // root (x64)
 		assert.Equal(t, "4d21b016-b534-45c2-a9fb-5c16e091fd2d", partitions[4].PartitionTypeUuid) // var
 	}
+
+	// Check the partition sizes.
+	assert.Equal(t, uint64(8*diskutils.MiB), partitions[1].Size)
+	assert.Equal(t, uint64(99*diskutils.MiB), partitions[2].Size)
+	assert.Equal(t, uint64(1940*diskutils.MiB), partitions[3].Size)
+	assert.Equal(t, uint64(2047*diskutils.MiB), partitions[4].Size)
 }
 
 func TestCustomizeImagePartitionsSizeOnly(t *testing.T) {
@@ -186,6 +192,11 @@ func TestCustomizeImagePartitionsSizeOnly(t *testing.T) {
 		assert.Equal(t, "0fc63daf-8483-4772-8e79-3d69d8477de4", partitions[2].PartitionTypeUuid) // linux generic
 		assert.Equal(t, "0fc63daf-8483-4772-8e79-3d69d8477de4", partitions[3].PartitionTypeUuid) // linux generic
 	}
+
+	// Check the partition sizes.
+	assert.Equal(t, uint64(8*diskutils.MiB), partitions[1].Size)
+	assert.Equal(t, uint64(2*diskutils.GiB), partitions[2].Size)
+	assert.Equal(t, uint64(2*diskutils.GiB), partitions[3].Size)
 }
 
 func TestCustomizeImagePartitionsEfiToLegacy(t *testing.T) {
@@ -253,6 +264,10 @@ func testCustomizeImagePartitionsToLegacy(t *testing.T, testName string, imageTy
 		assert.Equal(t, "21686148-6449-6e6f-744e-656564454649", partitions[1].PartitionTypeUuid) // BIOS boot
 		assert.Equal(t, "0fc63daf-8483-4772-8e79-3d69d8477de4", partitions[2].PartitionTypeUuid) // linux generic
 	}
+
+	// Check the partition sizes.
+	assert.Equal(t, uint64(8*diskutils.MiB), partitions[1].Size)
+	assert.Equal(t, uint64(4086*diskutils.MiB), partitions[2].Size)
 }
 
 func TestCustomizeImageKernelCommandLine(t *testing.T) {

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
@@ -121,10 +121,10 @@ func testCustomizeImagePartitionsToEfi(t *testing.T, testName string, imageType 
 	}
 
 	// Check the partition sizes.
-	assert.Equal(t, uint64(8*diskutils.MiB), partitions[1].Size)
-	assert.Equal(t, uint64(99*diskutils.MiB), partitions[2].Size)
-	assert.Equal(t, uint64(1940*diskutils.MiB), partitions[3].Size)
-	assert.Equal(t, uint64(2047*diskutils.MiB), partitions[4].Size)
+	assert.Equal(t, uint64(8*diskutils.MiB), partitions[1].SizeInBytes)
+	assert.Equal(t, uint64(99*diskutils.MiB), partitions[2].SizeInBytes)
+	assert.Equal(t, uint64(1940*diskutils.MiB), partitions[3].SizeInBytes)
+	assert.Equal(t, uint64(2047*diskutils.MiB), partitions[4].SizeInBytes)
 }
 
 func TestCustomizeImagePartitionsSizeOnly(t *testing.T) {
@@ -194,9 +194,9 @@ func TestCustomizeImagePartitionsSizeOnly(t *testing.T) {
 	}
 
 	// Check the partition sizes.
-	assert.Equal(t, uint64(8*diskutils.MiB), partitions[1].Size)
-	assert.Equal(t, uint64(2*diskutils.GiB), partitions[2].Size)
-	assert.Equal(t, uint64(2*diskutils.GiB), partitions[3].Size)
+	assert.Equal(t, uint64(8*diskutils.MiB), partitions[1].SizeInBytes)
+	assert.Equal(t, uint64(2*diskutils.GiB), partitions[2].SizeInBytes)
+	assert.Equal(t, uint64(2*diskutils.GiB), partitions[3].SizeInBytes)
 }
 
 func TestCustomizeImagePartitionsEfiToLegacy(t *testing.T) {
@@ -266,8 +266,8 @@ func testCustomizeImagePartitionsToLegacy(t *testing.T, testName string, imageTy
 	}
 
 	// Check the partition sizes.
-	assert.Equal(t, uint64(8*diskutils.MiB), partitions[1].Size)
-	assert.Equal(t, uint64(4086*diskutils.MiB), partitions[2].Size)
+	assert.Equal(t, uint64(8*diskutils.MiB), partitions[1].SizeInBytes)
+	assert.Equal(t, uint64(4086*diskutils.MiB), partitions[2].SizeInBytes)
 }
 
 func TestCustomizeImageKernelCommandLine(t *testing.T) {

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
@@ -173,8 +173,9 @@ func testCustomizeImageVerityShrinkExtractHelper(t *testing.T, testName string, 
 	assert.Equal(t, int64(8*diskutils.MiB), espStat.Size())
 	assert.Equal(t, int64(100*diskutils.MiB), hashStat.Size())
 
-	// These partitions are shrunk.
-	// So, their size will vary slightly.
+	// These partitions are shrunk. Their final size will vary based on base image version, package versions, filesystem
+	// implementation details, and randomness. So, just enforce that the final size is below an arbitary value. Values
+	// were picked by observing values seen during test and adding a good buffer.
 	assert.Greater(t, int64(100*diskutils.MiB), bootStat.Size())
 	assert.Greater(t, int64(650*diskutils.MiB), rootStat.Size())
 	assert.Greater(t, int64(150*diskutils.MiB), varStat.Size())


### PR DESCRIPTION
In the CustomizeImage tests that customize partitions, verify the final size of the partitions.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
