### PR TITLE
Switch to Kong CLI parser.

### DIFF
--- a/toolkit/tools/go.mod
+++ b/toolkit/tools/go.mod
@@ -5,6 +5,7 @@ go 1.23.6
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.8.2
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.0
+	github.com/alecthomas/kong v1.9.0
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2
 	github.com/cavaliercoder/go-cpio v0.0.0-20180626203310-925f9528c45e
 	github.com/fatih/color v1.18.0

--- a/toolkit/tools/go.sum
+++ b/toolkit/tools/go.sum
@@ -78,6 +78,12 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7 h1:uSoVVbwJiQipAclBbw+8quDsfcvFjOpI5iCf4p/cqCs=
 github.com/alcortesm/tgz v0.0.0-20161220082320-9c5fe88206d7/go.mod h1:6zEj6s6u/ghQa61ZWa/C2Aw3RkjiTBOix7dkqa1VLIs=
+github.com/alecthomas/assert/v2 v2.11.0 h1:2Q9r3ki8+JYXvGsDyBXwH3LcJ+WK5D0gc5E8vS6K3D0=
+github.com/alecthomas/assert/v2 v2.11.0/go.mod h1:Bze95FyfUr7x34QZrjL+XP+0qgp/zg8yS+TtBj1WA3k=
+github.com/alecthomas/kong v1.9.0 h1:Wgg0ll5Ys7xDnpgYBuBn/wPeLGAuK0NvYmEcisJgrIs=
+github.com/alecthomas/kong v1.9.0/go.mod h1:p2vqieVMeTAnaC83txKtXe8FLke2X07aruPWXyMPQrU=
+github.com/alecthomas/repr v0.4.0 h1:GhI2A8MACjfegCPVq9f1FLvIBS+DrQ2KQBFZP1iFzXc=
+github.com/alecthomas/repr v0.4.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20240927000941-0f3dac36c52b h1:mimo19zliBX/vSQ6PWWSL9lK8qwHozUj03+zLoEB8O0=
@@ -244,6 +250,8 @@ github.com/googleapis/go-type-adapters v1.0.0/go.mod h1:zHW75FOG2aur7gAO2B+MLby+
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=

--- a/toolkit/tools/imagecustomizer/main.go
+++ b/toolkit/tools/imagecustomizer/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/microsoft/azurelinux/toolkit/tools/pkg/imagecustomizerlib"
 )
 
