### PR TITLE
Fix `TestCustomizeImageVerityShrinkExtract` on ARM64.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
@@ -176,7 +176,7 @@ func testCustomizeImageVerityShrinkExtractHelper(t *testing.T, testName string, 
 	// These partitions are shrunk. Their final size will vary based on base image version, package versions, filesystem
 	// implementation details, and randomness. So, just enforce that the final size is below an arbitary value. Values
 	// were picked by observing values seen during test and adding a good buffer.
-	assert.Greater(t, int64(100*diskutils.MiB), bootStat.Size())
+	assert.Greater(t, int64(150*diskutils.MiB), bootStat.Size())
 	assert.Greater(t, int64(650*diskutils.MiB), rootStat.Size())
 	assert.Greater(t, int64(150*diskutils.MiB), varStat.Size())
 


### PR DESCRIPTION
The boot partition is apparently a little larger on ARM64.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
