### PR TITLE
Add support for reinitializing verity.

### DIFF
--- a/docs/imagecustomizer/api/cli.md
+++ b/docs/imagecustomizer/api/cli.md
@@ -31,6 +31,21 @@ But it can also be an Azure Linux image that has been customized.
 
 Supported image file formats: vhd, vhdx, qcow2, and raw.
 
+If verity is enabled in the base image, then:
+
+- If the partitions are recustomized using the
+  [disks](../api/configuration/storage.md#disks-disk) API, then the existing verity
+  settings are thrown away.
+  New verity settings can be configured with the
+  [verity](../api/configuration/verity.md) API.
+
+- Otherwise, the existing verity settings are reapplied to the image after OS
+  customization.
+
+  This feature is in preview and may be subject to breaking changes.
+  You may enable this feature by adding `reinitialize-verity` to the
+  [previewfeatures](./configuration/config.md#previewfeatures-string) API.
+
 Added in v0.3.
 
 ## --output-image-file=FILE-PATH

--- a/docs/imagecustomizer/api/configuration/config.md
+++ b/docs/imagecustomizer/api/configuration/config.md
@@ -99,6 +99,12 @@ Supported options:
 
   Added in v0.14.
 
+- `reinitialize-verity`: Enables support for customizing an image that has verity
+  enabled (without needing to recustomize the partitions). The verity settings are read
+  from the image and reapplied after OS customization.
+
+  Added in v0.15.
+
 ## output [[output](./output.md)]
 
 Specifies the configuration for the output image and artifacts.

--- a/docs/imagecustomizer/api/configuration/inputImage.md
+++ b/docs/imagecustomizer/api/configuration/inputImage.md
@@ -26,4 +26,19 @@ But it can also be an Azure Linux image that has been customized.
 
 Supported image file formats: vhd, vhdx, qcow2, and raw.
 
+If verity is enabled in the base image, then:
+
+- If the partitions are recustomized using the
+  [disks](../api/configuration/storage.md#disks-disk) API, then the existing verity
+  settings are thrown away.
+  New verity settings can be configured with the
+  [verity](../api/configuration/verity.md) API.
+
+- Otherwise, the existing verity settings are reapplied to the image after OS
+  customization.
+
+  This feature is in preview and may be subject to breaking changes.
+  You may enable this feature by adding `reinitialize-verity` to the
+  [previewfeatures](./configuration/config.md#previewfeatures-string) API.
+
 Added in v0.13.0.

--- a/docs/imagecustomizer/api/configuration/inputImage.md
+++ b/docs/imagecustomizer/api/configuration/inputImage.md
@@ -29,16 +29,16 @@ Supported image file formats: vhd, vhdx, qcow2, and raw.
 If verity is enabled in the base image, then:
 
 - If the partitions are recustomized using the
-  [disks](../api/configuration/storage.md#disks-disk) API, then the existing verity
+  [disks](storage.md#disks-disk) API, then the existing verity
   settings are thrown away.
   New verity settings can be configured with the
-  [verity](../api/configuration/verity.md) API.
+  [verity](verity.md) API.
 
 - Otherwise, the existing verity settings are reapplied to the image after OS
   customization.
 
   This feature is in preview and may be subject to breaking changes.
   You may enable this feature by adding `reinitialize-verity` to the
-  [previewfeatures](./configuration/config.md#previewfeatures-string) API.
+  [previewfeatures](config.md#previewfeatures-string) API.
 
 Added in v0.13.0.

--- a/toolkit/tools/imagecustomizerapi/previewfeaturetype.go
+++ b/toolkit/tools/imagecustomizerapi/previewfeaturetype.go
@@ -16,6 +16,9 @@ const (
 
 	// PreviewFeatureInjectFiles enables files injection into target partitions.
 	PreviewFeatureInjectFiles PreviewFeature = "inject-files"
+
+	// PreviewFeatureReinitializeVerity will reinitialize verity on verity partitions in the base image.
+	PreviewFeatureReinitializeVerity = "reinitialize-verity"
 )
 
 func (pf PreviewFeature) IsValid() error {

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
@@ -16,7 +16,7 @@ import (
 func customizePartitionsUsingFileCopy(buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
 	buildImageFile string, newBuildImageFile string,
 ) (map[string]string, error) {
-	existingImageConnection, _, err := connectToExistingImage(buildImageFile, buildDir, "imageroot", false)
+	existingImageConnection, _, _, err := connectToExistingImage(buildImageFile, buildDir, "imageroot", false)
 	if err != nil {
 		return nil, err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsuuids.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsuuids.go
@@ -124,6 +124,11 @@ func resetFileSystemUuid(partition diskutils.PartitionInfo) (string, error) {
 		newUuid = strings.ToUpper(newUuid)
 		newUuid = newUuid[:4] + "-" + newUuid[4:]
 
+	case "DM_verity_hash":
+		// Resetting partition IDs on a disk with verity would require updating the kernel command-line args.
+		// This is probably doable, just not implemented yet.
+		return "", fmt.Errorf("resetting partition IDs on a verity-enabled image is not implemented")
+
 	default:
 		return "", fmt.Errorf("unsupported filesystem type (%s)", partition.FileSystemType)
 	}
@@ -174,7 +179,7 @@ func fixPartitionUuidsInFstabFile(partitions []diskutils.PartitionInfo, newUuids
 		// Find the partition.
 		// Note: The 'partitions' list was collected before all the changes were made. So, the fstab entries will still
 		// match the values in the `partitions` list.
-		mountIdType, _, partitionIndex, err := findSourcePartition(fstabEntry.Source, partitions, buildDir)
+		mountIdType, _, partitionIndex, _, err := findSourcePartition(fstabEntry.Source, partitions, buildDir)
 		if err != nil {
 			return err
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
@@ -295,6 +296,32 @@ func SystemdFormatCorruptionOption(corruptionOption imagecustomizerapi.Corruptio
 	default:
 		return "", fmt.Errorf("invalid corruptionOption provided (%s)", string(corruptionOption))
 	}
+}
+
+func ParseSystemdVerityOptions(options string) (imagecustomizerapi.CorruptionOption, error) {
+	corruptionOption := imagecustomizerapi.CorruptionOptionIoError
+
+	optionValues := strings.Split(options, ",")
+	for _, option := range optionValues {
+		switch option {
+		case "":
+			// Ignore empty string.
+
+		case "ignore-corruption":
+			corruptionOption = imagecustomizerapi.CorruptionOptionIgnore
+
+		case "panic-on-corruption":
+			corruptionOption = imagecustomizerapi.CorruptionOptionPanic
+
+		case "restart-on-corruption":
+			corruptionOption = imagecustomizerapi.CorruptionOptionRestart
+
+		default:
+			return "", fmt.Errorf("unknown verity option (%s)", option)
+		}
+	}
+
+	return corruptionOption, nil
 }
 
 func validateVerityDependencies(imageChroot *safechroot.Chroot) error {

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
@@ -298,7 +298,7 @@ func SystemdFormatCorruptionOption(corruptionOption imagecustomizerapi.Corruptio
 	}
 }
 
-func ParseSystemdVerityOptions(options string) (imagecustomizerapi.CorruptionOption, error) {
+func parseSystemdVerityOptions(options string) (imagecustomizerapi.CorruptionOption, error) {
 	corruptionOption := imagecustomizerapi.CorruptionOptionIoError
 
 	optionValues := strings.Split(options, ",")

--- a/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
@@ -21,44 +21,46 @@ import (
 type installOSFunc func(imageChroot *safechroot.Chroot) error
 
 func connectToExistingImage(imageFilePath string, buildDir string, chrootDirName string, includeDefaultMounts bool,
-) (*ImageConnection, map[string]diskutils.FstabEntry, error) {
+) (*ImageConnection, map[string]diskutils.FstabEntry, []verityDeviceMetadata, error) {
 	imageConnection := NewImageConnection()
 
-	partUuidToMountPath, err := connectToExistingImageHelper(imageConnection, imageFilePath, buildDir, chrootDirName, includeDefaultMounts)
+	partUuidToMountPath, verityMetadata, err := connectToExistingImageHelper(imageConnection, imageFilePath, buildDir,
+		chrootDirName, includeDefaultMounts)
 	if err != nil {
 		imageConnection.Close()
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	return imageConnection, partUuidToMountPath, nil
+	return imageConnection, partUuidToMountPath, verityMetadata, nil
 }
 
 func connectToExistingImageHelper(imageConnection *ImageConnection, imageFilePath string,
 	buildDir string, chrootDirName string, includeDefaultMounts bool,
-) (map[string]diskutils.FstabEntry, error) {
+) (map[string]diskutils.FstabEntry, []verityDeviceMetadata, error) {
 	// Connect to image file using loopback device.
 	err := imageConnection.ConnectLoopback(imageFilePath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	partitions, err := diskutils.GetDiskPartitions(imageConnection.Loopback().DevicePath())
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	rootfsPartition, err := findRootfsPartition(partitions, buildDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find rootfs partition:\n%w", err)
+		return nil, nil, fmt.Errorf("failed to find rootfs partition:\n%w", err)
 	}
 
 	fstabEntries, err := readFstabEntriesFromRootfs(rootfsPartition, partitions, buildDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read fstab entries from rootfs partition:\n%w", err)
+		return nil, nil, fmt.Errorf("failed to read fstab entries from rootfs partition:\n%w", err)
 	}
 
-	mountPoints, partUuidToFstabEntry, err := fstabEntriesToMountPoints(fstabEntries, partitions, buildDir)
+	mountPoints, partUuidToFstabEntry, verityMetadata, err := fstabEntriesToMountPoints(fstabEntries, partitions,
+		buildDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to find mount info for fstab file entries:\n%w", err)
+		return nil, nil, fmt.Errorf("failed to find mount info for fstab file entries:\n%w", err)
 	}
 
 	// Create chroot environment.
@@ -66,10 +68,10 @@ func connectToExistingImageHelper(imageConnection *ImageConnection, imageFilePat
 
 	err = imageConnection.ConnectChroot(imageChrootDir, false, []string(nil), mountPoints, includeDefaultMounts)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	return partUuidToFstabEntry, nil
+	return partUuidToFstabEntry, verityMetadata, nil
 }
 
 func createNewImage(targetOs targetos.TargetOs, filename string, diskConfig imagecustomizerapi.Disk,
@@ -245,7 +247,7 @@ func createImageBoilerplate(targetOs targetos.TargetOs, imageConnection *ImageCo
 		return nil, "", err
 	}
 
-	mountPoints, _, err := fstabEntriesToMountPoints(fstabEntries, diskPartitions, buildDir)
+	mountPoints, _, _, err := fstabEntriesToMountPoints(fstabEntries, diskPartitions, buildDir)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to find mount info for fstab file entries:\n%w", err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -65,7 +65,7 @@ func createLiveOSIsoImage(buildDir, baseConfigPath string, inputArtifactsStore *
 	}()
 
 	logger.Log.Debugf("Connecting to raw image (%s)", rawImageFile)
-	rawImageConnection, _, err := connectToExistingImage(rawImageFile, isoBuildDir, "readonly-rootfs-mount", false /*includeDefaultMounts*/)
+	rawImageConnection, _, _, err := connectToExistingImage(rawImageFile, isoBuildDir, "readonly-rootfs-mount", false /*includeDefaultMounts*/)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
@@ -425,7 +425,7 @@ func findVerityPartitionsFromCmdline(partitions []diskutils.PartitionInfo, cmdli
 		return diskutils.PartitionInfo{}, 0, verityDeviceMetadata{}, err
 	}
 
-	corruptionOption, err := ParseSystemdVerityOptions(options)
+	corruptionOption, err := parseSystemdVerityOptions(options)
 	if err != nil {
 		err = fmt.Errorf("failed parse verity options (%s) kernel argument:\n%w", optionsArgName, err)
 		return diskutils.PartitionInfo{}, 0, verityDeviceMetadata{}, err

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-reinit.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-reinit.yaml
@@ -1,0 +1,14 @@
+previewFeatures:
+- reinitialize-verity
+
+os:
+  additionalFiles:
+  - content: |
+      cat, dog, elephant, squirrel
+    destination: /usr/local/share/animals.txt
+
+  users:
+  - name: root
+    password:
+      type: plain-text
+      value: hello


### PR DESCRIPTION
Add support for reading the existing verity settings from the base image and then reapplying them after OS customization.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
