### PR TITLE
Switch from `parted` to `sfdisk`.

### DIFF
--- a/docs/imagecustomizer/how-to/quick-start.md
+++ b/docs/imagecustomizer/how-to/quick-start.md
@@ -39,7 +39,7 @@ nav_order: 1
 
      ```bash
      sudo tdnf install -y qemu-img rpm coreutils util-linux systemd openssl \
-        sed createrepo_c squashfs-tools cdrkit parted e2fsprogs dosfstools \
+        sed createrepo_c squashfs-tools cdrkit e2fsprogs dosfstools \
         xfsprogs zstd veritysetup grub2 grub2-pc binutils
      ```
 
@@ -47,7 +47,7 @@ nav_order: 1
 
      ```bash
      sudo tdnf install -y qemu-img rpm coreutils util-linux systemd openssl \
-        sed createrepo_c squashfs-tools cdrkit parted e2fsprogs dosfstools \
+        sed createrepo_c squashfs-tools cdrkit e2fsprogs dosfstools \
         xfsprogs zstd veritysetup grub2 grub2-pc systemd-ukify binutils
      ```
 

--- a/docs/imagecustomizer/how-to/quick-start.md
+++ b/docs/imagecustomizer/how-to/quick-start.md
@@ -23,7 +23,7 @@ nav_order: 1
 
 3. Install prerequisites: `qemu-img`, `rpm`, `dd`, `lsblk`, `losetup`, `sfdisk`,
    `udevadm`, `flock`, `blkid`, `openssl`, `sed`, `createrepo`, `mksquashfs`,
-   `genisoimage`, `parted`, `mkfs`, `mkfs.ext4`, `mkfs.vfat`, `mkfs.xfs`, `fsck`,
+   `genisoimage`, `mkfs`, `mkfs.ext4`, `mkfs.vfat`, `mkfs.xfs`, `fsck`,
    `e2fsck`, `xfs_repair`, `resize2fs`, `tune2fs`, `xfs_admin`, `fatlabel`, `zstd`,
    `veritysetup`, `grub2-install` (or `grub-install`), `ukify`, `objcopy`.
 
@@ -31,7 +31,7 @@ nav_order: 1
 
      ```bash
      sudo apt -y install qemu-utils rpm coreutils util-linux mount fdisk udev openssl \
-        sed createrepo-c squashfs-tools genisoimage parted e2fsprogs dosfstools \
+        sed createrepo-c squashfs-tools genisoimage e2fsprogs dosfstools \
         xfsprogs zstd cryptsetup-bin grub2-common binutils
      ```
 

--- a/toolkit/tools/imagecustomizerapi/disk.go
+++ b/toolkit/tools/imagecustomizerapi/disk.go
@@ -116,7 +116,7 @@ func (d *Disk) IsValid() error {
 		}
 
 		// Verify MaxSize value.
-		lastPartition := d.Partitions[len(d.Partitions)-1]
+		lastPartition := &d.Partitions[len(d.Partitions)-1]
 		lastPartitionEnd, lastPartitionHasEnd := lastPartition.GetEnd()
 
 		switch {
@@ -143,6 +143,14 @@ func (d *Disk) IsValid() error {
 			if requiredSize > *d.MaxSize {
 				return fmt.Errorf("disk's partitions need %s but maxSize is only %s:\nGPT footer size is %s",
 					requiredSize.HumanReadable(), d.MaxSize.HumanReadable(), gptFooterSize.HumanReadable())
+			}
+
+			if !lastPartitionHasEnd {
+				// Explicitly set the size of the last partition.
+				// This allows us to control the alignment of the GPT footer instead of relying on the behavior of the
+				// partitioning tool (e.g. sfdisk).
+				lastPartitionEnd := *d.MaxSize - gptFooterSize
+				lastPartition.End = &lastPartitionEnd
 			}
 		}
 	}

