### PR TITLE
Rename output.path to output.image.path

### DIFF
--- a/docs/imagecustomizer/api/cli.md
+++ b/docs/imagecustomizer/api/cli.md
@@ -33,8 +33,9 @@ Added in v0.3.
 
 ## --output-image-file=FILE-PATH
 
-Required, unless [output.path](./configuration/output.md#path-string) is
-provided in the configuration file. If both `output.path` and
+Required, unless
+[output.image.path](./configuration/outputImage.md#path-string) is
+provided in the configuration file. If both `output.image.path` and
 `--output-image-file` are provided, then the `--output-image-file` value
 is used.
 

--- a/docs/imagecustomizer/api/configuration.md
+++ b/docs/imagecustomizer/api/configuration.md
@@ -232,4 +232,5 @@ os:
       - [name](./configuration/script.md#name-string)
   - [previewFeatures type](./configuration/config.md#previewfeatures-string)
   - [output](./configuration/config.md#output-output) ([output type](./configuration/output.md))
-    - [path](./configuration/output.md#path-string)
+    - [image](./configuration/output.md#image-outputimage) ([outputImage type](./configuration/outputImage.md))
+      - [path](./configuration/outputImage.md#path-string)

--- a/docs/imagecustomizer/api/configuration/output.md
+++ b/docs/imagecustomizer/api/configuration/output.md
@@ -10,16 +10,12 @@ Example:
 
 ```yaml
 output:
-  path: ./out/image.vhdx
+  image:
+    path: ./out/image.vhdx
 ```
 
-## path [string]
+## image [[outputImage](./outputImage.md)]
 
-Required, unless
-[--output-image-file](../cli.md#--output-image-filefile-path) is provided
-on the command line. If both `--output-image-file` are `output.path` are
-provided, then the value of `--output-image-file` is used.
-
-The file path to write the final customized image to.
+Specifies the configuration for the output image.
 
 Added in v0.13.0.

--- a/docs/imagecustomizer/api/configuration/outputImage.md
+++ b/docs/imagecustomizer/api/configuration/outputImage.md
@@ -1,0 +1,25 @@
+---
+parent: Configuration
+---
+
+# outputImage type
+
+Specifies the configuration for the output image.
+
+Example:
+
+```yaml
+image:
+  path: ./out/image.vhdx
+```
+
+## path [string]
+
+Required, unless
+[--output-image-file](../cli.md#--output-image-filefile-path) is provided
+on the command line. If both `--output-image-file` are `output.image.path`
+are provided, then the value of `--output-image-file` is used.
+
+The file path to write the final customized image to.
+
+Added in v0.13.0.

--- a/toolkit/tools/imagecustomizerapi/config_test.go
+++ b/toolkit/tools/imagecustomizerapi/config_test.go
@@ -45,7 +45,9 @@ func TestConfigIsValid(t *testing.T) {
 		Scripts: Scripts{},
 		Iso:     &Iso{},
 		Output: Output{
-			Path: "./out/image.vhdx",
+			Image: OutputImage{
+				Path: "./out/image.vhdx",
+			},
 		},
 	}
 

--- a/toolkit/tools/imagecustomizerapi/output.go
+++ b/toolkit/tools/imagecustomizerapi/output.go
@@ -4,9 +4,9 @@
 package imagecustomizerapi
 
 type Output struct {
-	Path string `yaml:"path" json:"path,omitempty"`
+	Image OutputImage `yaml:"image" json:"image,omitempty"`
 }
 
 func (o Output) IsValid() error {
-	return nil
+	return o.Image.IsValid()
 }

--- a/toolkit/tools/imagecustomizerapi/output_image.go
+++ b/toolkit/tools/imagecustomizerapi/output_image.go
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+type OutputImage struct {
+	Path string `yaml:"path" json:"path,omitempty"`
+}
+
+func (oi OutputImage) IsValid() error {
+	return nil
+}

--- a/toolkit/tools/imagecustomizerapi/output_image_test.go
+++ b/toolkit/tools/imagecustomizerapi/output_image_test.go
@@ -1,0 +1,13 @@
+package imagecustomizerapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOutputImageIsValid(t *testing.T) {
+	var oi OutputImage
+	err := oi.IsValid()
+	assert.NoError(t, err)
+}

--- a/toolkit/tools/imagecustomizerapi/schema.json
+++ b/toolkit/tools/imagecustomizerapi/schema.json
@@ -280,6 +280,15 @@
     },
     "Output": {
       "properties": {
+        "image": {
+          "$ref": "#/$defs/OutputImage"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object"
+    },
+    "OutputImage": {
+      "properties": {
         "path": {
           "type": "string"
         }

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -159,7 +159,7 @@ func createImageCustomizerParameters(buildDir string,
 	ic.outputIsIso = ic.outputImageFormat == ImageFormatIso
 	ic.outputImageFile = outputImageFile
 	if ic.outputImageFile == "" {
-		ic.outputImageFile = config.Output.Path
+		ic.outputImageFile = config.Output.Image.Path
 	}
 
 	ic.outputImageBase = strings.TrimSuffix(filepath.Base(ic.outputImageFile), filepath.Ext(ic.outputImageFile))
@@ -773,8 +773,8 @@ func validatePackageLists(baseConfigPath string, config *imagecustomizerapi.OS, 
 }
 
 func validateOutput(output imagecustomizerapi.Output, outputImageFile string) error {
-	if outputImageFile == "" && output.Path == "" {
-		return fmt.Errorf("output image file must be specified, either via the command line option '--output-image-file' or in the config file property 'output.path'")
+	if outputImageFile == "" && output.Image.Path == "" {
+		return fmt.Errorf("output image file must be specified, either via the command line option '--output-image-file' or in the config file property 'output.image.path'")
 	}
 
 	return nil

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -263,7 +263,7 @@ func TestValidateOutput_AcceptsValidPaths(t *testing.T) {
 	err := validateConfig(testDir, config, nil, "./out/image.vhdx", true)
 	assert.NoError(t, err)
 
-	config.Output.Path = "./out/image.vhdx"
+	config.Output.Image.Path = "./out/image.vhdx"
 
 	// The output image file is specified in both the config and as an
 	// argument, so it should not return an error.
@@ -339,7 +339,9 @@ func TestCustomizeImage_OutputImageFileSelection(t *testing.T) {
 			},
 		},
 		Output: imagecustomizerapi.Output{
-			Path: outImageFilePathFromConfig,
+			Image: imagecustomizerapi.OutputImage{
+				Path: outImageFilePathFromConfig,
+			},
 		},
 	}
 	err := CustomizeImage(buildDir, buildDir, config, baseImage, nil, "", "raw", "",
@@ -352,7 +354,7 @@ func TestCustomizeImage_OutputImageFileSelection(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Pass the output image file only through the argument.
-	config.Output.Path = ""
+	config.Output.Image.Path = ""
 	err = CustomizeImage(buildDir, buildDir, config, baseImage, nil, outputImageFilePathFromArgs, "raw", "",
 		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
 	assert.NoError(t, err)
@@ -364,7 +366,7 @@ func TestCustomizeImage_OutputImageFileSelection(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Pass the output image file through both the config and the argument.
-	config.Output.Path = outImageFilePathFromConfig
+	config.Output.Image.Path = outImageFilePathFromConfig
 	err = CustomizeImage(buildDir, buildDir, config, baseImage, nil, outputImageFilePathFromArgs, "raw", "",
 		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, false /*enableShrinkFilesystems*/)
 	assert.NoError(t, err)
@@ -397,7 +399,7 @@ func TestCreateImageCustomizerParameters_OutputImageFileSelection(t *testing.T) 
 	assert.Equal(t, ic.outputImageFile, "")
 
 	// Pass the output image file only in the config.
-	config.Output.Path = outImageFilePathAsConfig
+	config.Output.Image.Path = outImageFilePathAsConfig
 
 	// The output image file should be set to the value in the config.
 	ic, err = createImageCustomizerParameters(buildDir, inputImageFile, configPath, config, useBaseImageRpmRepos,
@@ -409,7 +411,7 @@ func TestCreateImageCustomizerParameters_OutputImageFileSelection(t *testing.T) 
 	assert.Equal(t, ic.outputImageDir, buildDir)
 
 	// Pass the output image file only as an argument.
-	config.Output.Path = ""
+	config.Output.Image.Path = ""
 	outputImageFile = outImageFilePathAsArg
 
 	// The output image file should be set to the value passed as an argument.
@@ -422,7 +424,7 @@ func TestCreateImageCustomizerParameters_OutputImageFileSelection(t *testing.T) 
 	assert.Equal(t, ic.outputImageDir, buildDir)
 
 	// Pass the output image file in both the config and as an argument.
-	config.Output.Path = outImageFilePathAsConfig
+	config.Output.Image.Path = outImageFilePathAsConfig
 	outputImageFile = outImageFilePathAsArg
 
 	// The output image file should be set to the value passed as an


### PR DESCRIPTION
Note: The type is named outputImage instead of image to make room for future inputImage type.

---

### **Checklist**
- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
