### PR TITLE
Suppress extraneous warnings when building LiveISO.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -988,7 +988,7 @@ func (b *LiveOSIsoBuilder) prepareLiveOSDir(inputSavedConfigsFilePath string, wr
 				updatedSavedConfigs.OS.RequestedSELinuxMode != imagecustomizerapi.SELinuxModeDefault {
 				return fmt.Errorf("SELinux cannot be enabled due to older dracut and selinux-policy package versions:\n%w", err)
 			} else {
-				logger.Log.Warnf("SELinux cannot be enabled due to older dracut and selinux-policy package versions:\n%s", err)
+				logger.Log.Infof("SELinux disabled due to older dracut and selinux-policy package versions:\n%s", err)
 			}
 
 			disableSELinux = true
@@ -1040,7 +1040,7 @@ func (b *LiveOSIsoBuilder) createSquashfsImage(writeableRootfsDir string) error 
 
 	// '-xattrs' allows SELinux labeling to be retained within the squashfs.
 	mksquashfsParams := []string{writeableRootfsDir, squashfsImagePath, "-xattrs"}
-	err = shell.ExecuteLive(false, "mksquashfs", mksquashfsParams...)
+	err = shell.ExecuteLive(true, "mksquashfs", mksquashfsParams...)
 	if err != nil {
 		return fmt.Errorf("failed to create squashfs:\n%w", err)
 	}

--- a/toolkit/tools/pkg/isomakerlib/isomaker.go
+++ b/toolkit/tools/pkg/isomakerlib/isomaker.go
@@ -264,7 +264,7 @@ func (im *IsoMaker) setUpIsoGrub2Bootloader() (err error) {
 	}
 
 	logger.Log.Debugf("Formatting '%s' as an MS-DOS filesystem.", im.efiBootImgPath)
-	err = shell.ExecuteLive(false /*squashErrors*/, "mkdosfs", im.efiBootImgPath)
+	err = shell.ExecuteLive(true /*squashErrors*/, "mkdosfs", im.efiBootImgPath)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
There are a few warnings when building a LiveISO which don't cause any problems. Hence downgrade these logs to either info or debug.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