-type BuildCmd struct {
+type CustomizeCmd struct {
 	BuildDir                 string   `name:"build-dir" help:"Directory to run build out of." required:""`
 	InputImageFile           string   `name:"image-file" help:"Path of the base Azure Linux image which the customization will be applied to."`
 	OutputImageFile          string   `name:"output-image-file" help:"Path to write the customized image to."`
@@ -29,7 +29,7 @@ type BuildCmd struct {
 }
 
 type RootCmd struct {
-	Build         BuildCmd         `name:"build" cmd:"" default:"withargs" help:"Customizes a pre-built Azure Linux image."`
+	Customize     CustomizeCmd     `name:"customize" cmd:"" default:"withargs" help:"Customizes a pre-built Azure Linux image."`
 	Version       kong.VersionFlag `name:"version" help:"Print version information and quit"`
 	TimeStampFile string           `name:"timestamp-file" help:"File that stores timestamps for this program."`
 	exekong.LogFlags
@@ -60,8 +60,8 @@ func main() {
 	}
 
 	switch parseContext.Command() {
-	case "build":
-		err := customizeImage(cli.Build)
+	case "customize":
+		err := customizeImage(cli.Customize)
 		if err != nil {
 			log.Fatalf("image customization failed:\n%v", err)
 		}
@@ -71,10 +71,10 @@ func main() {
 	}
 }
 
-func customizeImage(buildCmd BuildCmd) error {
-	err := imagecustomizerlib.CustomizeImageWithConfigFile(buildCmd.BuildDir, buildCmd.ConfigFile,
-		buildCmd.InputImageFile, buildCmd.RpmSources, buildCmd.OutputImageFile, buildCmd.OutputImageFormat,
-		buildCmd.OutputPXEArtifactsDir, !buildCmd.DisableBaseImageRpmRepos)
+func customizeImage(cmd CustomizeCmd) error {
+	err := imagecustomizerlib.CustomizeImageWithConfigFile(cmd.BuildDir, cmd.ConfigFile, cmd.InputImageFile,
+		cmd.RpmSources, cmd.OutputImageFile, cmd.OutputImageFormat, cmd.OutputPXEArtifactsDir,
+		!cmd.DisableBaseImageRpmRepos)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/imagecustomizer/main.go
+++ b/toolkit/tools/imagecustomizer/main.go
@@ -4,57 +4,77 @@
 package main
 
 import (
-	"fmt"
 	"log"
-	"os"
+	"maps"
 	"strings"
 
+	"github.com/alecthomas/kong"
 	"github.com/microsoft/azurelinux/toolkit/tools/imagecustomizerapi"
-	"github.com/microsoft/azurelinux/toolkit/tools/internal/exe"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/exekong"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/ptrutils"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/timestamp"
 	"github.com/microsoft/azurelinux/toolkit/tools/pkg/imagecustomizerlib"
-	"gopkg.in/alecthomas/kingpin.v2"
 )
 
-var (
-	app = kingpin.New("imagecustomizer", "Customizes a pre-built Azure Linux image")
+type BuildCmd struct {
+	BuildDir                 string   `name:"build-dir" help:"Directory to run build out of." required:""`
+	InputImageFile           string   `name:"image-file" help:"Path of the base Azure Linux image which the customization will be applied to."`
+	OutputImageFile          string   `name:"output-image-file" help:"Path to write the customized image to."`
+	OutputImageFormat        string   `name:"output-image-format" placeholder:"(vhd|vhd-fixed|vhdx|qcow2|raw|iso|cosi)" help:"Format of output image." enum:"${imageformat}" default:""`
+	ConfigFile               string   `name:"config-file" help:"Path of the image customization config file." required:""`
+	RpmSources               []string `name:"rpm-source" help:"Path to a RPM repo config file or a directory containing RPMs."`
+	DisableBaseImageRpmRepos bool     `name:"disable-base-image-rpm-repos" help:"Disable the base image's RPM repos as an RPM source."`
+	OutputPXEArtifactsDir    string   `name:"output-pxe-artifacts-dir" help:"Create a directory with customized image PXE booting artifacts. '--output-image-format' must be set to 'iso'."`
+}
 
-	buildDir                 = app.Flag("build-dir", "Directory to run build out of.").Required().String()
-	inputImageFile           = app.Flag("image-file", "Path of the base Azure Linux image which the customization will be applied to.").String()
-	outputImageFile          = app.Flag("output-image-file", "Path to write the customized image to.").String()
-	outputImageFormat        = app.Flag("output-image-format", fmt.Sprintf("Format of output image. Supported: %s.", strings.Join(imagecustomizerapi.SupportedImageFormatTypes(), ", "))).Enum(imagecustomizerapi.SupportedImageFormatTypes()...)
-	configFile               = app.Flag("config-file", "Path of the image customization config file.").Required().String()
-	rpmSources               = app.Flag("rpm-source", "Path to a RPM repo config file or a directory containing RPMs.").Strings()
-	disableBaseImageRpmRepos = app.Flag("disable-base-image-rpm-repos", "Disable the base image's RPM repos as an RPM source").Bool()
-	outputPXEArtifactsDir    = app.Flag("output-pxe-artifacts-dir", "Create a directory with customized image PXE booting artifacts. '--output-image-format' must be set to 'iso'.").String()
-	logFlags                 = exe.SetupLogFlags(app)
-	timestampFile            = app.Flag("timestamp-file", "File that stores timestamps for this program.").String()
-)
+type RootCmd struct {
+	Build         BuildCmd         `name:"build" cmd:"" default:"withargs" help:"Customizes a pre-built Azure Linux image."`
+	Version       kong.VersionFlag `name:"version" help:"Print version information and quit"`
+	TimeStampFile string           `name:"timestamp-file" help:"File that stores timestamps for this program."`
+	exekong.LogFlags
+}
 
 func main() {
-	var err error
+	cli := &RootCmd{}
 
-	app.Version(imagecustomizerlib.ToolVersion)
-	kingpin.MustParse(app.Parse(os.Args[1:]))
+	vars := kong.Vars{
+		"imageformat": strings.Join(imagecustomizerapi.SupportedImageFormatTypes(), ",") + ",",
+		"version":     imagecustomizerlib.ToolVersion,
+	}
+	maps.Copy(vars, exekong.KongVars)
 
-	logger.InitBestEffort(logFlags)
+	parseContext := kong.Parse(cli,
+		vars,
+		kong.HelpOptions{
+			Compact:   true,
+			FlagsLast: true,
+		},
+		kong.UsageOnError())
 
-	if *timestampFile != "" {
-		timestamp.BeginTiming("imagecustomizer", *timestampFile)
+	logger.InitBestEffort(ptrutils.PtrTo(cli.LogFlags.AsLoggerFlags()))
+
+	if cli.TimeStampFile != "" {
+		timestamp.BeginTiming("imagecustomizer", cli.TimeStampFile)
 		defer timestamp.CompleteTiming()
 	}
 
-	err = customizeImage()
-	if err != nil {
-		log.Fatalf("image customization failed:\n%v", err)
+	switch parseContext.Command() {
+	case "build":
+		err := customizeImage(cli.Build)
+		if err != nil {
+			log.Fatalf("image customization failed:\n%v", err)
+		}
+
+	default:
+		panic(parseContext.Command())
 	}
 }
 
-func customizeImage() error {
-	err := imagecustomizerlib.CustomizeImageWithConfigFile(*buildDir, *configFile, *inputImageFile,
-		*rpmSources, *outputImageFile, *outputImageFormat, *outputPXEArtifactsDir,
-		!*disableBaseImageRpmRepos)
+func customizeImage(buildCmd BuildCmd) error {
+	err := imagecustomizerlib.CustomizeImageWithConfigFile(buildCmd.BuildDir, buildCmd.ConfigFile,
+		buildCmd.InputImageFile, buildCmd.RpmSources, buildCmd.OutputImageFile, buildCmd.OutputImageFormat,
+		buildCmd.OutputPXEArtifactsDir, !buildCmd.DisableBaseImageRpmRepos)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/internal/exekong/exekong.go
+++ b/toolkit/tools/internal/exekong/exekong.go
@@ -1,0 +1,32 @@
+package exekong
+
+import (
+	"strings"
+
+	"github.com/alecthomas/kong"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
+)
+
+var (
+	KongVars = kong.Vars{
+		"logcolorhelp":   logger.ColorFlagHelp,
+		"logcolorvalues": strings.Join(logger.Colors(), ", ") + ",",
+		"logfilehelp":    logger.FileFlagHelp,
+		"loglevelhelp":   logger.LevelsHelp,
+		"loglevelvalues": strings.Join(logger.Levels(), ", ") + ",",
+	}
+)
+
+type LogFlags struct {
+	LogColor string `name:"log-color" placeholder:"(always|auto|never)" help:"${logcolorhelp}" enum:"${logcolorvalues}" default:""`
+	LogFile  string `name:"log-file" help:"${logfilehelp}"`
+	LogLevel string `name:"log-level" placeholder:"(panic|fatal|error|warn|info|debug|trace)" help:"${loglevelhelp}" enum:"${loglevelvalues}" default:""`
+}
+
+func (f LogFlags) AsLoggerFlags() logger.LogFlags {
+	return logger.LogFlags{
+		LogColor: &f.LogColor,
+		LogFile:  &f.LogFile,
+		LogLevel: &f.LogLevel,
+	}
+}


### PR DESCRIPTION
Switch from the kingpin CLI parser to using kong instead. Kong is the successor of kingpin and is more actively maintained. This means that some of the warts have been fixed and there are more features available. In particular, kong has an inbuilt option to print usage on error.

This change also introduces a `build` sub-command. If no command is specified, `build` is the default command. This will allow us to easily add other sub-commands in the future. For example, `validate-config`.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
