### PR TITLE
Use 64 bit integers when shrinking partitions.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
@@ -21,6 +21,11 @@ func shrinkFilesystems(imageLoopDevice string) error {
 		return err
 	}
 
+	sectorSize, _, err := diskutils.GetSectorSize(imageLoopDevice)
+	if err != nil {
+		return fmt.Errorf("failed to get disk (%s) sector size:\n%w", imageLoopDevice, err)
+	}
+
 	for _, diskPartition := range diskPartitions {
 		if diskPartition.Type != "part" {
 			continue
@@ -37,67 +42,93 @@ func shrinkFilesystems(imageLoopDevice string) error {
 
 		logger.Log.Infof("Shrinking partition (%s)", partitionLoopDevice)
 
-		partitionNumber, err := getPartitionNum(partitionLoopDevice)
-		if err != nil {
-			return err
+		fileSystemSizeInBytes := uint64(0)
+		switch fstype {
+		case "ext2", "ext3", "ext4":
+			fileSystemSizeInBytes, err = shrinkExt4FileSystem(partitionLoopDevice, imageLoopDevice)
+			if err != nil {
+				return fmt.Errorf("failed to shrink %s filesystem (%s):\n%w", fstype, partitionLoopDevice, err)
+			}
+
+		default:
+			continue
 		}
 
-		// Check the file system with e2fsck
-		err = shell.ExecuteLive(true /*squashErrors*/, "e2fsck", "-fy", partitionLoopDevice)
-		if err != nil {
-			return fmt.Errorf("failed to check (%s) with e2fsck:\n%w", partitionLoopDevice, err)
-		}
-
-		// Shrink the file system with resize2fs -M
-		stdout, stderr, err := shell.Execute("flock", "--timeout", "5", imageLoopDevice,
-			"resize2fs", "-M", partitionLoopDevice)
-		if err != nil {
-			return fmt.Errorf("failed to resize (%s) with resize2fs (and flock):\n%v", partitionLoopDevice, stderr)
-		}
-
-		// Find the new partition end value
-		filesystemSizeInSectors, err := getFilesystemSizeInSectors(stdout, stderr, imageLoopDevice)
-		if err != nil {
-			return fmt.Errorf("failed to parse new filesystem size:\n%w", err)
-		}
-
-		if filesystemSizeInSectors < 0 {
-			// Filesystem wasn't resized. So, there is no need to resize the partition.
+		if fileSystemSizeInBytes == 0 {
+			// The filesystem wasn't resized. So, there is no need to resize the partition.
 			logger.Log.Infof("Filesystem is already at its min size (%s)", partitionLoopDevice)
 			continue
 		}
 
-		// Resize the partition.
-		sfdiskScript := fmt.Sprintf("unit: sectors\nsize=%d", filesystemSizeInSectors)
+		fileSystemSizeInSectors := convertBytesToSectors(fileSystemSizeInBytes, sectorSize)
 
-		err = shell.NewExecBuilder("flock", "--timeout", "5", imageLoopDevice, "sfdisk", "--lock=no",
-			"-N", strconv.Itoa(partitionNumber), imageLoopDevice).
-			Stdin(sfdiskScript).
-			LogLevel(logrus.DebugLevel, logrus.WarnLevel).
-			ErrorStderrLines(1).
-			Execute()
+		err = resizePartition(partitionLoopDevice, imageLoopDevice, fileSystemSizeInSectors)
 		if err != nil {
-			return fmt.Errorf("failed to resize partition (%s) with sfdisk (and flock):\n%v", partitionLoopDevice, stderr)
-		}
-
-		// Changes to the partition table causes all of the disk's parition /dev nodes to be deleted and then
-		// recreated. So, wait for that to finish.
-		err = diskutils.RefreshPartitions(imageLoopDevice)
-		if err != nil {
-			return fmt.Errorf("failed to wait for disk (%s) to update:\n%w", imageLoopDevice, err)
+			return err
 		}
 	}
 	return nil
 }
 
-// Get the filesystem size in sectors.
-// Returns -1 if the resize was a no-op.
-func getFilesystemSizeInSectors(resize2fsStdout string, resize2fsStderr string, imageLoopDevice string,
-) (filesystemSizeInSectors int, err error) {
+func shrinkExt4FileSystem(partitionDevice string, diskDevice string) (uint64, error) {
+	// Check the file system with e2fsck
+	err := shell.ExecuteLive(true /*squashErrors*/, "e2fsck", "-fy", partitionDevice)
+	if err != nil {
+		return 0, fmt.Errorf("failed to check (%s) with e2fsck:\n%w", partitionDevice, err)
+	}
+
+	// Shrink the file system with resize2fs -M
+	stdout, stderr, err := shell.Execute("flock", "--timeout", "5", diskDevice,
+		"resize2fs", "-M", partitionDevice)
+	if err != nil {
+		return 0, fmt.Errorf("failed to resize (%s) with resize2fs (and flock):\n%v", partitionDevice, stderr)
+	}
+
+	// Find the new partition end value
+	fileSystemSizeInBytes, err := getExt4FileSystemSizeInBytes(stdout, stderr)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse new filesystem size from resize2fs output:\n%w", err)
+	}
+
+	return fileSystemSizeInBytes, nil
+}
+
+func resizePartition(partitionDevice string, diskDevice string, newSizeInSectors uint64) error {
+	partitionNumber, err := getPartitionNum(partitionDevice)
+	if err != nil {
+		return err
+	}
+
+	// Resize the partition.
+	sfdiskScript := fmt.Sprintf("unit: sectors\nsize=%d", newSizeInSectors)
+
+	err = shell.NewExecBuilder("flock", "--timeout", "5", diskDevice, "sfdisk", "--lock=no",
+		"-N", strconv.Itoa(partitionNumber), diskDevice).
+		Stdin(sfdiskScript).
+		LogLevel(logrus.DebugLevel, logrus.WarnLevel).
+		ErrorStderrLines(1).
+		Execute()
+	if err != nil {
+		return fmt.Errorf("failed to resize partition (%s) with sfdisk (and flock):\n%w", partitionDevice, err)
+	}
+
+	// Changes to the partition table causes all of the disk's parition /dev nodes to be deleted and then
+	// recreated. So, wait for that to finish.
+	err = diskutils.RefreshPartitions(diskDevice)
+	if err != nil {
+		return fmt.Errorf("failed to wait for disk (%s) to update:\n%w", diskDevice, err)
+	}
+
+	return nil
+}
+
+// Get the filesystem size in bytes.
+// Returns 0 if the resize was a no-op.
+func getExt4FileSystemSizeInBytes(resize2fsStdout string, resize2fsStderr string) (uint64, error) {
 	const resize2fsNopMessage = "Nothing to do!"
 	if strings.Contains(resize2fsStderr, resize2fsNopMessage) {
 		// Resize operation was a no-op.
-		return -1, nil
+		return 0, nil
 	}
 
 	// Example resize2fs output first line: "Resizing the filesystem on /dev/loop44p2 to 21015 (4k) blocks."
@@ -113,41 +144,37 @@ func getFilesystemSizeInSectors(resize2fsStdout string, resize2fsStderr string, 
 			resize2fsStderr)
 	}
 
-	blockCount, err := strconv.Atoi(match[1]) // Example: 21015
+	blockCount, err := strconv.ParseUint(match[1], 10, 64) // Example: 21015
 	if err != nil {
 		return 0, fmt.Errorf("failed to parse block count (%s):\n%w", match[1], err)
 	}
-	multiplier, err := strconv.Atoi(match[2]) // Example: 4
+	multiplier, err := strconv.ParseUint(match[2], 10, 64) // Example: 4
 	if err != nil {
 		return 0, fmt.Errorf("failed to parse multiplier for block size (%s):\n%w", match[2], err)
 	}
 	unit := match[3] // Example: 'k'
 
 	// Calculate block size
-	var blockSize int
-	const KiB = 1024 // kibibyte in bytes
+	var blockSize uint64
 	switch unit {
 	case "k":
-		blockSize = multiplier * KiB
+		blockSize = multiplier * diskutils.KiB
 	default:
 		return 0, fmt.Errorf("unrecognized unit (%s)", unit)
 	}
 
-	filesystemSizeInBytes := blockCount * blockSize
+	filesystemSizeInBytes := blockCount * uint64(blockSize)
+	return filesystemSizeInBytes, nil
+}
 
-	// Get the sector size
-	logicalSectorSize, _, err := diskutils.GetSectorSize(imageLoopDevice)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get sector size:\n%w", err)
-	}
-	sectorSizeInBytes := int(logicalSectorSize) // cast from uint64 to int
-
-	filesystemSizeInSectors = filesystemSizeInBytes / sectorSizeInBytes
-	if filesystemSizeInBytes%sectorSizeInBytes != 0 {
-		filesystemSizeInSectors++
+func convertBytesToSectors(sizeInBytes uint64, sectorSizeInBytes uint64) uint64 {
+	sizeInSectors := sizeInBytes / sectorSizeInBytes
+	rem := sizeInBytes % sectorSizeInBytes
+	if rem != 0 {
+		sizeInSectors += 1
 	}
 
-	return filesystemSizeInSectors, nil
+	return sizeInSectors
 }
 
 // Checks if the provided fstype is supported by shrink filesystems.


### PR DESCRIPTION
Currently, the shrink partitions logic uses 32 bit integers. So, it can't handle disk sizes above 4 GiB. This change fixes this.

Also, refactor the shrinking logic somewhat. This is being done in preparation of shrinking verity hash partitions.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
