### PR TITLE
Stop all chroot processes before unmounting chroot.

### DIFF
--- a/docs/imagecustomizer/how-to/quick-start.md
+++ b/docs/imagecustomizer/how-to/quick-start.md
@@ -25,14 +25,14 @@ nav_order: 1
    `udevadm`, `flock`, `blkid`, `openssl`, `sed`, `createrepo`, `mksquashfs`,
    `genisoimage`, `mkfs`, `mkfs.ext4`, `mkfs.vfat`, `mkfs.xfs`, `fsck`,
    `e2fsck`, `xfs_repair`, `resize2fs`, `tune2fs`, `xfs_admin`, `fatlabel`, `zstd`,
-   `veritysetup`, `grub2-install` (or `grub-install`), `ukify`, `objcopy`.
+   `veritysetup`, `grub2-install` (or `grub-install`), `ukify`, `objcopy`, `lsof`.
 
    - For Ubuntu 22.04 images, run:
 
      ```bash
      sudo apt -y install qemu-utils rpm coreutils util-linux mount fdisk udev openssl \
         sed createrepo-c squashfs-tools genisoimage e2fsprogs dosfstools \
-        xfsprogs zstd cryptsetup-bin grub2-common binutils
+        xfsprogs zstd cryptsetup-bin grub2-common binutils lsof
      ```
 
    - For Azure Linux 2.0, run:
@@ -40,7 +40,7 @@ nav_order: 1
      ```bash
      sudo tdnf install -y qemu-img rpm coreutils util-linux systemd openssl \
         sed createrepo_c squashfs-tools cdrkit e2fsprogs dosfstools \
-        xfsprogs zstd veritysetup grub2 grub2-pc binutils
+        xfsprogs zstd veritysetup grub2 grub2-pc binutils lsof
      ```
 
    - For Azure Linux 3.0, run:
@@ -48,7 +48,7 @@ nav_order: 1
      ```bash
      sudo tdnf install -y qemu-img rpm coreutils util-linux systemd openssl \
         sed createrepo_c squashfs-tools cdrkit e2fsprogs dosfstools \
-        xfsprogs zstd veritysetup grub2 grub2-pc systemd-ukify binutils
+        xfsprogs zstd veritysetup grub2 grub2-pc systemd-ukify binutils lsof
      ```
 
    Note: The `ukify` tool is not available in Ubuntu 22.04 or Azure Linux 2.0. So, you

--- a/toolkit/tools/imagecustomizer/container/prism.Dockerfile
+++ b/toolkit/tools/imagecustomizer/container/prism.Dockerfile
@@ -5,6 +5,6 @@ FROM mcr.microsoft.com/azurelinux/base/core:3.0
 RUN tdnf update -y && \
    tdnf install -y qemu-img rpm coreutils util-linux systemd openssl \
       sed createrepo_c squashfs-tools cdrkit parted e2fsprogs dosfstools \
-      xfsprogs zstd veritysetup grub2 grub2-pc systemd-ukify binutils
+      xfsprogs zstd veritysetup grub2 grub2-pc systemd-ukify binutils lsof
 
 COPY . /

--- a/toolkit/tools/internal/processes/processes.go
+++ b/toolkit/tools/internal/processes/processes.go
@@ -1,0 +1,96 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package processes
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/shell"
+	"github.com/sirupsen/logrus"
+)
+
+type ProcessRecord struct {
+	ProcessId   int
+	ProcessName string
+	ProcessRoot string
+}
+
+func GetProcessesUsingPath(path string) ([]ProcessRecord, error) {
+	stdout, _, err := shell.NewExecBuilder("lsof", "-Q", "-F", "pcn", "--", path).
+		LogLevel(logrus.TraceLevel, logrus.DebugLevel).
+		ExecuteCaptureOuput()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list running processes using path (%s) using lsof\n%w", path,
+			err)
+	}
+
+	records := []ProcessRecord(nil)
+	record := ProcessRecord{
+		ProcessId: -1,
+	}
+	scanner := bufio.NewScanner(strings.NewReader(stdout))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if len(line) < 0 {
+			continue
+		}
+
+		prefix := line[0]
+		value := line[1:]
+		switch prefix {
+		case 'p':
+			if record.ProcessId >= 0 {
+				// Add previous item.
+				records = append(records, record)
+			}
+
+			record = ProcessRecord{}
+
+			record.ProcessId, err = strconv.Atoi(value)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse process ID string (%s):\n%w", value, err)
+			}
+
+			record.ProcessRoot, err = os.Readlink(fmt.Sprintf("/proc/%d/root", record.ProcessId))
+			if err != nil {
+				return nil, fmt.Errorf("failed to read process chroot path (%d):\n%w", record.ProcessId, err)
+			}
+
+		case 'c':
+			record.ProcessName = value
+
+		case 'n':
+			// 'n' is only requested so that it is in the trace logs.
+		}
+	}
+
+	if record.ProcessId >= 0 {
+		// Add last item.
+		records = append(records, record)
+	}
+
+	return records, nil
+}
+
+func StopProcessById(pid int) error {
+	logger.Log.Debugf("Stopping process: Pid=%d.", pid)
+
+	process, err := os.FindProcess(pid)
+	defer process.Release()
+	if err != nil {
+		return fmt.Errorf("failed to find process (%d) to stop:\n%w", pid, err)
+	}
+
+	err = process.Signal(os.Interrupt)
+	if err != nil {
+		return fmt.Errorf("failed to stop process (%d):\n%w", pid, err)
+	}
+
+	return nil
+}

--- a/toolkit/tools/internal/processes/processes.go
+++ b/toolkit/tools/internal/processes/processes.go
@@ -38,7 +38,7 @@ func GetProcessesUsingPath(path string) ([]ProcessRecord, error) {
 	scanner := bufio.NewScanner(strings.NewReader(stdout))
 	for scanner.Scan() {
 		line := scanner.Text()
-		if len(line) < 0 {
+		if len(line) <= 0 {
 			continue
 		}
 

--- a/toolkit/tools/internal/processes/processes.go
+++ b/toolkit/tools/internal/processes/processes.go
@@ -21,6 +21,7 @@ type ProcessRecord struct {
 	ProcessRoot string
 }
 
+// GetProcessesUsingPath returns a list of all the processes that have a file opened under the provided path.
 func GetProcessesUsingPath(path string) ([]ProcessRecord, error) {
 	stdout, _, err := shell.NewExecBuilder("lsof", "-Q", "-F", "pcn", "--", path).
 		LogLevel(logrus.TraceLevel, logrus.DebugLevel).


### PR DESCRIPTION
Some Linux tools like to start services in the background. For example, `tdnf`/`dnf` will start `gpg-agent` when installing packages. If these processes aren't stopped, then the chroot can't close properly and an error occurs.

We have existing logic for stopping `gpg-agent`. But this same problem can occur for other processes as well. So, this change modifies the logic to stop all proceses started inside the chroot.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
