### PR TITLE
Install packages in single batch.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
@@ -213,7 +213,7 @@ func TestCustomizeImagePackagesDiskSpace(t *testing.T) {
 	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
 		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
 	assert.ErrorContains(t, err, "failed to customize raw image")
-	assert.ErrorContains(t, err, "failed to install package (gcc)")
+	assert.ErrorContains(t, err, "failed to install packages ([gcc])")
 }
 
 func ensureTdnfCacheCleanup(t *testing.T, imageConnection *ImageConnection, dirPath string) {

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/packages-add-large.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/packages-add-large.yaml
@@ -1,0 +1,62 @@
+storage:
+  disks:
+  - partitionTableType: gpt
+    partitions:
+    - id: esp
+      type: esp
+      size: 8M
+
+    - id: rootfs
+      size: 10G
+
+  bootType: efi
+
+  filesystems:
+  - deviceId: esp
+    type: fat32
+    mountPoint:
+      path: /boot/efi
+      options: umask=0077
+
+  - deviceId: rootfs
+    type: ext4
+    mountPoint:
+      path: /
+
+os:
+  bootloader:
+    resetType: hard-reset
+
+  packages:
+    install:
+      # Install a large number of packages, mainly by picking packages with lots of dependencies.
+    - llvm
+    - gcc
+    - clang
+    - kubernetes
+    - fluent-bit
+    - kernel-devel
+    - perl
+    - python3
+    - ocaml
+    - mariadb
+    - ceph
+    - curl
+    - lvm2
+    - etcd
+    - fuse
+    - gdb
+    - golang
+    - grpc
+    - java
+    - lldb
+    - lua
+    - moby-engine
+    - nodejs
+    - postgresql
+    - qemu
+    - libvirt
+    - ruby
+    - rust
+    - xz
+    - zstd


### PR DESCRIPTION
When installing packages, instead of calling `tdnf` for each package, install all the packages in a single call to `tdnf`. This has a number of advantages including reducing the number of calls to `dracut` and allowing tdnf's RPM dependency solver to work more effectively.

In addition, add more of the tdnf logs to the DEBUG level to make it easier for the user to track package installation progress.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
