### PR TITLE
Cleanup build files when no longer needed.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/cosicommon.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/cosicommon.go
@@ -30,6 +30,7 @@ func convertToCosi(ic *ImageCustomizerParameters) error {
 	if err != nil {
 		return fmt.Errorf("failed to create folder %s:\n%w", outputDir, err)
 	}
+	defer os.Remove(outputDir)
 
 	imageLoopback, err := safeloopback.NewLoopback(ic.rawImageFile)
 	if err != nil {
@@ -41,6 +42,9 @@ func convertToCosi(ic *ImageCustomizerParameters) error {
 		"raw-zst", ic.imageUuid)
 	if err != nil {
 		return err
+	}
+	for _, partition := range partitionMetadataOutput {
+		defer os.Remove(path.Join(outputDir, partition.PartitionFilename))
 	}
 
 	err = buildCosiFile(outputDir, ic.outputImageFile, partitionMetadataOutput, ic.verityMetadata,

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitions.go
@@ -4,6 +4,7 @@
 package imagecustomizerlib
 
 import (
+	"os"
 	"path/filepath"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/imagecustomizerapi"
@@ -24,6 +25,7 @@ func customizePartitions(buildDir string, baseConfigPath string, config *imagecu
 		partIdToPartUuid, err := customizePartitionsUsingFileCopy(buildDir, baseConfigPath, config,
 			buildImageFile, newBuildImageFile)
 		if err != nil {
+			os.Remove(newBuildImageFile)
 			return false, "", nil, err
 		}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -440,7 +440,11 @@ func customizeOSContents(ic *ImageCustomizerParameters) error {
 	if err != nil {
 		return err
 	}
-	ic.rawImageFile = newRawImageFile
+
+	if ic.rawImageFile != newRawImageFile {
+		os.Remove(ic.rawImageFile)
+		ic.rawImageFile = newRawImageFile
+	}
 
 	// Customize the raw image file.
 	partUuidToFstabEntry, osRelease, err := customizeImageHelper(ic.buildDirAbs, ic.configPath, ic.config, ic.rawImageFile, ic.rpmsSources,


### PR DESCRIPTION
This change ensures that the `image.raw` file and the `cosiimages` directory are removed from the build directory once they are no longer needed.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
