### PR TITLE
Accept integer for filepermissions json schema

### DIFF
--- a/toolkit/tools/imagecustomizerapi/filepermissions.go
+++ b/toolkit/tools/imagecustomizerapi/filepermissions.go
@@ -4,6 +4,7 @@
 package imagecustomizerapi
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strconv"
@@ -50,7 +51,16 @@ func (p *FilePermissions) UnmarshalYAML(value *yaml.Node) error {
 
 func (FilePermissions) JSONSchema() *jsonschema.Schema {
 	return &jsonschema.Schema{
-		Type:    "string",
-		Pattern: "^[0-7]{3,4}$",
+		OneOf: []*jsonschema.Schema{
+			{
+				Type:    "string",
+				Pattern: "^[0-7]{3,4}$",
+			},
+			{
+				Type:    "integer",
+				Minimum: json.Number("0"),   // no negatives
+				Maximum: json.Number("777"), // Highest valid value
+			},
+		},
 	}
 }

--- a/toolkit/tools/imagecustomizerapi/filepermissions.go
+++ b/toolkit/tools/imagecustomizerapi/filepermissions.go
@@ -59,7 +59,7 @@ func (FilePermissions) JSONSchema() *jsonschema.Schema {
 			{
 				Type:    "integer",
 				Minimum: json.Number("0"),   // no negatives
-				Maximum: json.Number("777"), // Highest valid value
+				Maximum: json.Number("777"), // highest valid value
 			},
 		},
 	}

--- a/toolkit/tools/imagecustomizerapi/schema.json
+++ b/toolkit/tools/imagecustomizerapi/schema.json
@@ -125,8 +125,17 @@
       "pattern": "^\\d+[KMGT]$"
     },
     "FilePermissions": {
-      "type": "string",
-      "pattern": "^[0-7]{3,4}$"
+      "oneOf": [
+        {
+          "type": "string",
+          "pattern": "^[0-7]{3,4}$"
+        },
+        {
+          "type": "integer",
+          "maximum": 777,
+          "minimum": 0
+        }
+      ]
     },
     "FileSystem": {
       "properties": {


### PR DESCRIPTION
Fixes errors in vscode due to invalid schema.

Validated against sample 
```
os:
  additionalFiles:
   - destination: /usr/local/bin/myservice.sh
    permissions: 755
    content: |
      #!/usr/bin/env bash
      set -eu
```

---

### **Checklist**
- [] Tests added/updated
- [] Documentation updated (if needed)
- [x] Code conforms to style guidelines
