### PR TITLE
Ensure oras is always copied to the Prism docker build staging folder.

### DIFF
--- a/toolkit/tools/imagecustomizer/container/build-mic-container.sh
+++ b/toolkit/tools/imagecustomizer/container/build-mic-container.sh
@@ -81,8 +81,10 @@ if [ ! -d "$orasUnzipDir" ]; then
 
   mkdir "$orasUnzipDir"
   tar -zxf "$ORAS_TAR" -C "$orasUnzipDir/"
-  cp "$orasUnzipDir/oras" "${stagingBinDir}"
 fi
+
+# stage oras
+cp "$orasUnzipDir/oras" "${stagingBinDir}"
 
 # azl doesn't support grub2-pc for arm64, hence remove it from dockerfile
 if [ "$ARCH" == "arm64" ]; then


### PR DESCRIPTION
<!-- Description: Please provide a summary of the changes and the motivation behind them. -->
When we run `azure-linux-image-tools/toolkit/tools/imagecustomizer/container/build-mic-container.sh`, it downloads oras tar.gz, unpacks it, and copies it to a staging folder so that it is included in the final container.
This logic is executed only if the script does not find the extraction folder (from a previous run). 

The problem is that the staging folder gets deleted before the script exists, but not the extraction folder. This means on a subsequent run, it will find the extraction folder, and skip the download/extraction/and copying to the staging folder.

The build will succeed without an issue because it copies file with wild cards (so a missing oras won't trigger an error).

However, when the user attempts to use run.sh, it fails because oras is not present in the docker image.

---

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] Code conforms to style guidelines
