### PR TITLE
MIC: De-duplicate files in LiveOS ISOs.

### DIFF
--- a/toolkit/tools/internal/isogenerator/isogenerator.go
+++ b/toolkit/tools/internal/isogenerator/isogenerator.go
@@ -224,12 +224,17 @@ func setUpIsoGrub2Bootloader(info isoGenInfo) (err error) {
 	}
 	defer os.RemoveAll(extractedShimDir)
 
-	shimFileName := "bootx64.efi"
-	grubFileName := "grubx64.efi"
-
-	if runtime.GOARCH == "arm64" {
+	shimFileName := ""
+	grubFileName := ""
+	switch runtime.GOARCH {
+	case "arm64":
 		shimFileName = "bootaa64.efi"
 		grubFileName = "grubaa64.efi"
+	case "amd64":
+		shimFileName = "bootx64.efi"
+		grubFileName = "grubx64.efi"
+	default:
+		return fmt.Errorf("failed to determine shim/grub efi file names. Unsupported host architecture (%s)", runtime.GOARCH)
 	}
 
 	// Extract the shim/grub binaries.

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -521,13 +521,13 @@ func convertWriteableFormatToOutputImage(ic *ImageCustomizerParameters, inputIso
 				requestedSELinuxMode = ic.config.OS.SELinux.Mode
 			}
 			err := createLiveOSIsoImage(ic.buildDirAbs, ic.configPath, inputIsoArtifacts, requestedSELinuxMode, ic.config.Iso, ic.config.Pxe,
-				ic.rawImageFile, ic.outputImageDir, ic.outputImageBase, ic.outputPXEArtifactsDir)
+				ic.rawImageFile, ic.outputImageFile, ic.outputPXEArtifactsDir)
 			if err != nil {
 				return fmt.Errorf("failed to create LiveOS iso image:\n%w", err)
 			}
 		} else {
 			err := inputIsoArtifacts.createImageFromUnchangedOS(ic.configPath, ic.config.Iso, ic.config.Pxe,
-				ic.outputImageDir, ic.outputImageBase, ic.outputPXEArtifactsDir)
+				ic.outputImageFile, ic.outputPXEArtifactsDir)
 			if err != nil {
 				return fmt.Errorf("failed to create LiveOS iso image:\n%w", err)
 			}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -317,7 +317,7 @@ func convertInputImageToWriteableFormat(ic *ImageCustomizerParameters) (*LiveOSI
 		// it. If no OS customizations are defined, we can skip this step and
 		// just re-use the existing squashfs.
 		if ic.customizeOSPartitions {
-			err = inputIsoArtifacts.createWriteableImageFromSquashfs(ic.buildDirAbs, ic.rawImageFile)
+			err = inputIsoArtifacts.createWriteableImageFromArtifacts(ic.buildDirAbs, ic.rawImageFile)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create writeable image:\n%w", err)
 			}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -1923,8 +1923,6 @@ func stageIsoFiles(artifacts IsoArtifacts, baseConfigPath string, additionalIsoF
 
 	// map of file full local path to location on iso media.
 	artifactsToIsoMap := map[string]string{
-		artifacts.bootEfiPath:       "efi/boot",
-		artifacts.grubEfiPath:       "efi/boot",
 		artifacts.isoBootImagePath:  "boot/grub2",
 		artifacts.isoGrubCfgPath:    "boot/grub2",
 		artifacts.vmlinuzPath:       "boot",
@@ -1991,6 +1989,12 @@ func stageIsoFiles(artifacts IsoArtifacts, baseConfigPath string, additionalIsoF
 	err = safechroot.AddFilesToDestination(stagingDir, filesToCopy...)
 	if err != nil {
 		return fmt.Errorf("failed to stage config-defined additional files:\n%w", err)
+	}
+
+	// Apply Rufus workaround
+	err = isogenerator.ApplyRufusWorkaround(artifacts.bootEfiPath, artifacts.grubEfiPath, stagingDir)
+	if err != nil {
+		return fmt.Errorf("failed to apply Rufus work-around:\n%w", err)
 	}
 
 	return nil

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -2005,7 +2005,9 @@ func (b *LiveOSIsoBuilder) createIsoImage(outputImagePath string) error {
 		return fmt.Errorf("failed to stage one or more iso files:\n%w", err)
 	}
 
-	err = isogenerator.BuildIsoImage(stagingDir, outputImagePath)
+	biosBootEnabled := false
+	biosFilesDirPath := ""
+	err = isogenerator.BuildIsoImage(stagingDir, biosBootEnabled, biosFilesDirPath, outputImagePath)
 	if err != nil {
 		return fmt.Errorf("failed to create (%s) using the (%s) folder:\n%w", outputImagePath, stagingDir, err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -56,12 +56,15 @@ const (
 	rootValueLiveOSTemplate = "live:LABEL=%s"
 	rootValuePxeTemplate    = "live:%s"
 
-	isoBootDir        = "boot"
-	initrdImage       = "initrd.img"
-	vmLinuzPrefix     = "vmlinuz-"
+	isoBootDir  = "boot"
+	initrdImage = "initrd.img"
+	// In vhd(x)/qcow images, the kernel is named 'vmlinuz-<version>'.
+	// In the ISO image, the kernel is named 'vmlinuz'.
+	vmLinuzPrefix     = "vmlinuz"
 	isoInitrdPath     = "/boot/" + initrdImage
 	isoKernelPath     = "/boot/vmlinuz"
 	isoBootloadersDir = "/efi/boot"
+	isoBootImagePath  = "/boot/grub2/efiboot.img"
 
 	// This folder is necessary to include in the initrd image so that the
 	// emergency shell can work correctly with the keyboard.
@@ -152,6 +155,7 @@ type IsoArtifacts struct {
 	selinuxPolicyPackageInfo *PackageVersionInformation
 	bootEfiPath              string
 	grubEfiPath              string
+	isoBootImagePath         string
 	isoGrubCfgPath           string
 	pxeGrubCfgPath           string
 	savedConfigsFilePath     string
@@ -201,24 +205,6 @@ func (b *LiveOSIsoBuilder) cleanUp() error {
 	return err
 }
 
-type isoImageNameInfo struct {
-	tag            string
-	releaseVersion string
-	baseName       string
-	name           string // derived from the other fields.
-}
-
-func getImageNameFromImageBaseName(isoOutputBaseName string) isoImageNameInfo {
-	// isoMaker constructs the final image name as follows:
-	// {isoOutputBaseName}{releaseVersion}{imageNameTag}.iso
-	var info isoImageNameInfo
-	info.baseName = isoOutputBaseName
-	info.releaseVersion = ""
-	info.tag = ""
-	info.name = info.baseName + info.releaseVersion + info.tag + ".iso"
-	return info
-}
-
 // populateWriteableRootfsDir
 //
 //	copies the contents of the rootfs partition unto the build machine.
@@ -244,72 +230,6 @@ func (b *LiveOSIsoBuilder) populateWriteableRootfsDir(sourceDir, writeableRootfs
 	err = copyPartitionFiles(sourceDir+"/.", writeableRootfsDir)
 	if err != nil {
 		return fmt.Errorf("failed to copy rootfs contents to a writeable folder (%s):\n%w", writeableRootfsDir, err)
-	}
-
-	return nil
-}
-
-// stageIsoMakerInitrdArtifacts
-//
-//	IsoMaker looks for the vmlinuz/bootloader files inside the initrd image
-//	file under specific directory structure.
-//	This function stages those artifacts and places them under the same
-//	directory structure expected by IsoMaker.
-//	Later,  we run 'dracut' which takes this directory structure and embeds
-//	it into the initrd image.
-//	Finaly, the IsoMaker will read the initrd image and find the artifacts
-//	it needs to copy to the final iso media.
-//	Something to consider in the future: change IsoMaker so that it can pick
-//	those artifacts from the build machine directly.
-//
-// inputs:
-//   - 'writeableRootfsDir':
-//     path to an existing folder holding the contents of the rootfs.
-//   - 'isoMakerArtifactsStagingDir'
-//     path to a folder where the extracted artifacts will stored under.
-//
-// outputs:
-//
-//	the artifacts will be stored in 'isoMakerArtifactsStagingDir'.
-func (b *LiveOSIsoBuilder) stageIsoMakerInitrdArtifacts(writeableRootfsDir, isoMakerArtifactsStagingDir string) error {
-
-	logger.Log.Debugf("Staging isomaker artifacts into writeable image")
-
-	targetBootloadersInChroot := filepath.Join(isoMakerArtifactsStagingDir, "/efi/EFI/BOOT")
-	targetBootloadersDir := filepath.Join(writeableRootfsDir, targetBootloadersInChroot)
-
-	err := os.MkdirAll(targetBootloadersDir, os.ModePerm)
-	if err != nil {
-		return fmt.Errorf("failed to create %s\n%w", targetBootloadersDir, err)
-	}
-
-	_, bootFilesConfig, err := getBootArchConfig()
-	if err != nil {
-		return err
-	}
-
-	sourceBootEfiPath := b.artifacts.bootEfiPath
-	targetBootEfiPath := filepath.Join(targetBootloadersDir, bootFilesConfig.bootBinary)
-	err = file.Copy(sourceBootEfiPath, targetBootEfiPath)
-	if err != nil {
-		return fmt.Errorf("failed to stage bootloader file (%s):\n%w", bootFilesConfig.bootBinary, err)
-	}
-
-	sourceGrubEfiPath := b.artifacts.grubEfiPath
-	targetGrubEfiPath := filepath.Join(targetBootloadersDir, bootFilesConfig.grubBinary)
-
-	err = file.Copy(sourceGrubEfiPath, targetGrubEfiPath)
-	if err != nil {
-		return fmt.Errorf("failed to stage bootloader file (%s):\n%w", bootFilesConfig.grubBinary, err)
-	}
-
-	targetVmlinuzLocalDir := filepath.Join(writeableRootfsDir, isoMakerArtifactsStagingDir)
-
-	sourceVmlinuzPath := b.artifacts.vmlinuzPath
-	targetVmlinuzPath := filepath.Join(targetVmlinuzLocalDir, "vmlinuz")
-	err = file.Copy(sourceVmlinuzPath, targetVmlinuzPath)
-	if err != nil {
-		return fmt.Errorf("failed to stage vmlinuz:\n%w", err)
 	}
 
 	return nil
@@ -601,7 +521,7 @@ func generatePxeGrubCfg(inputContentString string, pxeIsoImageBaseUrl string, px
 	// If the specified URL is not a full path to an iso, append the generated
 	// iso file name to it.
 	if pxeIsoImageFileUrl == "" {
-		pxeIsoImageFileUrl, err = url.JoinPath(pxeIsoImageBaseUrl, getImageNameFromImageBaseName(outputImageBase).name)
+		pxeIsoImageFileUrl, err = url.JoinPath(pxeIsoImageBaseUrl, outputImageBase)
 		if err != nil {
 			return fmt.Errorf("failed to concatenate URL (%s) and (%s)\n%w", pxeIsoImageBaseUrl, outputImageBase, err)
 		}
@@ -893,10 +813,6 @@ func getSELinuxMode(imageChroot *safechroot.Chroot) (imagecustomizerapi.SELinuxM
 //   - 'inputSavedConfigsFilePath':
 //   - writeableRootfsDir:
 //     A writeable folder where the rootfs content is.
-//   - 'isoMakerArtifactsStagingDir':
-//     The folder where the artifacts needed by isoMaker will be staged before
-//     'dracut' is run. 'dracut' will include this folder as-is and place it in
-//     the initrd image.
 //   - 'requestedSelinuxMode'
 //     requested selinux mode by the user (from os.selinux.mode).
 //   - 'extraCommandLine':
@@ -914,7 +830,7 @@ func getSELinuxMode(imageChroot *safechroot.Chroot) (imagecustomizerapi.SELinuxM
 //   - customized writeableRootfsDir (new files, deleted files, etc)
 //   - extracted artifacts
 func (b *LiveOSIsoBuilder) prepareLiveOSDir(inputSavedConfigsFilePath string, writeableRootfsDir string,
-	isoMakerArtifactsStagingDir string, requestedSelinuxMode imagecustomizerapi.SELinuxMode, extraCommandLine []string,
+	requestedSelinuxMode imagecustomizerapi.SELinuxMode, extraCommandLine []string,
 	pxeIsoImageBaseUrl string, pxeIsoImageFileUrl string, outputImageBase string) error {
 
 	logger.Log.Debugf("Creating LiveOS squashfs image")
@@ -1006,9 +922,10 @@ func (b *LiveOSIsoBuilder) prepareLiveOSDir(inputSavedConfigsFilePath string, wr
 		return fmt.Errorf("failed to update grub.cfg:\n%w", err)
 	}
 
-	err = b.stageIsoMakerInitrdArtifacts(writeableRootfsDir, isoMakerArtifactsStagingDir)
+	b.artifacts.isoBootImagePath = filepath.Join(b.workingDirs.isoArtifactsDir, isoBootImagePath)
+	err = isogenerator.BuildIsoBootImage(b.workingDirs.isoBuildDir, b.artifacts.bootEfiPath, b.artifacts.grubEfiPath, b.artifacts.isoBootImagePath)
 	if err != nil {
-		return fmt.Errorf("failed to stage isomaker initrd artifacts:\n%w", err)
+		return fmt.Errorf("failed to build iso boot image:\n%w", err)
 	}
 
 	err = b.prepareRootfsForDracut(writeableRootfsDir)
@@ -1031,9 +948,7 @@ func (b *LiveOSIsoBuilder) prepareLiveOSDir(inputSavedConfigsFilePath string, wr
 //   - creates a squashfs image and stores its path in
 //     b.artifacts.squashfsImagePath
 func (b *LiveOSIsoBuilder) createSquashfsImage(writeableRootfsDir string) error {
-
 	logger.Log.Debugf("Creating squashfs of %s", writeableRootfsDir)
-
 	squashfsImagePath := filepath.Join(b.workingDirs.isoArtifactsDir, liveOSImage)
 
 	exists, err := file.PathExists(squashfsImagePath)
@@ -1056,7 +971,7 @@ func (b *LiveOSIsoBuilder) createSquashfsImage(writeableRootfsDir string) error 
 	return nil
 }
 
-// generateInitrdImage
+// createInitrdImage
 //
 //	runs dracut against rootfs to create an initrd image file.
 //
@@ -1064,16 +979,10 @@ func (b *LiveOSIsoBuilder) createSquashfsImage(writeableRootfsDir string) error 
 //   - rootfsSourceDir:
 //     local folder (on the build machine) of the rootfs to be used when
 //     creating the initrd image.
-//   - artifactsSourceDir:
-//     source directory (on the build machine) holding an artifacts tree to
-//     include in the initrd image.
-//   - artifactsTargetDir:
-//     target directory (within the initrd image) where the contents of the
-//     artifactsSourceDir tree will be copied to.
 //
 // outputs:
 // - creates an initrd.img and stores its path in b.artifacts.initrdImagePath.
-func (b *LiveOSIsoBuilder) generateInitrdImage(rootfsSourceDir, artifactsSourceDir, artifactsTargetDir string) error {
+func (b *LiveOSIsoBuilder) createInitrdImage(rootfsSourceDir string) error {
 
 	logger.Log.Debugf("Generating initrd")
 
@@ -1102,7 +1011,6 @@ func (b *LiveOSIsoBuilder) generateInitrdImage(rootfsSourceDir, artifactsSourceD
 			initrdPathInChroot,
 			"--kver", b.artifacts.kernelVersion,
 			"--filesystems", "squashfs",
-			"--include", artifactsSourceDir, artifactsTargetDir,
 			"--include", usrLibLocaleDir, usrLibLocaleDir}
 
 		return shell.ExecuteLive(true /*squashErrors*/, "dracut", dracutParams...)
@@ -1113,7 +1021,7 @@ func (b *LiveOSIsoBuilder) generateInitrdImage(rootfsSourceDir, artifactsSourceD
 
 	generatedInitrdPath := filepath.Join(rootfsSourceDir, initrdPathInChroot)
 	targetInitrdPath := filepath.Join(b.workingDirs.isoArtifactsDir, initrdImage)
-	err = file.Copy(generatedInitrdPath, targetInitrdPath)
+	err = file.Move(generatedInitrdPath, targetInitrdPath)
 	if err != nil {
 		return fmt.Errorf("failed to copy generated initrd:\n%w", err)
 	}
@@ -1148,7 +1056,7 @@ func (b *LiveOSIsoBuilder) generateInitrdImage(rootfsSourceDir, artifactsSourceD
 // outputs:
 //   - all the extracted/generated artifacts will be placed in the
 //     `LiveOSIsoBuilder.workingDirs.isoArtifactsDir` folder.
-//   - the paths to individual artifaces are found in the
+//   - the paths to individual artifacts are found in the
 //     `LiveOSIsoBuilder.artifacts` data structure.
 func (b *LiveOSIsoBuilder) prepareArtifactsFromFullImage(inputSavedConfigsFilePath string, rawImageFile string, requestedSelinuxMode imagecustomizerapi.SELinuxMode,
 	extraCommandLine []string, pxeIsoImageBaseUrl string, pxeIsoImageFileUrl string, outputImageBase string) error {
@@ -1167,11 +1075,21 @@ func (b *LiveOSIsoBuilder) prepareArtifactsFromFullImage(inputSavedConfigsFilePa
 		return fmt.Errorf("failed to copy the contents of rootfs from image (%s) to local folder (%s):\n%w", rawImageFile, writeableRootfsDir, err)
 	}
 
-	isoMakerArtifactsStagingDir := "/boot-staging"
-	err = b.prepareLiveOSDir(inputSavedConfigsFilePath, writeableRootfsDir, isoMakerArtifactsStagingDir,
-		requestedSelinuxMode, extraCommandLine, pxeIsoImageBaseUrl, pxeIsoImageFileUrl, outputImageBase)
+	err = b.prepareLiveOSDir(inputSavedConfigsFilePath, writeableRootfsDir, requestedSelinuxMode, extraCommandLine,
+		pxeIsoImageBaseUrl, pxeIsoImageFileUrl, outputImageBase)
 	if err != nil {
 		return fmt.Errorf("failed to convert rootfs folder to a LiveOS folder:\n%w", err)
+	}
+
+	err = b.createInitrdImage(writeableRootfsDir)
+	if err != nil {
+		return fmt.Errorf("failed to create initrd image:\n%w", err)
+	}
+
+	logger.Log.Debugf("Removing boot folder from %s", writeableRootfsDir)
+	err = os.RemoveAll(filepath.Join(writeableRootfsDir, "boot"))
+	if err != nil {
+		return fmt.Errorf("failed to remove the /boot folder from the source image:\n%w", err)
 	}
 
 	err = b.createSquashfsImage(writeableRootfsDir)
@@ -1179,109 +1097,7 @@ func (b *LiveOSIsoBuilder) prepareArtifactsFromFullImage(inputSavedConfigsFilePa
 		return fmt.Errorf("failed to create squashfs image:\n%w", err)
 	}
 
-	isoMakerArtifactsDirInInitrd := "/boot"
-	err = b.generateInitrdImage(writeableRootfsDir, isoMakerArtifactsStagingDir, isoMakerArtifactsDirInInitrd)
-	if err != nil {
-		return fmt.Errorf("failed to generate initrd image:\n%w", err)
-	}
-
 	return nil
-}
-
-// createIsoImage
-//
-//	creates an LiveOS ISO image.
-//
-// inputs:
-//   - additionalIsoFiles:
-//     map of addition files to copy to the iso media.
-//     sourcePath -> [ targetPath0, targetPath1, ...]
-//   - isoOutputDir:
-//     path to a folder where the output image will be placed. It does not
-//     need to be created before calling this function.
-//   - isoOutputBaseName:
-//     path to the iso image to be created upon successful copmletion of this
-//     function.
-//
-// ouptuts:
-//   - create a LiveOS ISO.
-func (b *LiveOSIsoBuilder) createIsoImage(additionalIsoFiles []safechroot.FileToCopy, isoOutputDir, isoOutputBaseName string) (isoImagePath string, err error) {
-	// Construct the output image full path
-	isoImageNameInfo := getImageNameFromImageBaseName(isoOutputBaseName)
-	isoImagePath = filepath.Join(isoOutputDir, isoImageNameInfo.name)
-
-	// Add the squashfs file
-	squashfsImageToCopy := safechroot.FileToCopy{
-		Src:  b.artifacts.squashfsImagePath,
-		Dest: filepath.Join(liveOSDir, liveOSImage),
-	}
-	additionalIsoFiles = append(additionalIsoFiles, squashfsImageToCopy)
-
-	// Add /boot/* files
-	for sourceFile, targetFile := range b.artifacts.additionalFiles {
-		fileToCopy := safechroot.FileToCopy{
-			Src:           sourceFile,
-			Dest:          targetFile,
-			NoDereference: true,
-		}
-		additionalIsoFiles = append(additionalIsoFiles, fileToCopy)
-	}
-
-	// Add the iso saved config file
-	exists, err := file.PathExists(b.artifacts.savedConfigsFilePath)
-	if err != nil {
-		return "", fmt.Errorf("failed to check if (%s) exists:\n%w", b.artifacts.savedConfigsFilePath, err)
-	}
-	if exists {
-		fileToCopy := safechroot.FileToCopy{
-			Src:  b.artifacts.savedConfigsFilePath,
-			Dest: filepath.Join("/", savedConfigsDir, savedConfigsFileName),
-		}
-		additionalIsoFiles = append(additionalIsoFiles, fileToCopy)
-	}
-
-	// Add the grub-pxe.cfg file
-	exists, err = file.PathExists(b.artifacts.pxeGrubCfgPath)
-	if err != nil {
-		return "", fmt.Errorf("failed to check if (%s) exists:\n%w", b.artifacts.pxeGrubCfgPath, err)
-	}
-	if exists {
-		fileToCopy := safechroot.FileToCopy{
-			Src:  b.artifacts.pxeGrubCfgPath,
-			Dest: filepath.Join("/", grubCfgDir, pxeGrubCfg),
-		}
-		additionalIsoFiles = append(additionalIsoFiles, fileToCopy)
-	}
-
-	err = os.MkdirAll(isoOutputDir, os.ModePerm)
-	if err != nil {
-		return "", err
-	}
-
-	targetGrubCfg := filepath.Join(b.workingDirs.isomakerBuildDir, installutils.GrubCfgFile)
-	err = file.Copy(b.artifacts.isoGrubCfgPath, targetGrubCfg)
-	if err != nil {
-		return "", err
-	}
-
-	err = safechroot.AddFilesToDestination(b.workingDirs.isomakerBuildDir, additionalIsoFiles...)
-	if err != nil {
-		return "", err
-	}
-
-	err = isogenerator.GenerateIso(isogenerator.IsoGenConfig{
-		BuildDirPath:      b.workingDirs.isoBuildDir,
-		StagingDirPath:    b.workingDirs.isomakerBuildDir,
-		InitrdPath:        b.artifacts.initrdImagePath,
-		EnableBiosBoot:    false,
-		IsoOsFilesDirPath: isoBootDir,
-		OutputFilePath:    isoImagePath,
-	})
-	if err != nil {
-		return "", err
-	}
-
-	return isoImagePath, nil
 }
 
 // micIsoConfigToIsoMakerConfig
@@ -1350,11 +1166,8 @@ func micIsoConfigToIsoMakerConfig(baseConfigPath string, isoConfig *imagecustomi
 //     user provided configuration for the PXE flow.
 //   - 'rawImageFile':
 //     path to an existing raw full disk image (has boot + rootfs partitions).
-//   - 'outputImageDir':
-//     path to a folder where the generated iso will be placed.
-//   - 'outputImageBase':
-//     base name of the image to generate. The generated name will be on the
-//     form: {outputImageDir}/{outputImageBase}.iso
+//   - 'outputImagePath':
+//     path to the output image.
 //   - 'outputPXEArtifactsDir'
 //     optional directory path where the PXE artifacts will be exported to if
 //     specified.
@@ -1363,7 +1176,7 @@ func micIsoConfigToIsoMakerConfig(baseConfigPath string, isoConfig *imagecustomi
 //
 //	creates a LiveOS ISO image.
 func createLiveOSIsoImage(buildDir, baseConfigPath string, inputIsoArtifacts *LiveOSIsoBuilder, requestedSelinuxMode imagecustomizerapi.SELinuxMode,
-	isoConfig *imagecustomizerapi.Iso, pxeConfig *imagecustomizerapi.Pxe, rawImageFile, outputImageDir, outputImageBase string,
+	isoConfig *imagecustomizerapi.Iso, pxeConfig *imagecustomizerapi.Pxe, rawImageFile, outputImagePath string,
 	outputPXEArtifactsDir string) (err error) {
 
 	additionalIsoFiles, extraCommandLine, err := micIsoConfigToIsoMakerConfig(baseConfigPath, isoConfig)
@@ -1419,7 +1232,7 @@ func createLiveOSIsoImage(buildDir, baseConfigPath string, inputIsoArtifacts *Li
 		}
 	}()
 
-	// if there is an input iso, make sure to pick-up it's saved kernel args
+	// if there is an input iso, make sure to pick-up its saved kernel args
 	// file.
 	inputSavedConfigsFilePath := ""
 	if inputIsoArtifacts != nil {
@@ -1427,7 +1240,7 @@ func createLiveOSIsoImage(buildDir, baseConfigPath string, inputIsoArtifacts *Li
 	}
 
 	err = isoBuilder.prepareArtifactsFromFullImage(inputSavedConfigsFilePath, rawImageFile, requestedSelinuxMode, extraCommandLine,
-		pxeIsoImageBaseUrl, pxeIsoImageFileUrl, outputImageBase)
+		pxeIsoImageBaseUrl, pxeIsoImageFileUrl, filepath.Base(outputImagePath))
 	if err != nil {
 		return err
 	}
@@ -1454,7 +1267,7 @@ func createLiveOSIsoImage(buildDir, baseConfigPath string, inputIsoArtifacts *Li
 		}
 	}
 
-	err = isoBuilder.createIsoImageAndPXEFolder(additionalIsoFiles, outputImageDir, outputImageBase, outputPXEArtifactsDir)
+	err = isoBuilder.createIsoImageAndPXEFolder(additionalIsoFiles, outputImagePath, outputPXEArtifactsDir)
 	if err != nil {
 		return fmt.Errorf("failed to generate iso image and/or PXE artifacts folder\n%w", err)
 	}
@@ -1622,20 +1435,15 @@ func createIsoBuilderFromIsoImage(buildDir string, buildDirAbs string, isoImageF
 		switch relativeFilePath {
 		case isoBootBinaryPath:
 			isoBuilder.artifacts.bootEfiPath = isoFile
-			// isomaker will extract this from initrd and copy it to include it
-			// in the iso media - so no need to schedule it as an additional
-			// file.
 			scheduleAdditionalFile = false
 		case isoGrubBinaryPath:
-			// Note that grubx64NoPrefixBinary is not expected to on an existing
-			// iso - and hence we do not look for it here. grubx64NoPrefixBinary
-			// may exist only on a vhdx/qcow when the grub-noprefix package is
-			// installed. When such images are converted to an iso, we rename
-			// the grub binary to its regular name (grubx64.efi).
+			// Note that grubx64NoPrefixBinary is not expected to be present on
+			// an existing iso - and hence we do not look for it here.
+			// grubx64NoPrefixBinary may exist only on a vhdx/qcow when the
+			// grub-noprefix package is installed. When such images are
+			// converted to an iso, we rename the grub binary to its regular
+			// name (grubx64.efi).
 			isoBuilder.artifacts.grubEfiPath = isoFile
-			// isomaker will extract this from initrd and copy it to include it
-			// in the iso media - so no need to schedule it as an additional
-			// file.
 			scheduleAdditionalFile = false
 		case isoGrubCfgPath:
 			isoBuilder.artifacts.isoGrubCfgPath = isoFile
@@ -1650,17 +1458,15 @@ func createIsoBuilderFromIsoImage(buildDir string, buildDirAbs string, isoImageF
 			scheduleAdditionalFile = false
 		case isoInitrdPath:
 			isoBuilder.artifacts.initrdImagePath = isoFile
-			// initrd.img is passed as a parameter to isomaker.
 			scheduleAdditionalFile = false
 		case savedConfigsFileNamePath:
 			isoBuilder.artifacts.savedConfigsFilePath = isoFile
 			scheduleAdditionalFile = false
-		}
-		if strings.HasPrefix(filepath.Base(isoFile), vmLinuzPrefix) {
+		case isoKernelPath:
 			isoBuilder.artifacts.vmlinuzPath = isoFile
-			// isomaker will extract this from initrd and copy it to include it
-			// in the iso media - so no need to schedule it as an additional
-			// file.
+			scheduleAdditionalFile = false
+		case isoBootImagePath:
+			isoBuilder.artifacts.isoBootImagePath = isoFile
 			scheduleAdditionalFile = false
 		}
 
@@ -1668,6 +1474,11 @@ func createIsoBuilderFromIsoImage(buildDir string, buildDirAbs string, isoImageF
 			isoBuilder.artifacts.additionalFiles[isoFile] = strings.TrimPrefix(isoFile, isoExpansionFolder)
 		}
 	}
+
+	// Instead of creating a new 'artifacts' directory and copying everything
+	// from the expansion folder over to the artifacts folder, we use the
+	// expansion folder as the artifacts folder.
+	isoBuilder.workingDirs.isoArtifactsDir = isoExpansionFolder
 
 	return isoBuilder, nil
 }
@@ -1689,11 +1500,8 @@ func createIsoBuilderFromIsoImage(buildDir string, buildDirAbs string, isoImageF
 //     user provided configuration for the iso image.
 //   - 'pxeConfig'
 //     user provided configuration for the PXE flow.
-//   - 'outputImageDir':
-//     path to a folder where the generated iso will be placed.
-//   - 'outputImageBase':
-//     base name of the image to generate. The generated name will be on the
-//     form: {outputImageDir}/{outputImageBase}.iso
+//   - 'outputImagePath':
+//     path to a the output image.
 //   - 'outputPXEArtifactsDir'
 //     optional directory path where the PXE artifacts will be exported to if
 //     specified.
@@ -1702,7 +1510,7 @@ func createIsoBuilderFromIsoImage(buildDir string, buildDirAbs string, isoImageF
 //
 //   - creates an iso image.
 func (b *LiveOSIsoBuilder) createImageFromUnchangedOS(baseConfigPath string, isoConfig *imagecustomizerapi.Iso,
-	pxeConfig *imagecustomizerapi.Pxe, outputImageDir string, outputImageBase string, outputPXEArtifactsDir string) error {
+	pxeConfig *imagecustomizerapi.Pxe, outputImagePath string, outputPXEArtifactsDir string) error {
 
 	logger.Log.Infof("Creating LiveOS iso image using unchanged OS partitions")
 
@@ -1745,12 +1553,12 @@ func (b *LiveOSIsoBuilder) createImageFromUnchangedOS(baseConfigPath string, iso
 	// selinux and not enable it either.
 	disableSELinux := false
 
-	err = b.updateGrubCfg(b.artifacts.isoGrubCfgPath, b.artifacts.pxeGrubCfgPath, disableSELinux, updatedSavedConfigs, outputImageBase)
+	err = b.updateGrubCfg(b.artifacts.isoGrubCfgPath, b.artifacts.pxeGrubCfgPath, disableSELinux, updatedSavedConfigs, filepath.Base(outputImagePath))
 	if err != nil {
 		return fmt.Errorf("failed to update grub.cfg:\n%w", err)
 	}
 
-	err = b.createIsoImageAndPXEFolder(additionalIsoFiles, outputImageDir, outputImageBase, outputPXEArtifactsDir)
+	err = b.createIsoImageAndPXEFolder(additionalIsoFiles, outputImagePath, outputPXEArtifactsDir)
 	if err != nil {
 		return fmt.Errorf("failed to generate iso image and/or PXE artifacts folder\n%w", err)
 	}
@@ -1768,10 +1576,7 @@ func (b *LiveOSIsoBuilder) createImageFromUnchangedOS(baseConfigPath string, iso
 //   - additionalIsoFiles:
 //     map of addition files to copy to the iso media.
 //     sourcePath -> [ targetPath0, targetPath1, ...]
-//   - outputImageDir:
-//     path to a folder where the output image will be placed. It does not
-//     need to be created before calling this function.
-//   - outputImageBase:
+//   - outputIsoImage:
 //     path to the iso image to be created upon successful copmletion of this
 //     function.
 //   - 'outputPXEArtifactsDir'
@@ -1781,21 +1586,22 @@ func (b *LiveOSIsoBuilder) createImageFromUnchangedOS(baseConfigPath string, iso
 //
 //   - create an iso image.
 //   - creates a folder with PXE artifacts.
-func (b *LiveOSIsoBuilder) createIsoImageAndPXEFolder(additionalIsoFiles []safechroot.FileToCopy, outputImageDir string,
-	outputImageBase string, outputPXEArtifactsDir string) error {
-	isoImagePath, err := b.createIsoImage(additionalIsoFiles, outputImageDir, outputImageBase)
+func (b *LiveOSIsoBuilder) createIsoImageAndPXEFolder(additionalIsoFiles []safechroot.FileToCopy, outputImagePath string,
+	outputPXEArtifactsDir string) error {
+
+	err := b.createIsoImage(outputImagePath)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create the Iso image.\n%w", err)
 	}
 
 	if outputPXEArtifactsDir != "" {
 		err = verifyDracutPXESupport(b.artifacts.dracutPackageInfo)
 		if err != nil {
-			return fmt.Errorf("cannot generate the PXE artifacts folder.\n%w", err)
+			return fmt.Errorf("failed to verify Dracut's PXE support.\n%w", err)
 		}
-		err = populatePXEArtifactsDir(isoImagePath, b.workingDirs.isoBuildDir, outputPXEArtifactsDir, outputImageBase)
+		err = populatePXEArtifactsDir(outputImagePath, b.workingDirs.isoBuildDir, outputPXEArtifactsDir)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to populate the PXE artifacts folder.\n%w", err)
 		}
 	}
 
@@ -1816,14 +1622,11 @@ func (b *LiveOSIsoBuilder) createIsoImageAndPXEFolder(additionalIsoFiles []safec
 //     path to a directory to hold intermediate files.
 //   - 'outputPXEArtifactsDir'
 //     path to the output directory where the extract artifacts will be saved to.
-//   - 'outputImageBase':
-//     base name of the image to generate. The generated name will be on the
-//     form: {outputImageDir}/{outputImageBase}.iso
 //
 // outputs:
 //
 //   - creates a folder with PXE artifacts.
-func populatePXEArtifactsDir(isoImagePath string, buildDir string, outputPXEArtifactsDir string, outputImageBase string) error {
+func populatePXEArtifactsDir(isoImagePath string, buildDir string, outputPXEArtifactsDir string) error {
 
 	logger.Log.Infof("Copying PXE artifacts to (%s)", outputPXEArtifactsDir)
 
@@ -1872,7 +1675,7 @@ func populatePXEArtifactsDir(isoImagePath string, buildDir string, outputPXEArti
 
 	// The iso image file itself must be placed in the PXE folder because
 	// dracut livenet module will download it.
-	artifactsIsoImagePath := filepath.Join(outputPXEArtifactsDir, getImageNameFromImageBaseName(outputImageBase).name)
+	artifactsIsoImagePath := filepath.Join(outputPXEArtifactsDir, filepath.Base(isoImagePath))
 	err = file.Copy(isoImagePath, artifactsIsoImagePath)
 	if err != nil {
 		return fmt.Errorf("failed to copy (%s) while populating the PXE artifacts directory:\n%w", isoImagePath, err)
@@ -1952,7 +1755,7 @@ func getDiskSizeEstimateInMBs(rootDir string, safetyFactor float64) (size uint64
 	return estimatedSizeInMBs, nil
 }
 
-// createWriteableImageFromSquashfs
+// createWriteableImageFromArtifacts
 //
 //   - given a squashfs image file, it creates a writeable image with two
 //     partitions, and copies the contents of the squashfs unto that writeable
@@ -1971,7 +1774,7 @@ func getDiskSizeEstimateInMBs(rootDir string, safetyFactor float64) (size uint64
 // outputs:
 //
 //   - creates the specified writeable image.
-func (b *LiveOSIsoBuilder) createWriteableImageFromSquashfs(buildDir, rawImageFile string) error {
+func (b *LiveOSIsoBuilder) createWriteableImageFromArtifacts(buildDir, rawImageFile string) error {
 
 	logger.Log.Infof("Creating writeable image from squashfs (%s)", b.artifacts.squashfsImagePath)
 
@@ -1988,12 +1791,12 @@ func (b *LiveOSIsoBuilder) createWriteableImageFromSquashfs(buildDir, rawImageFi
 	}
 	defer squashfsLoopDevice.Close()
 
-	isoImageMount, err := safemount.NewMount(squashfsLoopDevice.DevicePath(), squashMountDir,
+	squashfsMount, err := safemount.NewMount(squashfsLoopDevice.DevicePath(), squashMountDir,
 		"squashfs" /*fstype*/, 0 /*flags*/, "" /*data*/, false /*makeAndDelete*/)
 	if err != nil {
 		return err
 	}
-	defer isoImageMount.Close()
+	defer squashfsMount.Close()
 
 	// estimate the new disk size
 	safeDiskSizeMB, err := getDiskSizeEstimateInMBs(squashMountDir, expansionSafetyFactor)
@@ -2060,6 +1863,39 @@ func (b *LiveOSIsoBuilder) createWriteableImageFromSquashfs(buildDir, rawImageFi
 		if err != nil {
 			return fmt.Errorf("failed to copy squashfs contents to a writeable disk:\n%w", err)
 		}
+
+		// Note that before the LiveOS ISO is first created, the boot folder is
+		// removed from the squashfs since it is not needed. The boot artifacts
+		// are stored directly on the ISO media outside the squashfs image.
+		// Now that we are re-constructing the full file system, we need to
+		// pull the boot artifacts back into the full file system so that
+		// it is restored to its original state and subsequent customization
+		// or extraction can proceed transparently.
+
+		artifactsBootDir := filepath.Join(b.workingDirs.isoArtifactsDir, "boot")
+		err = copyPartitionFiles(artifactsBootDir, imageChroot.RootDir())
+		if err != nil {
+			return fmt.Errorf("failed to copy (%s) contents to a writeable disk:\n%w", artifactsBootDir, err)
+		}
+
+		targetEfiDir := filepath.Join(imageChroot.RootDir(), "boot/efi/EFI/BOOT")
+		err = os.MkdirAll(targetEfiDir, os.ModePerm)
+		if err != nil {
+			return fmt.Errorf("failed to create destination efi directory (%s):\n%w", targetEfiDir, err)
+		}
+
+		targetShimPath := filepath.Join(targetEfiDir, filepath.Base(b.artifacts.bootEfiPath))
+		err = file.Copy(b.artifacts.bootEfiPath, targetShimPath)
+		if err != nil {
+			return fmt.Errorf("failed to copy (%s) to (%s):\n%w", b.artifacts.bootEfiPath, targetShimPath, err)
+		}
+
+		targetGrubPath := filepath.Join(targetEfiDir, filepath.Base(b.artifacts.grubEfiPath))
+		err = file.Copy(b.artifacts.grubEfiPath, targetGrubPath)
+		if err != nil {
+			return fmt.Errorf("failed to copy (%s) to (%s):\n%w", b.artifacts.grubEfiPath, targetGrubPath, err)
+		}
+
 		return err
 	}
 
@@ -2071,7 +1907,7 @@ func (b *LiveOSIsoBuilder) createWriteableImageFromSquashfs(buildDir, rawImageFi
 		return fmt.Errorf("failed to copy squashfs into new writeable image (%s):\n%w", rawImageFile, err)
 	}
 
-	err = isoImageMount.CleanClose()
+	err = squashfsMount.CleanClose()
 	if err != nil {
 		return err
 	}
@@ -2079,6 +1915,99 @@ func (b *LiveOSIsoBuilder) createWriteableImageFromSquashfs(buildDir, rawImageFi
 	err = squashfsLoopDevice.CleanClose()
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+func stageIsoFile(sourcePath string, stageDirPath string, isoRelativeDir string) error {
+	targetPath := filepath.Join(stageDirPath, isoRelativeDir, filepath.Base(sourcePath))
+	targetDir := filepath.Dir(targetPath)
+	err := os.MkdirAll(targetDir, os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("failed to create destination directory (%s):\n%w", targetDir, err)
+	}
+
+	err = file.Copy(sourcePath, targetPath)
+	if err != nil {
+		return fmt.Errorf("failed to stage file from (%s) to (%s):\n%w", sourcePath, targetPath, err)
+	}
+
+	return nil
+}
+
+func stageIsoFiles(artifacts IsoArtifacts, stagingDir string) error {
+	err := os.RemoveAll(stagingDir)
+	if err != nil {
+		return err
+	}
+
+	err = os.MkdirAll(stagingDir, os.ModePerm)
+	if err != nil {
+		return err
+	}
+
+	// map of file full local path to location on iso media.
+	artifactsToIsoMap := map[string]string{
+		artifacts.bootEfiPath:       "efi/boot",
+		artifacts.grubEfiPath:       "efi/boot",
+		artifacts.isoBootImagePath:  "boot/grub2",
+		artifacts.isoGrubCfgPath:    "boot/grub2",
+		artifacts.vmlinuzPath:       "boot",
+		artifacts.initrdImagePath:   "boot",
+		artifacts.squashfsImagePath: "liveos",
+	}
+
+	// Add optional saved config file if it exists.
+	if artifacts.savedConfigsFilePath != "" {
+		exists, err := file.PathExists(artifacts.savedConfigsFilePath)
+		if err != nil {
+			return fmt.Errorf("failed to check if (%s) exists:\n%w", artifacts.savedConfigsFilePath, err)
+		}
+		if exists {
+			artifactsToIsoMap[artifacts.savedConfigsFilePath] = "azl-image-customizer"
+		}
+	}
+
+	// Add optional grub-pxe.cfg file if it exists.
+	if artifacts.pxeGrubCfgPath != "" {
+		exists, err := file.PathExists(artifacts.pxeGrubCfgPath)
+		if err != nil {
+			return fmt.Errorf("failed to check if (%s) exists:\n%w", artifacts.pxeGrubCfgPath, err)
+		}
+		if exists {
+			artifactsToIsoMap[artifacts.pxeGrubCfgPath] = "boot/grub2"
+		}
+	}
+
+	// Add additional files
+	for source, isoRelativePath := range artifacts.additionalFiles {
+		isoRelativeDir := filepath.Dir(isoRelativePath)
+		artifactsToIsoMap[source] = isoRelativeDir
+	}
+
+	// Stage the files
+	for source, isoRelativeDir := range artifactsToIsoMap {
+		err = stageIsoFile(source, stagingDir, isoRelativeDir)
+		if err != nil {
+			return fmt.Errorf("failed to stage (%s):\n%w", source, err)
+		}
+	}
+
+	return nil
+}
+
+func (b *LiveOSIsoBuilder) createIsoImage(outputImagePath string) error {
+	stagingDir := filepath.Join(b.workingDirs.isoBuildDir, "staging")
+
+	err := stageIsoFiles(b.artifacts, stagingDir)
+	if err != nil {
+		return fmt.Errorf("failed to stage one or more iso files:\n%w", err)
+	}
+
+	err = isogenerator.BuildIsoImage(stagingDir, outputImagePath)
+	if err != nil {
+		return fmt.Errorf("failed to create (%s) using the (%s) folder:\n%w", outputImagePath, stagingDir, err)
 	}
 
 	return nil

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/microsoft/azurelinux/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
-	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/installutils"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/isogenerator"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"


### PR DESCRIPTION
- Smaller initrd
  - Stop embedding kernel+shim+bootloader into initrd
    - This was a work around to be able to use isomaker as-is. The fix is stop using isomaker and create the boot image and call mkisofs directly.
- Smaller rootfs
  - Remove the re-created initrd from the squashfs.
    - The initrd is always generated under chroot and is created within the customized rootfs. It was then copied to the iso media. The fix is to delete (move) it from the customized rootfs as it is not needed to be there.
  - Remove the boot folder entirely.
    - When the input image with all its partitions is mounted, we ended up copying all the contents including the files at /boot. However, those files are already on the iso media and do not need to remain in the squashfs image. The fix is to delete that folder entirely.

The size gains are:
|            | old   | new   |                                    |
|------------|-------|-------|------------------------------------|
| initrd.img |  47MB |  32MB | removal of kernel+shim+bootloader  |
| rootfs.img | 173MB | 138MB | removal of /boot and initrd.img    |
| Test iso   | 250MB | 200MB |                                    |

<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

---

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] Code conforms to style guidelines
