### PR TITLE
Fix docs build.

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,3 +1,5 @@
+default: build
+
 .PHONY: prereqs
 prereqs:
 	gem install jekyll bundler
@@ -13,7 +15,7 @@ serve:
 .PHONY: build
 build:
 	bundle exec jekyll build
-	bundle exec htmlproofer --assume_extension '.html' ./_site
+	bundle exec htmlproofer --disable-external --assume_extension '.html' ./_site
 
 update-dependencies:
 	bundle update


### PR DESCRIPTION
We use htmlproofer to verify all the URLs in the docs are valid. Unfortunately, it seems that the checking sends requests too quickly so some websites (e.g. GitHub) have started returning HTTP 429 (Too Many Requests).

This change disables external website checking to fix this issue.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
