### PR TITLE
Docs: Change WSL guidance.

### DIFF
--- a/docs/imagecustomizer/how-to/quick-start.md
+++ b/docs/imagecustomizer/how-to/quick-start.md
@@ -56,10 +56,6 @@ nav_order: 1
    Image Customizer directly on those distros. However, using the
    [Image Customizer container](../how-to/container.md) on those distros should work.
 
-   Note: There are known issues with trying to use Image Customizer in WSL (Windows
-   Subsystem for Linux). It is recommended that use the Image Customizer tool in a
-   Linux OS running on a bare-metal host or a virtual machine.
-
 4. Run the Image Customizer tool.
 
    For example:
@@ -80,6 +76,11 @@ nav_order: 1
 
    For a description of all the command line options, see:
    [Image Customizer command line](../api/cli.md)
+
+   Note: If you are running in WSL (Windows Subsystem for Linux), then you should place
+   the `--build-dir` directory in one of the Linux directories (e.g. `~/build`).
+   Otherwise, the tool will run very slowly. However, it is fine for `--image-file` and
+   `--output-image-file` to be located in either a Windows or Linux directory.
 
 5. Use the customized image.
 

--- a/docs/imagecustomizer/how-to/quick-start.md
+++ b/docs/imagecustomizer/how-to/quick-start.md
@@ -78,9 +78,12 @@ nav_order: 1
    [Image Customizer command line](../api/cli.md)
 
    Note: If you are running in WSL (Windows Subsystem for Linux), then you should place
-   the `--build-dir` directory in one of the Linux directories (e.g. `~/build`).
-   Otherwise, the tool will run very slowly. However, it is fine for `--image-file` and
-   `--output-image-file` to be located in either a Windows or Linux directory.
+   the `--build-dir` directory in the native Linux filesystem (e.g. `~/build`) instead
+   of one of the mounted Windows filesystems (e.g. `/mnt/c`). Otherwise, the tool will
+   run very slowly due to I/O performance issues. However, it is fine for `--image-file`
+   and `--output-image-file` to be located in either a Windows or Linux filesystem.
+
+   Also, Image Customizer will not run successfully in WSL1. You must use WSL2.
 
 5. Use the customized image.
 


### PR DESCRIPTION
It seems that with the `sfdisk` change, imagecustomizer seems to work in WSL. So, remove the warning from the docs.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