--- a/toolkit/tools/imager/imager.go
+++ b/toolkit/tools/imager/imager.go
@@ -374,7 +374,7 @@ func setupDisk(outputDir, diskName string, liveInstallFlag bool, diskConfig conf
 		if liveInstallFlag {
 			diskDevPath = diskConfig.TargetDisk.Value
 			partIDToDevPathMap, partIDToFsTypeMap, encryptedRoot, err = setupRealDisk(diskDevPath, diskConfig,
-				rootEncryption, false /*diskKnownToBeEmpty*/)
+				rootEncryption)
 		} else {
 			err = fmt.Errorf("target Disk Type is set but --live-install option is not set. Please check your config or enable the --live-install option")
 			return
@@ -410,8 +410,7 @@ func setupLoopDeviceDisk(outputDir, diskName string, diskConfig configuration.Di
 		return
 	}
 
-	partIDToDevPathMap, partIDToFsTypeMap, encryptedRoot, err = setupRealDisk(diskDevPath, diskConfig, rootEncryption,
-		true /*diskKnownToBeEmpty*/)
+	partIDToDevPathMap, partIDToFsTypeMap, encryptedRoot, err = setupRealDisk(diskDevPath, diskConfig, rootEncryption)
 	if err != nil {
 		err = fmt.Errorf("failed to setup loopback disk partitions (%s):\n%w", rawDisk, err)
 		return
@@ -420,11 +419,11 @@ func setupLoopDeviceDisk(outputDir, diskName string, diskConfig configuration.Di
 	return
 }
 
-func setupRealDisk(diskDevPath string, diskConfig configuration.Disk, rootEncryption configuration.RootEncryption, diskKnownToBeEmpty bool,
+func setupRealDisk(diskDevPath string, diskConfig configuration.Disk, rootEncryption configuration.RootEncryption,
 ) (partIDToDevPathMap, partIDToFsTypeMap map[string]string, encryptedRoot diskutils.EncryptedRootDevice, err error) {
 	// Set up partitions
 	partIDToDevPathMap, partIDToFsTypeMap, encryptedRoot, err = diskutils.CreatePartitions(
-		targetos.TargetOsAzureLinux3, diskDevPath, diskConfig, rootEncryption, diskKnownToBeEmpty)
+		targetos.TargetOsAzureLinux3, diskDevPath, diskConfig, rootEncryption)
 	if err != nil {
 		err = fmt.Errorf("failed to create partitions on disk (%s):\n%w", diskDevPath, err)
 		return

--- a/toolkit/tools/internal/safemount/safemount_test.go
+++ b/toolkit/tools/internal/safemount/safemount_test.go
@@ -68,7 +68,7 @@ func TestResourceBusy(t *testing.T) {
 
 	// Set up partitions.
 	_, _, _, err = diskutils.CreatePartitions(targetos.TargetOsAzureLinux3, loopback.DevicePath(), diskConfig,
-		configuration.RootEncryption{}, true /*diskKnownToBeEmpty*/)
+		configuration.RootEncryption{})
 	if !assert.NoError(t, err, "failed to create partitions on disk", loopback.DevicePath()) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
@@ -193,8 +193,7 @@ func createImageBoilerplate(targetOs targetos.TargetOs, imageConnection *ImageCo
 
 	// Set up partitions.
 	partIDToDevPathMap, partIDToFsTypeMap, _, err := diskutils.CreatePartitions(
-		targetOs, imageConnection.Loopback().DevicePath(), imagerDiskConfig, configuration.RootEncryption{},
-		true /*diskKnownToBeEmpty*/)
+		targetOs, imageConnection.Loopback().DevicePath(), imagerDiskConfig, configuration.RootEncryption{})
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to create partitions on disk (%s):\n%w", imageConnection.Loopback().DevicePath(), err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/versionsOfToolDependencies.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/versionsOfToolDependencies.go
@@ -14,7 +14,7 @@ func logVersionsOfToolDeps() {
 	versionFlags := map[string][]string{
 		"--version": {
 			"qemu-img", "rpm", "dd", "lsblk", "losetup", "sfdisk", "udevadm",
-			"flock", "blkid", "sed", "createrepo", "genisoimage", "parted", "mkfs",
+			"flock", "blkid", "sed", "createrepo", "genisoimage", "mkfs",
 			"fsck", "fatlabel", "zstd", "veritysetup", "grub-install", "objcopy",
 		},
 		"-version": {


### PR DESCRIPTION
Switch from using `parted` for creating partitions to using `sfdisk` instead. The `sfdisk` API is slightly nicer to use. For example, we only need a single call to `sfdisk` to provision a partition, instead of multiple calls to `parted`. Also, `sfdisk` acquired some (GPT) features a lot earlier than `parted`. So, using `sfdisk` allows us to avoid disabling features for older versions of `parted`. In adddition, this avoids an annoying patch[1] in Ubuntu which calls `udevadm settle` in `parted` which can cause our code to deadlock in Ubuntu 24.04.

[1] https://git.launchpad.net/ubuntu/+source/parted/tree/debian/patches/udevadm-settle.patch

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
