### PR TITLE
Remove REBUILD_TOOLS from Makefile.

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -72,7 +72,7 @@ jobs:
     - name: build & test
       run: |
         pushd toolkit
-        sudo env "PATH=$PATH" make go-imager go-imagecustomizer go-osmodifier REBUILD_TOOLS=y
+        sudo env "PATH=$PATH" make go-imager go-imagecustomizer go-osmodifier
 
     - name: check schema.json is up-to-date
       run: |

--- a/test/vmtests/Makefile
+++ b/test/vmtests/Makefile
@@ -58,7 +58,7 @@ fix-black:
 
 .PHONY: ${IMAGE_CUSTOMIZER_BIN}
 ${IMAGE_CUSTOMIZER_BIN}:
-	${MAKE} -C ${TOOLKIT_DIR} go-imagecustomizer REBUILD_TOOLS=y
+	${MAKE} -C ${TOOLKIT_DIR} go-imagecustomizer
 
 .PHONY: image-customizer-container
 image-customizer-container: ${IMAGE_CUSTOMIZER_BIN}


### PR DESCRIPTION
Remove the need to specify `REBUILD_TOOLS=y` when building. This was inherited from the Azure Linux build system and isn't needed here.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
