### PR TITLE
Fix when partitions are explictly set to `linux-generic`.

### DIFF
--- a/toolkit/tools/imagecustomizerapi/partitiontype.go
+++ b/toolkit/tools/imagecustomizerapi/partitiontype.go
@@ -42,14 +42,15 @@ var (
 	// - https://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
 	// - https://uapi-group.org/specifications/specs/discoverable_partitions_specification/
 	partitionTypeToUuidArchIndependent = map[PartitionType]string{
-		PartitionTypeESP:      "c12a7328-f81f-11d2-ba4b-00a0c93ec93b",
-		PartitionTypeBiosGrub: "21686148-6449-6E6F-744E-656564454649",
-		PartitionTypeHome:     "933ac7e1-2eb4-4f13-b844-0e14e2aef915",
-		PartitionTypeSrv:      "3b8f8425-20e0-4f3b-907f-1a25a76f98e8",
-		PartitionTypeSwap:     "0657fd6d-a4ab-43c4-84e5-0933c84b4f4f",
-		PartitionTypeTmp:      "7ec6f557-3bc5-4aca-b293-16ef5df639d1",
-		PartitionTypeVar:      "4d21b016-b534-45c2-a9fb-5c16e091fd2d",
-		PartitionTypeXbootldr: "bc13c2ff-59e6-4262-a352-b275fd6f7172",
+		PartitionTypeESP:          "c12a7328-f81f-11d2-ba4b-00a0c93ec93b",
+		PartitionTypeBiosGrub:     "21686148-6449-6E6F-744E-656564454649",
+		PartitionTypeHome:         "933ac7e1-2eb4-4f13-b844-0e14e2aef915",
+		PartitionTypeLinuxGeneric: "0fc63daf-8483-4772-8e79-3d69d8477de4",
+		PartitionTypeSrv:          "3b8f8425-20e0-4f3b-907f-1a25a76f98e8",
+		PartitionTypeSwap:         "0657fd6d-a4ab-43c4-84e5-0933c84b4f4f",
+		PartitionTypeTmp:          "7ec6f557-3bc5-4aca-b293-16ef5df639d1",
+		PartitionTypeVar:          "4d21b016-b534-45c2-a9fb-5c16e091fd2d",
+		PartitionTypeXbootldr:     "bc13c2ff-59e6-4262-a352-b275fd6f7172",
 	}
 
 	PartitionTypeToUuid map[PartitionType]string

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/partitions-size-only-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/partitions-size-only-config.yaml
@@ -10,6 +10,7 @@ storage:
       size: 2G
 
     - id: var
+      type: linux-generic
       size: 2G
 
   bootType: efi


### PR DESCRIPTION
The `linux-generic` type is missing from the map from friendly names to UUIDs. This causes the code to pass the wrong value to `sfdisk`.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
