### PR TITLE
Support older lsof versions.

### DIFF
--- a/toolkit/tools/internal/processes/processes.go
+++ b/toolkit/tools/internal/processes/processes.go
@@ -7,12 +7,19 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"regexp"
 	"strconv"
 	"strings"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/shell"
 	"github.com/sirupsen/logrus"
+)
+
+var (
+	// Example:
+	//     revision: 4.93.2
+	lsofVersionRegexp = regexp.MustCompile(`(?m)^\s*revision:\s+(\d+)\.(\d+)\.\d+\s*$`)
 )
 
 type ProcessRecord struct {
@@ -23,10 +30,30 @@ type ProcessRecord struct {
 
 // GetProcessesUsingPath returns a list of all the processes that have a file opened under the provided path.
 func GetProcessesUsingPath(path string) ([]ProcessRecord, error) {
-	stdout, _, err := shell.NewExecBuilder("lsof", "-Q", "-F", "pcn", "--", path).
+	lsofVersionMajor, lsofVersionMinor, err := getLsofVersion()
+	if err != nil {
+		return nil, err
+	}
+
+	qArgAvailable := lsofVersionMajor > 4 || (lsofVersionMajor == 4 && lsofVersionMinor >= 95)
+
+	args := []string(nil)
+	if qArgAvailable {
+		args = append(args, "-Q")
+	}
+
+	args = append(args, "-F", "pcn", "--", path)
+
+	stdout, _, err := shell.NewExecBuilder("lsof", args...).
 		LogLevel(logrus.TraceLevel, logrus.DebugLevel).
 		ExecuteCaptureOuput()
 	if err != nil {
+		if !qArgAvailable {
+			// The -Q arg isn't available. So, this error could just mean there are no results.
+			// So, just hope that this is in fact the case, to avoid unexpected errors.
+			return nil, nil
+		}
+
 		return nil, fmt.Errorf("failed to list running processes using path (%s) using lsof\n%w", path,
 			err)
 	}
@@ -77,6 +104,28 @@ func GetProcessesUsingPath(path string) ([]ProcessRecord, error) {
 	}
 
 	return records, nil
+}
+
+func getLsofVersion() (int, int, error) {
+	_, stderr, err := shell.NewExecBuilder("lsof", "-v").
+		LogLevel(logrus.TraceLevel, logrus.TraceLevel).
+		ExecuteCaptureOuput()
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to get lsof's version:\n%w", err)
+	}
+
+	match := lsofVersionRegexp.FindStringSubmatch(stderr)
+	if match == nil {
+		return 0, 0, fmt.Errorf("failed to parse lsof version string")
+	}
+
+	majorStr := match[1]
+	minorStr := match[2]
+
+	major, _ := strconv.Atoi(majorStr)
+	minor, _ := strconv.Atoi(minorStr)
+
+	return major, minor, nil
 }
 
 func StopProcessById(pid int) error {

--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -513,7 +513,7 @@ func (c *Chroot) Close(leaveOnDisk bool) (err error) {
 		err = c.stopRunningProcesses()
 		if err != nil {
 			// Don't want to leave a stale root if GPG components fail to exit. Logging a Warn and letting close continue...
-			logger.Log.Warnf("Failed to stop running processes while tearing down the (%s) chroot: %s", c.rootDir, err)
+			logger.Log.Warnf("Failed to stop running processes while tearing down the (%s) chroot:\n%s", c.rootDir, err)
 		}
 
 		// mount is only supported in regular pipeline


### PR DESCRIPTION
Older versions of lsof don't support the `-Q` argument. So, detect when an older version of `lsof` is being used and apply a workaround.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
