### PR TITLE
Fix VHD upload instructions.

### DIFF
--- a/docs/imagecustomizer/how-to/azure-vm.md
+++ b/docs/imagecustomizer/how-to/azure-vm.md
@@ -186,7 +186,7 @@ in front of any HTTP endpoints.
 
    ```bash
    SAS_JSON="$(az disk grant-access -n "$DISK_NAME" -g "$VM_RG" --access-level Write --duration-in-seconds 86400)"
-   SAS_URL="$(jq -r '.accessSas' <<< "$SAS_JSON")"
+   SAS_URL="$(jq -r '.accessSas // .accessSAS' <<< "$SAS_JSON")"
 
    azcopy copy "$LOCAL_DISK_PATH" "$SAS_URL" --blob-type PageBlob
 

--- a/docs/imagecustomizer/how-to/download-marketplace-image.md
+++ b/docs/imagecustomizer/how-to/download-marketplace-image.md
@@ -68,7 +68,7 @@ customized using Image Customizer.
 
    ```bash
    SAS_JSON="$(az disk grant-access --duration-in-seconds 86400 --access-level Read --name "$DISK_NAME" --resource-group "$DISK_RG")"
-   SAS_URL="$(jq -r '.accessSas' <<< "$SAS_JSON")"
+   SAS_URL="$(jq -r '.accessSas // .accessSAS' <<< "$SAS_JSON")"
    ```
 
 8. Download VHD:


### PR DESCRIPTION
It seems that the `az disk grant-access` command decided to rename the JSON output field `accessSAS` to `accessSas` at some point. So, update the docs to be able to handle both versions.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
