### PR TITLE
Enable GPG checking when installing/updating packages.

### DIFF
--- a/docs/imagecustomizer/api/cli.md
+++ b/docs/imagecustomizer/api/cli.md
@@ -86,13 +86,27 @@ Can be one of:
 
   The RPMs may either be in the directory itself or any subdirectories.
 
+  GPG signature checking is disabled for local directories.
+  If you wish to enable GPG signature checking, then use a repo file instead and set the
+  `gpgkey` field within the repo file.
+
 - `*.repo` file path: A path to a RPM repo definition file.
 
   The file name extension must be `.repo`.
 
-  Note: This file is not installed in the image during customization.
-  If that is also needed, then use `AdditionalFiles` to place the repo file within
+  If the repo file's `baseurl` or `gpgkey` fields contain a `file://` URL, then the
+  host's directories pointed to by the URL will be bind mounted into the chroot
+  environment and the URL will replaced with the chroot equivalent URL.
+
+  GPG signature checking is enabled by default.
+  If you wish to disable GPG checking, then set both `gpgcheck` and `repo_gpgcheck` to
+  `0` in the repo file.
+
+  The repo file will only be used during image customization and will not be added to
   the image.
+  If you want to add the repo file to the image, then use use
+  [additionalFiles](../api/configuration/os.md#additionalfiles-additionalfile) to place
+  the repo file under the `/etc/yum.repos.d` directory.
 
 This option can be specified multiple times.
 

--- a/docs/imagecustomizer/api/cli.md
+++ b/docs/imagecustomizer/api/cli.md
@@ -96,7 +96,7 @@ Can be one of:
 
   If the repo file's `baseurl` or `gpgkey` fields contain a `file://` URL, then the
   host's directories pointed to by the URL will be bind mounted into the chroot
-  environment and the URL will replaced with the chroot equivalent URL.
+  environment and the URL will be replaced with the chroot equivalent URL.
 
   GPG signature checking is enabled by default.
   If you wish to disable GPG checking, then set both `gpgcheck` and `repo_gpgcheck` to

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages.go
@@ -106,7 +106,7 @@ func addRemoveAndUpdatePackages(buildDir string, baseConfigPath string, config *
 
 func refreshTdnfMetadata(imageChroot *safechroot.Chroot) error {
 	tdnfArgs := []string{
-		"-v", "check-update", "--refresh", "--nogpgcheck", "--assumeyes",
+		"-v", "check-update", "--refresh", "--assumeyes",
 		"--setopt", fmt.Sprintf("reposdir=%s", rpmsMountParentDirInChroot),
 	}
 
@@ -168,7 +168,7 @@ func updateAllPackages(imageChroot *safechroot.Chroot) error {
 	logger.Log.Infof("Updating base image packages")
 
 	tdnfUpdateArgs := []string{
-		"-v", "update", "--nogpgcheck", "--assumeyes", "--cacheonly",
+		"-v", "update", "--assumeyes", "--cacheonly",
 		"--setopt", fmt.Sprintf("reposdir=%s", rpmsMountParentDirInChroot),
 	}
 
@@ -189,7 +189,7 @@ func installOrUpdatePackages(action string, allPackagesToAdd []string, imageChro
 	// Note: When using `--repofromdir`, tdnf will not use any default repos and will only use the last
 	// `--repofromdir` specified.
 	tdnfInstallArgs := []string{
-		"-v", action, "--nogpgcheck", "--assumeyes", "--cacheonly",
+		"-v", action, "--assumeyes", "--cacheonly",
 		"--setopt", fmt.Sprintf("reposdir=%s", rpmsMountParentDirInChroot),
 	}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
@@ -132,12 +132,22 @@ func copyRpms(sourceDir string, targetDir string, excludePrefixes []string) erro
 	return nil
 }
 
-func TestCustomizeImagePackagesAddOfflineLocalRepo(t *testing.T) {
-	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImagePackagesAddOfflineLocalRepo")
+func TestCustomizeImagePackagesAddOfflineLocalRepoWithGpgKey(t *testing.T) {
+	testCustomizeImagePackagesAddOfflineLocalRepoHelper(t, "TestCustomizeImagePackagesAddOfflineLocalRepoWithGpgKey",
+		true)
+}
+
+func TestCustomizeImagePackagesAddOfflineLocalRepoNoGpgKey(t *testing.T) {
+	testCustomizeImagePackagesAddOfflineLocalRepoHelper(t, "TestCustomizeImagePackagesAddOfflineLocalRepoNoGpgKey",
+		false)
+}
+
+func testCustomizeImagePackagesAddOfflineLocalRepoHelper(t *testing.T, testName string, withGpgKey bool) {
+	testTmpDir := filepath.Join(tmpDir, testName)
 
 	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
-	downloadedRpmsRepoFile := getDownloadedRpmsRepoFile(t, "2.0")
+	downloadedRpmsRepoFile := getDownloadedRpmsRepoFile(t, "2.0", withGpgKey)
 	rpmSources := []string{downloadedRpmsRepoFile}
 
 	buildDir := filepath.Join(testTmpDir, "build")

--- a/toolkit/tools/pkg/imagecustomizerlib/main_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/main_test.go
@@ -140,8 +140,14 @@ func getDownloadedRpmsDir(t *testing.T, azureLinuxVersion string) string {
 	return downloadedRpmsDir
 }
 
-func getDownloadedRpmsRepoFile(t *testing.T, azureLinuxVersion string) string {
+func getDownloadedRpmsRepoFile(t *testing.T, azureLinuxVersion string, withGpgKey bool) string {
 	dir := getDownloadedRpmsDir(t, azureLinuxVersion)
-	repoFile := filepath.Join(dir, "../", fmt.Sprintf("rpms-%s.repo", azureLinuxVersion))
+
+	suffix := "nokey"
+	if withGpgKey {
+		suffix = "withkey"
+	}
+
+	repoFile := filepath.Join(dir, "../", fmt.Sprintf("rpms-%s-%s.repo", azureLinuxVersion, suffix))
 	return repoFile
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/testrpms/downloader/Dockerfile
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/testrpms/downloader/Dockerfile
@@ -5,7 +5,7 @@ RUN tdnf update -y && \
    tdnf install -y dnf dnf-plugins-core createrepo_c
 
 # Download the RPMs needed by the following tests:
-# - TestCustomizeImageAddPackage
+# - TestCustomizeImagePackagesAddOfflineLocalRepo
 RUN dnf download -y --resolve --alldeps --destdir /downloadedrpms \
     jq \
     golang


### PR DESCRIPTION
Currently, GPG signature checking is disabled when installing/updating packages. This is less than ideal when downloading packages from external sources such as PMC (packages.microsoft.com).

This change enables GPG checking by default for both the base image's repo files and the repo files provided by the user. However, the user can disable the GPG checks for their provided repo files by setting `gpgcheck` and `repo_gpgcheck` to `0`.

GPG checking remains disabled for local directories since there is no way for the user to provide a GPG public key. Also, local directories are likely to contain a user's custom built packages anyway, which are unlikely to be signed.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
