### PR TITLE
Fix `TestCustomizeImageVerityCosiShrinkExtract'.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
@@ -177,13 +177,13 @@ func testCustomizeImageVerityCosiExtractHelper(t *testing.T, testName string, im
 
 	// Check partition sizes.
 	assert.Equal(t, int64(8*diskutils.MiB), espStat.Size())
-	assert.Equal(t, int64(100*diskutils.MiB), hashStat.Size())
 
 	// These partitions are shrunk. Their final size will vary based on base image version, package versions, filesystem
 	// implementation details, and randomness. So, just enforce that the final size is below an arbitary value. Values
 	// were picked by observing values seen during test and adding a good buffer.
 	assert.Greater(t, int64(150*diskutils.MiB), bootStat.Size())
 	assert.Greater(t, int64(650*diskutils.MiB), rootStat.Size())
+	assert.Greater(t, int64(10*diskutils.MiB), hashStat.Size())
 	assert.Greater(t, int64(150*diskutils.MiB), varStat.Size())
 
 	bootDevice, err := safeloopback.NewLoopback(bootPartitionPath)


### PR DESCRIPTION
PR #201 introduced shrinking the verity hash partition. But that change forgot to update the tests.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
