### PR TITLE
Shrink verity hash partition.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/safeloopback"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/safemount"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/shell"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
@@ -434,7 +435,8 @@ func customizeOSContents(ic *ImageCustomizerParameters) error {
 	ic.osRelease = osRelease
 
 	// For COSI, always shrink the filesystems.
-	if ic.outputImageFormat == imagecustomizerapi.ImageFormatTypeCosi {
+	shrinkPartitions := ic.outputImageFormat == imagecustomizerapi.ImageFormatTypeCosi
+	if shrinkPartitions {
 		err = shrinkFilesystemsHelper(ic.rawImageFile)
 		if err != nil {
 			return fmt.Errorf("failed to shrink filesystems:\n%w", err)
@@ -443,7 +445,8 @@ func customizeOSContents(ic *ImageCustomizerParameters) error {
 
 	if len(ic.config.Storage.Verity) > 0 {
 		// Customize image for dm-verity, setting up verity metadata and security features.
-		verityMetadata, err := customizeVerityImageHelper(ic.buildDirAbs, ic.config, ic.rawImageFile, partIdToPartUuid)
+		verityMetadata, err := customizeVerityImageHelper(ic.buildDirAbs, ic.config, ic.rawImageFile, partIdToPartUuid,
+			shrinkPartitions)
 		if err != nil {
 			return err
 		}
@@ -851,9 +854,9 @@ func shrinkFilesystemsHelper(buildImageFile string) error {
 }
 
 func customizeVerityImageHelper(buildDir string, config *imagecustomizerapi.Config,
-	buildImageFile string, partIdToPartUuid map[string]string,
+	buildImageFile string, partIdToPartUuid map[string]string, shrinkHashPartition bool,
 ) (map[string]verityDeviceMetadata, error) {
-	logger.Log.Debugf("Provisioning verity")
+	logger.Log.Infof("Provisioning verity")
 
 	verityMetadata := make(map[string]verityDeviceMetadata)
 
@@ -866,6 +869,11 @@ func customizeVerityImageHelper(buildDir string, config *imagecustomizerapi.Conf
 	diskPartitions, err := diskutils.GetDiskPartitions(loopback.DevicePath())
 	if err != nil {
 		return nil, err
+	}
+
+	sectorSize, _, err := diskutils.GetSectorSize(loopback.DevicePath())
+	if err != nil {
+		return nil, fmt.Errorf("failed to get disk's (%s) sector size:\n%w", loopback.DevicePath(), err)
 	}
 
 	for _, verityConfig := range config.Storage.Verity {
@@ -882,9 +890,11 @@ func customizeVerityImageHelper(buildDir string, config *imagecustomizerapi.Conf
 		}
 
 		// Extract root hash using regular expressions.
-		verityOutput, _, err := shell.Execute("veritysetup", "format", dataPartition.Path, hashPartition.Path)
+		verityOutput, _, err := shell.NewExecBuilder("veritysetup", "format", dataPartition.Path, hashPartition.Path).
+			LogLevel(logrus.DebugLevel, logrus.DebugLevel).
+			ExecuteCaptureOutput()
 		if err != nil {
-			return nil, fmt.Errorf("failed to calculate root hash:\n%w", err)
+			return nil, fmt.Errorf("failed to calculate root hash (%s):\n%w", dataPartition.Path, err)
 		}
 
 		rootHashRegex, err := regexp.Compile(`Root hash:\s+([0-9a-fA-F]+)`)
@@ -897,6 +907,38 @@ func customizeVerityImageHelper(buildDir string, config *imagecustomizerapi.Conf
 			return nil, fmt.Errorf("failed to parse root hash from veritysetup output")
 		}
 
+		rootHash := rootHashMatches[1]
+
+		err = diskutils.RefreshPartitions(loopback.DevicePath())
+		if err != nil {
+			return nil, fmt.Errorf("failed to wait for disk (%s) to update:\n%w", loopback.DevicePath(), err)
+		}
+
+		if shrinkHashPartition {
+			// Calculate the size of the hash partition from it's superblock.
+			// In newer `veritysetup` versions, `veritysetup format` returns the size in its output. But that feature
+			// is too new for now.
+			hashPartitionSizeInBytes, err := calculateHashFileSizeInBytes(hashPartition.Path)
+			if err != nil {
+				return nil, fmt.Errorf("failed to calculate hash partition's (%s) size:\n%w", hashPartition.Path, err)
+			}
+
+			hashPartitionSizeInSectors := convertBytesToSectors(hashPartitionSizeInBytes, sectorSize)
+
+			err = resizePartition(hashPartition.Path, loopback.DevicePath(), hashPartitionSizeInSectors)
+			if err != nil {
+				return nil, fmt.Errorf("failed to shrink hash partition (%s):\n%w", loopback.DevicePath(), err)
+			}
+
+			// Verify everything is still valid.
+			err = shell.NewExecBuilder("veritysetup", "verify", dataPartition.Path, hashPartition.Path, rootHash).
+				LogLevel(logrus.DebugLevel, logrus.DebugLevel).
+				Execute()
+			if err != nil {
+				return nil, fmt.Errorf("failed to verify verity (%s):\n%w", dataPartition.Path, err)
+			}
+		}
+
 		// Refresh disk partitions after running veritysetup so that the hash partition's UUID is correct.
 		diskPartitions, err = diskutils.GetDiskPartitions(loopback.DevicePath())
 		if err != nil {
@@ -904,7 +946,7 @@ func customizeVerityImageHelper(buildDir string, config *imagecustomizerapi.Conf
 		}
 
 		verityMetadata[verityConfig.MountPath] = verityDeviceMetadata{
-			rootHash:              rootHashMatches[1],
+			rootHash:              rootHash,
 			dataPartUuid:          dataPartition.PartUuid,
 			hashPartUuid:          hashPartition.PartUuid,
 			dataDeviceMountIdType: verityConfig.DataDeviceMountIdType,

--- a/toolkit/tools/pkg/imagecustomizerlib/verityutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/verityutils.go
@@ -1,0 +1,137 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerlib
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"os"
+)
+
+// From: https://gitlab.com/cryptsetup/cryptsetup/-/wikis/DMVerity
+type veritySuperBlock struct {
+	Signature     [8]uint8   // "verity\0\0"
+	Version       uint32     // Superblock version: 1
+	HashType      uint32     // 0: Chrome OS, 1: normal
+	Uuid          [16]uint8  // UUID of hash device
+	Algorithm     [32]uint8  // Hash algorithm name
+	DataBlockSize uint32     // Data block in bytes
+	HashBlockSize uint32     // Hash block in bytes
+	DataBlocks    uint64     // Number of data blocks
+	SaltSize      uint16     // Salt size
+	Pad1          [6]uint8   // Padding
+	Salt          [256]uint8 // Salt
+	Pad2          [168]uint8 // Padding
+}
+
+func calculateHashFileSizeInBytes(hashPartitionPath string) (uint64, error) {
+	hashPartition, err := os.Open(hashPartitionPath)
+	if err != nil {
+		return 0, fmt.Errorf("failed to open hash partition (%s) block device:\n%w", hashPartitionPath, err)
+	}
+	defer hashPartition.Close()
+
+	superblock := veritySuperBlock{}
+	err = binary.Read(hashPartition, binary.LittleEndian, &superblock)
+	if err != nil {
+		return 0, fmt.Errorf("failed to read hash partition's (%s) superblock:\n%w", hashPartitionPath, err)
+	}
+
+	sizeInBytes, err := calculateHashFileSizeInBytesFromSuperBlock(superblock)
+	if err != nil {
+		return 0, fmt.Errorf("hash partition's (%s) superblock is invalid:\n%w", hashPartitionPath, err)
+	}
+
+	return sizeInBytes, nil
+}
+
+func calculateHashFileSizeInBytesFromSuperBlock(superblock veritySuperBlock) (uint64, error) {
+	var err error
+
+	if string(superblock.Signature[:]) != "verity\x00\x00" {
+		return 0, fmt.Errorf("wrong superblock signature")
+	}
+
+	if superblock.Version != 1 {
+		return 0, fmt.Errorf("unsupported version (%d)", superblock.Version)
+	}
+
+	if superblock.HashType != 1 {
+		return 0, fmt.Errorf("unsupported hash type (%d)", superblock.HashType)
+	}
+
+	algorithmBytes, _, _ := bytes.Cut(superblock.Algorithm[:], []byte{0})
+	algorithm := string(algorithmBytes)
+
+	hashSize := uint32(0)
+	switch algorithm {
+	case "sha256":
+		hashSize = 32
+
+	case "sha384":
+		hashSize = 48
+
+	case "sha512":
+		hashSize = 64
+
+	default:
+		return 0, fmt.Errorf("unknown hash algorithm (%s)", algorithm)
+	}
+
+	sizeInBytes, err := calculateHashFileSizeInBytesHelper(superblock.DataBlocks, superblock.DataBlockSize,
+		superblock.HashBlockSize, hashSize)
+	if err != nil {
+		return 0, err
+	}
+
+	return sizeInBytes, nil
+}
+
+func calculateHashFileSizeInBytesHelper(dataBlocksCount uint64, dataBlockSize uint32, hashBlockSize uint32,
+	hashSize uint32,
+) (uint64, error) {
+	if !isPowerOf2(dataBlockSize) {
+		return 0, fmt.Errorf("invalid data block size (%d)", dataBlockSize)
+	}
+
+	if !isPowerOf2(hashBlockSize) || hashBlockSize < hashSize {
+		return 0, fmt.Errorf("invalid hash block size (%d)", hashBlockSize)
+	}
+
+	// dm-verity pads each hash to the nearest power-of-2 to make the math easier.
+	hashSizeFull := roundUpToPowerOf2(hashSize)
+
+	hashesPerBlock := uint64(hashBlockSize / hashSizeFull)
+
+	totalTreeBlocks := uint64(0)
+	prevLevelTreeBlocks := dataBlocksCount
+	for prevLevelTreeBlocks > 1 {
+		levelTreeBlocks := prevLevelTreeBlocks / hashesPerBlock
+		rem := prevLevelTreeBlocks % hashesPerBlock
+		if rem != 0 {
+			// Round up the nearest whole block.
+			levelTreeBlocks += 1
+		}
+
+		totalTreeBlocks += levelTreeBlocks
+		prevLevelTreeBlocks = levelTreeBlocks
+	}
+
+	totalBlocks := totalTreeBlocks + 1 // add superblock
+	totalBytes := totalBlocks * uint64(hashBlockSize)
+	return totalBytes, nil
+}
+
+func isPowerOf2(n uint32) bool {
+	return (n & (n - 1)) == 0
+}
+
+func roundUpToPowerOf2(n uint32) uint32 {
+	res := uint32(1)
+	for res < n {
+		res *= 2
+	}
+	return res
+}


### PR DESCRIPTION
When partitions are shrunk (e.g. when outputting COSI files), also shrink the verity hash partitons. This ensures that COSI files don't contain any unnecessary data.

This change might also be useful in the future, if and when we ever decide to implement an API that automatically calulates the size of verity hash partitions, instead of requiring the user to manually specify the size.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
