### PR TITLE
Fix verity corruption option.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
@@ -74,5 +74,5 @@ func TestCustomizeImageVerityUsrUki(t *testing.T) {
 	usrDevice := partitionDevPath(imageConnection, 3)
 	usrHashDevice := partitionDevPath(imageConnection, 4)
 	verifyVerityUki(t, espPath, usrDevice, usrHashDevice, "PARTUUID="+partitions[3].PartUuid,
-		"PARTUUID="+partitions[4].PartUuid, "usr", buildDir, "rd.info")
+		"PARTUUID="+partitions[4].PartUuid, "usr", buildDir, "rd.info", "panic-on-corruption")
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
@@ -195,7 +195,7 @@ func constructVerityKernelCmdlineArgs(verityMetadata map[string]verityDeviceMeta
 			return nil, err
 		}
 
-		formattedCorruptionOption, err := SystemdFormatCorruptionOption(imagecustomizerapi.CorruptionOptionPanic)
+		formattedCorruptionOption, err := SystemdFormatCorruptionOption(metadata.corruptionOption)
 		if err != nil {
 			return nil, err
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -84,6 +84,7 @@ type verityDeviceMetadata struct {
 	hashPartUuid          string
 	dataDeviceMountIdType imagecustomizerapi.MountIdentifierType
 	hashDeviceMountIdType imagecustomizerapi.MountIdentifierType
+	corruptionOption      imagecustomizerapi.CorruptionOption
 }
 
 func createImageCustomizerParameters(buildDir string,
@@ -974,6 +975,7 @@ func customizeVerityImageHelper(buildDir string, config *imagecustomizerapi.Conf
 			hashPartUuid:          hashPartition.PartUuid,
 			dataDeviceMountIdType: verityConfig.DataDeviceMountIdType,
 			hashDeviceMountIdType: verityConfig.HashDeviceMountIdType,
+			corruptionOption:      verityConfig.CorruptionOption,
 		}
 	}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-config.yaml
@@ -24,7 +24,7 @@ storage:
     name: usr
     dataDeviceId: usr
     hashDeviceId: usrhash
-    corruptionOption: panic
+    corruptionOption: io-error
 
   filesystems:
   - deviceId: esp


### PR DESCRIPTION
PR #103 accidentally removed the logic that handles 'corruptionOption'. So, fix that. Also, change the existing verity tests to also verify 'corruptionOption'.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
