### PR TITLE
Fix TestCustomizeImage_InputImageFileSelection failing due to no output image format specified

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -316,6 +316,7 @@ func TestCustomizeImage_InputImageFileSelection(t *testing.T) {
 
 	buildDir := filepath.Join(tmpDir, "TestCustomizeImage_InputImageFileSelection")
 	outputImagePath := filepath.Join(buildDir, "image.vhd")
+	outputImageFormat := filepath.Ext(outputImagePath)[1:]
 
 	// Pass the input image file only through the config.
 	config := &imagecustomizerapi.Config{
@@ -325,19 +326,19 @@ func TestCustomizeImage_InputImageFileSelection(t *testing.T) {
 			},
 		},
 	}
-	err := CustomizeImage(buildDir, buildDir, config, "" /*inputImageFile*/, nil, outputImagePath, "",
+	err := CustomizeImage(buildDir, buildDir, config, "" /*inputImageFile*/, nil, outputImagePath, outputImageFormat,
 		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	assert.NoError(t, err)
 
 	// Pass the input image file only through the argument.
 	config.Input.Image.Path = ""
-	err = CustomizeImage(buildDir, buildDir, config, inputImagePath, nil, outputImagePath, "",
+	err = CustomizeImage(buildDir, buildDir, config, inputImagePath, nil, outputImagePath, outputImageFormat,
 		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	assert.NoError(t, err)
 
 	// Pass the input image file through both the config and the argument.
 	config.Input.Image.Path = filepath.Join(buildDir, "doesnotexist.xxx")
-	err = CustomizeImage(buildDir, buildDir, config, inputImagePath, nil, outputImagePath, "",
+	err = CustomizeImage(buildDir, buildDir, config, inputImagePath, nil, outputImagePath, outputImageFormat,
 		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
`TestCustomizeImage_InputImageFileSelection` began to fail after merging #159 with error `output image format must be specified`.

This is because the PR introduced a check for this in `CustomizeImage`. Previously, that check was not there. The fix is to simply add a valid output image format to the argument list in the calls to `CustomizeImage`.