### PR TITLE
Rev up minimum required Dracut version for LiveOS ISO

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoutils.go
@@ -16,7 +16,7 @@ const (
 
 	// Minumum dracut version required to enable SELinux.
 	LiveOsSelinuxDracutMinVersion        = 102
-	LiveOsSelinuxDracutMinPackageRelease = 9
+	LiveOsSelinuxDracutMinPackageRelease = 11
 	LiveOsSelinuxDracutDistroName        = "azl"
 	LiveOsSelinuxDracutMinDistroVersion  = 3
 


### PR DESCRIPTION
The logic in LiveOS ISO checks the Dracut version installed on the image to be customized.

If it is below a certain version, it will always disable SELinux since it knows SELinux is not supported for that version and the image will not boot.

However, if it is at or higher, it leave SELinux as-is.

The problem is that this version is not set at 102-8, which has a known bug blocking booting LiveOS ISO images when SELinux is enabled.

This change updates the version to a new Dracut package that has the fix necessary for booting LiveOS ISO image with SELinux enabled.

*Note*: Last month, we have updated Prism to depend on version 9 assuming we will be able to merge the pending PR matching Dracut package version 9 into Azure Linux.
However, two unrelated Dracut fixes got merged before ours and this resulted in changing our target fix version changing from 9 to 11. Since then, ours has been merged now (https://github.com/microsoft/azurelinux/commit/36b2761bcdc56a8d00c6d41fbd745017db4276f6) -
so we will not need to catch up again later.

The change was tested on x64 and arm64.

<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

---

### **Checklist**
- [n/a] Tests added/updated
- [n/a] Documentation updated (if needed)
- [n/a] Code conforms to style guidelines
