### PR TITLE
Prism: stop deleting the output folder before exporting the PXE artifacts

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -1842,14 +1842,8 @@ func populatePXEArtifactsDir(isoImagePath string, buildDir string, outputPXEArti
 
 	logger.Log.Infof("Copying PXE artifacts to (%s)", outputPXEArtifactsDir)
 
-	// Ensure output folder is clean.
-	err := os.RemoveAll(outputPXEArtifactsDir)
-	if err != nil {
-		return fmt.Errorf("failed to remove (%s):\n%w", outputPXEArtifactsDir, err)
-	}
-
 	// Extract all files from the iso image file.
-	err = extractIsoImageContents(buildDir, isoImagePath, outputPXEArtifactsDir)
+	err := extractIsoImageContents(buildDir, isoImagePath, outputPXEArtifactsDir)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Prism: stop deleting the output folder before exporting the PXE artifacts

<!-- Description: Please provide a summary of the changes and the motivation behind them. -->
When the `--output-pxe-artifacts-dir` is specified, Prism deletes that folder and then re-creates it before place the PXE artifacts there.

The problem is that if Prism is called from a container, and that folder happens to be a mapped folder from the host, then Prism will fail to delete it, and then fail to export the artifacts.

The deletion was put in place for cases where the tool is being re-run and different sets of artifacts are being saved to the same location over and over. We want to ensure we start from a clean state.

A work around for the user is not to map that folder at the container level. Instead, use a sub-folder of an already mapped folder. That way, Prism should be able to delete/re-create that subfolder.

---

### **Checklist**
- [n/a] Tests added/updated
- [n/a] Documentation updated (if needed)
- [x] Code conforms to style guidelines
