### PR TITLE
Add snapshot support (P1)

### DIFF
--- a/docs/imagecustomizer/api/cli.md
+++ b/docs/imagecustomizer/api/cli.md
@@ -172,3 +172,19 @@ Added in v0.3.
 Injects files into a disk image using an injection configuration.
 
 See [inject-files subcommand](./cli/inject-files.md) for full documentation.
+
+## --package-snapshot-time
+
+Limits package selection to those published before the specified timestamp.
+
+This flag enables snapshot-based package filtering during installation or update,
+ensuring only packages available at that point in time are considered.
+
+Supports:
+- A date in `YYYY-MM-DD` format (interpreted as UTC midnight)
+- A full RFC 3339 timestamp (e.g., `2024-05-20T23:59:59Z`)
+
+You may enable this feature by adding `package-snapshot-time` to the [previewfeatures]
+(./configuration/config.md#previewfeatures-string) API.
+
+Added in v0.15.

--- a/docs/imagecustomizer/api/configuration.md
+++ b/docs/imagecustomizer/api/configuration.md
@@ -33,7 +33,7 @@ The top level type for the YAML file is the [config](./configuration/config.md) 
    3. Install packages ([installLists](./configuration/packages.md#installlists-string),
    [install](./configuration/packages.md#install-string))
 
-   4. Update packages ([updateLists](./configuration/packages.md#removelists-string),
+   4. Update packages ([updateLists](./configuration/packages.md#updatelists-string),
    [update](./configuration/packages.md#update-string))
 
 4. Update hostname. ([hostname](./configuration/os.md#hostname-string))
@@ -183,6 +183,7 @@ os:
       - [remove](./configuration/packages.md#remove-string)
       - [updateLists](./configuration/packages.md#updatelists-string)
       - [update](./configuration/packages.md#update-string)
+      - [snapshotTime](./configuration/packages.md#snapshottime-string)
     - [additionalFiles](./configuration/os.md#additionalfiles-additionalfile) ([additionalFile type](./configuration/additionalfile.md))
       - [source](./configuration/additionalfile.md#source-string)
       - [content](./configuration/additionalfile.md#content-string)

--- a/docs/imagecustomizer/api/configuration/config.md
+++ b/docs/imagecustomizer/api/configuration/config.md
@@ -95,6 +95,14 @@ Supported options:
 
   Added in v0.15.
 
+- `package-snapshot-time`: Enables snapshot-based package filtering during image
+  customization. This allows specifying a cutoff timestamp using the
+  [`--package-snapshot-time`](../cli.md#--package-snapshot-time) CLI option or
+  [`os.packages.snapshotTime`](./packages.md#snapshottime-string) API field.
+  If both are provided, the CLI value takes precedence.
+
+  Added in v0.15.
+
 ## output [[output](./output.md)]
 
 Specifies the configuration for the output image and artifacts.

--- a/docs/imagecustomizer/api/configuration/packages.md
+++ b/docs/imagecustomizer/api/configuration/packages.md
@@ -139,3 +139,27 @@ os:
 ```
 
 Added in v0.3.
+
+## snapshotTime [string]
+
+Filters packages by publication time.
+
+Only packages published before the specified timestamp will be considered during
+install or update. This supports both ISO 8601 date-only format (`YYYY-MM-DD`)
+and full RFC 3339 timestamp (`YYYY-MM-DDTHH:MM:SSZ`).
+
+If this value is specified, then a `package-snapshot-time` entry must be added to
+[previewFeatures](./config.md#previewfeatures-string)
+
+Example:
+
+```yaml
+previewFeatures:
+- package-snapshot-time
+
+os:
+  packages:
+    snapshotTime: 2025-05-20T23:59:59Z
+```
+
+Added in v0.15.

--- a/toolkit/tools/imagecustomizer/main.go
+++ b/toolkit/tools/imagecustomizer/main.go
@@ -26,6 +26,7 @@ type CustomizeCmd struct {
 	RpmSources               []string `name:"rpm-source" help:"Path to a RPM repo config file or a directory containing RPMs."`
 	DisableBaseImageRpmRepos bool     `name:"disable-base-image-rpm-repos" help:"Disable the base image's RPM repos as an RPM source."`
 	OutputPXEArtifactsDir    string   `name:"output-pxe-artifacts-dir" help:"Create a directory with customized image PXE booting artifacts. '--output-image-format' must be set to 'iso'."`
+	PackageSnapshotTime      string   `name:"package-snapshot-time" help:"Only packages published before this snapshot time will be available during customization. Supports 'YYYY-MM-DD' or full RFC3339 timestamp (e.g., 2024-05-20T23:59:59Z)."`
 }
 
 type InjectFilesCmd struct {
@@ -89,7 +90,7 @@ func main() {
 func customizeImage(cmd CustomizeCmd) error {
 	err := imagecustomizerlib.CustomizeImageWithConfigFile(cmd.BuildDir, cmd.ConfigFile, cmd.InputImageFile,
 		cmd.RpmSources, cmd.OutputImageFile, cmd.OutputImageFormat, cmd.OutputPXEArtifactsDir,
-		!cmd.DisableBaseImageRpmRepos)
+		!cmd.DisableBaseImageRpmRepos, cmd.PackageSnapshotTime)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/imagecustomizerapi/config.go
+++ b/toolkit/tools/imagecustomizerapi/config.go
@@ -69,6 +69,10 @@ func (c *Config) IsValid() (err error) {
 				)
 			}
 		}
+
+		if c.OS.Packages.SnapshotTime != "" && !sliceutils.ContainsValue(c.PreviewFeatures, PreviewFeaturePackageSnapshotTime) {
+			return fmt.Errorf("the 'package-snapshot-time' preview feature must be enabled to use 'os.packages.snapshotTime'")
+		}
 	}
 
 	err = c.Scripts.IsValid()

--- a/toolkit/tools/imagecustomizerapi/os.go
+++ b/toolkit/tools/imagecustomizerapi/os.go
@@ -119,5 +119,10 @@ func (s *OS) IsValid() error {
 		}
 	}
 
+	err = s.Packages.SnapshotTime.IsValid()
+	if err != nil {
+		return fmt.Errorf("invalid package snapshot time:\n%w", err)
+	}
+
 	return nil
 }

--- a/toolkit/tools/imagecustomizerapi/packages.go
+++ b/toolkit/tools/imagecustomizerapi/packages.go
@@ -4,11 +4,12 @@
 package imagecustomizerapi
 
 type Packages struct {
-	UpdateExistingPackages bool     `yaml:"updateExistingPackages" json:"updateExistingPackages,omitempty"`
-	InstallLists           []string `yaml:"installLists" json:"-"`
-	Install                []string `yaml:"install" json:"install,omitempty"`
-	RemoveLists            []string `yaml:"removeLists" json:"-"`
-	Remove                 []string `yaml:"remove" json:"remove,omitempty"`
-	UpdateLists            []string `yaml:"updateLists" json:"-"`
-	Update                 []string `yaml:"update" json:"update,omitempty"`
+	UpdateExistingPackages bool                `yaml:"updateExistingPackages" json:"updateExistingPackages,omitempty"`
+	InstallLists           []string            `yaml:"installLists" json:"-"`
+	Install                []string            `yaml:"install" json:"install,omitempty"`
+	RemoveLists            []string            `yaml:"removeLists" json:"-"`
+	Remove                 []string            `yaml:"remove" json:"remove,omitempty"`
+	UpdateLists            []string            `yaml:"updateLists" json:"-"`
+	Update                 []string            `yaml:"update" json:"update,omitempty"`
+	SnapshotTime           PackageSnapshotTime `yaml:"snapshotTime" json:"snapshotTime,omitempty"`
 }

--- a/toolkit/tools/imagecustomizerapi/packagesnapshottime.go
+++ b/toolkit/tools/imagecustomizerapi/packagesnapshottime.go
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"fmt"
+	"time"
+)
+
+type PackageSnapshotTime string
+
+func (p PackageSnapshotTime) IsValid() error {
+	_, err := p.Parse()
+	return err
+}
+
+func (p PackageSnapshotTime) Parse() (time.Time, error) {
+	str := string(p)
+
+	if str == "" {
+		return time.Time{}, nil
+	}
+
+	// Try RFC3339
+	if t, err := time.Parse(time.RFC3339, str); err == nil {
+		return t, nil
+	}
+
+	// Try ISO 8601 (date only)
+	if t, err := time.Parse("2006-01-02", str); err == nil {
+		return t, nil
+	}
+
+	return time.Time{}, fmt.Errorf("invalid snapshot time format: must be YYYY-MM-DD or full RFC3339 (e.g., 2024-05-20T15:04:05Z)")
+}

--- a/toolkit/tools/imagecustomizerapi/packagesnapshottime_test.go
+++ b/toolkit/tools/imagecustomizerapi/packagesnapshottime_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSnapshotTime_EmptyIsValid(t *testing.T) {
+	s := PackageSnapshotTime("")
+	err := s.IsValid()
+	assert.NoError(t, err)
+}
+
+func TestSnapshotTime_ValidISODate(t *testing.T) {
+	s := PackageSnapshotTime("2024-05-20")
+	err := s.IsValid()
+	assert.NoError(t, err)
+}
+
+func TestSnapshotTime_ValidRFC3339(t *testing.T) {
+	s := PackageSnapshotTime("2024-05-20T12:34:56Z")
+	err := s.IsValid()
+	assert.NoError(t, err)
+}
+
+func TestSnapshotTime_InvalidDateFormat(t *testing.T) {
+	s := PackageSnapshotTime("20-05-2024")
+	err := s.IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "invalid snapshot time format")
+}
+
+func TestSnapshotTime_InvalidTimestampFormat(t *testing.T) {
+	s := PackageSnapshotTime("2024-05-20 23:59:59")
+	err := s.IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "invalid snapshot time format")
+}

--- a/toolkit/tools/imagecustomizerapi/previewfeaturetype.go
+++ b/toolkit/tools/imagecustomizerapi/previewfeaturetype.go
@@ -19,11 +19,14 @@ const (
 
 	// PreviewFeatureReinitializeVerity will reinitialize verity on verity partitions in the base image.
 	PreviewFeatureReinitializeVerity = "reinitialize-verity"
+
+	// PreviewFeatureSnapshotTime enables support for snapshot-based package filtering.
+	PreviewFeaturePackageSnapshotTime PreviewFeature = "package-snapshot-time"
 )
 
 func (pf PreviewFeature) IsValid() error {
 	switch pf {
-	case PreviewFeatureUki, PreviewFeatureOutputArtifacts, PreviewFeatureInjectFiles:
+	case PreviewFeatureUki, PreviewFeatureOutputArtifacts, PreviewFeatureInjectFiles, PreviewFeaturePackageSnapshotTime:
 		return nil
 	default:
 		return fmt.Errorf("invalid preview feature: %s", pf)

--- a/toolkit/tools/imagecustomizerapi/schema.json
+++ b/toolkit/tools/imagecustomizerapi/schema.json
@@ -393,6 +393,9 @@
             "type": "string"
           },
           "type": "array"
+        },
+        "snapshotTime": {
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput_test.go
@@ -33,7 +33,7 @@ func TestOutputAndInjectArtifacts(t *testing.T) {
 
 	// Customize image
 	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizebootloader_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizebootloader_test.go
@@ -41,7 +41,7 @@ func testCustomizeImageMultiKernel(t *testing.T, testName string, imageType base
 
 	// Customize image.
 	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizefiles_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizefiles_test.go
@@ -80,7 +80,7 @@ func TestCustomizeImageAdditionalFiles(t *testing.T) {
 
 	// Customize image.
 	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -126,7 +126,7 @@ func TestCustomizeImageAdditionalFilesInfiniteFile(t *testing.T) {
 
 	// Customize image.
 	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	assert.ErrorContains(t, err, "failed to copy (/dev/zero)")
 	assert.ErrorContains(t, err, "no space left on device")
 }
@@ -202,7 +202,7 @@ func TestCustomizeImageAdditionalDirs(t *testing.T) {
 
 	// Customize image.
 	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -258,7 +258,7 @@ func TestCustomizeImageAdditionalDirsInfiniteFile(t *testing.T) {
 
 	// Customize image.
 	err = CustomizeImage(buildDir, testTmpDir, &config, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	assert.ErrorContains(t, err, "failed to copy directory")
 	assert.ErrorContains(t, err, "failed to copy file")
 	assert.ErrorContains(t, err, "no space left on device")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizehostname_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizehostname_test.go
@@ -48,7 +48,7 @@ func TestCustomizeImageHostname(t *testing.T) {
 
 	// Customize image.
 	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
@@ -12,7 +12,7 @@ import (
 
 func doOsCustomizations(buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
 	imageConnection *ImageConnection, rpmsSources []string, useBaseImageRpmRepos bool, partitionsCustomized bool,
-	imageUuid string, partUuidToFstabEntry map[string]diskutils.FstabEntry,
+	imageUuid string, partUuidToFstabEntry map[string]diskutils.FstabEntry, packageSnapshotTime string,
 ) error {
 	var err error
 
@@ -26,7 +26,7 @@ func doOsCustomizations(buildDir string, baseConfigPath string, config *imagecus
 	}
 
 	err = addRemoveAndUpdatePackages(buildDir, baseConfigPath, config.OS, imageChroot, rpmsSources,
-		useBaseImageRpmRepos)
+		useBaseImageRpmRepos, packageSnapshotTime)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeoverlays_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeoverlays_test.go
@@ -24,7 +24,7 @@ func TestCustomizeImageOverlays(t *testing.T) {
 
 	// Customize image.
 	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -88,7 +88,7 @@ func TestCustomizeImageOverlaysSELinux(t *testing.T) {
 
 	// Customize image.
 	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
@@ -48,7 +48,7 @@ func testCustomizeImagePartitionsToEfi(t *testing.T, testName string, imageType 
 
 	// Customize image.
 	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -136,7 +136,7 @@ func TestCustomizeImagePartitionsSizeOnly(t *testing.T) {
 
 	// Customize image.
 	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -231,7 +231,7 @@ func testCustomizeImagePartitionsToLegacy(t *testing.T, testName string, imageTy
 
 	// Customize image.
 	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -283,7 +283,7 @@ func testCustomizeImageKernelCommandLineHelper(t *testing.T, testName string, ba
 
 	// Customize image.
 	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -352,7 +352,7 @@ func testCustomizeImageNewUUIDsHelper(t *testing.T, testName string, imageType b
 
 	// Customize image.
 	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeselinux_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeselinux_test.go
@@ -35,7 +35,7 @@ func testCustomizeImageSELinuxHelper(t *testing.T, testName string, imageType ba
 	// This tests enabling SELinux on a non-SELinux image.
 	configFile := filepath.Join(testDir, "selinux-force-enforcing.yaml")
 	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -64,7 +64,7 @@ func testCustomizeImageSELinuxHelper(t *testing.T, testName string, imageType ba
 	// This tests disabling (but not removing) SELinux on an SELinux enabled image.
 	configFile = filepath.Join(testDir, "selinux-disabled.yaml")
 	err = CustomizeImageWithConfigFile(buildDir, configFile, outImageFilePath, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -93,7 +93,7 @@ func testCustomizeImageSELinuxHelper(t *testing.T, testName string, imageType ba
 	// This tests enabling SELinux on an image with SELinux installed but disabled.
 	configFile = filepath.Join(testDir, "selinux-permissive.yaml")
 	err = CustomizeImageWithConfigFile(buildDir, configFile, outImageFilePath, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -132,7 +132,7 @@ func testCustomizeImageSELinuxAndPartitionsHelper(t *testing.T, testName string,
 	// This tests enabling SELinux on a non-SELinux image.
 	configFile := filepath.Join(testDir, "partitions-selinux-enforcing.yaml")
 	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -181,7 +181,7 @@ func TestCustomizeImageSELinuxNoPolicy(t *testing.T) {
 
 	// Customize image.
 	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	assert.ErrorContains(t, err, "SELinux is enabled but the (/etc/selinux/config) file is missing")
 	assert.ErrorContains(t, err, "please ensure an SELinux policy is installed")
 	assert.ErrorContains(t, err, "the 'selinux-policy' package provides the default policy")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeservices_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeservices_test.go
@@ -22,7 +22,7 @@ func TestCustomizeImageServicesEnableDisable(t *testing.T) {
 	// Customize image.
 	configFile := filepath.Join(testDir, "services-config.yaml")
 	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -63,7 +63,7 @@ func TestCustomizeImageServicesEnableUnknown(t *testing.T) {
 	}
 
 	err := CustomizeImage(buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	assert.ErrorContains(t, err, "failed to enable service (chocolate-chip-muffin)")
 	assert.ErrorContains(t, err, "chocolate-chip-muffin.service does not exist")
 }
@@ -87,7 +87,7 @@ func TestCustomizeImageServicesDisableUnknown(t *testing.T) {
 	}
 
 	err := CustomizeImage(buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	assert.ErrorContains(t, err, "failed to disable service (chocolate-chip-muffin)")
 	assert.ErrorContains(t, err, "No such file or directory")
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/customizetdnfsnapshot.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizetdnfsnapshot.go
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerlib
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/imagecustomizerapi"
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/safechroot"
+	"gopkg.in/ini.v1"
+)
+
+const customTdnfConfRelPath = "tmp/custom-tdnf.conf"
+
+func createTempTdnfConfigWithSnapshot(imageChroot *safechroot.Chroot, snapshotTime imagecustomizerapi.PackageSnapshotTime) error {
+	if snapshotTime == "" {
+		return nil
+	}
+
+	parsedTime, err := snapshotTime.Parse()
+	if err != nil {
+		return fmt.Errorf("failed to parse snapshot time:\n%w", err)
+	}
+
+	epoch := strconv.FormatInt(parsedTime.Unix(), 10)
+
+	tempTdnfConfPath := filepath.Join(imageChroot.RootDir(), customTdnfConfRelPath)
+	baseTdnfConfPath := filepath.Join(imageChroot.RootDir(), "etc/tdnf/tdnf.conf")
+
+	cfg := ini.Empty()
+	if _, err := os.Stat(baseTdnfConfPath); err == nil {
+		if err := cfg.Append(baseTdnfConfPath); err != nil {
+			return fmt.Errorf("failed to parse existing tdnf.conf:\n%w", err)
+		}
+	} else {
+		cfg.NewSection("main")
+	}
+
+	cfg.Section("main").Key("snapshottime").SetValue(epoch)
+
+	if err := os.MkdirAll(filepath.Dir(tempTdnfConfPath), 0755); err != nil {
+		return fmt.Errorf("failed to create directory for custom tdnf.conf:\n%w", err)
+	}
+
+	if err := cfg.SaveTo(tempTdnfConfPath); err != nil {
+		return fmt.Errorf("failed to write custom tdnf.conf:\n%w", err)
+	}
+
+	return nil
+}
+
+func cleanupSnapshotTimeConfig(imageChroot *safechroot.Chroot) error {
+	// e.g., remove the temp config file
+	err := os.Remove(filepath.Join(imageChroot.RootDir(), customTdnfConfRelPath))
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to clean up temp tdnf config: %w", err)
+	}
+	return nil
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
@@ -30,7 +30,7 @@ func TestCustomizeImageVerityUsrUki(t *testing.T) {
 
 	// Customize image.
 	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeusers_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeusers_test.go
@@ -79,7 +79,7 @@ func TestCustomizeImageUsers(t *testing.T) {
 
 	// Customize image.
 	err := CustomizeImage(buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -163,7 +163,7 @@ func TestCustomizeImageUsersExitingUserHomeDir(t *testing.T) {
 
 	// Customize image.
 	err := CustomizeImage(buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	assert.ErrorContains(t, err, "cannot set home directory (/home/root) on a user (root) that already exists")
 }
 
@@ -187,7 +187,7 @@ func TestCustomizeImageUsersExitingUserUid(t *testing.T) {
 
 	// Customize image.
 	err := CustomizeImage(buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	assert.ErrorContains(t, err, "cannot set UID (1) on a user (root) that already exists")
 }
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
@@ -42,7 +42,7 @@ func testCustomizeImageVerityHelper(t *testing.T, testName string, imageType bas
 
 	// Customize image.
 	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -51,7 +51,7 @@ func testCustomizeImageVerityHelper(t *testing.T, testName string, imageType bas
 
 	// Recustomize the image.
 	err = CustomizeImageWithConfigFile(buildDir, configFile, outImageFilePath, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -143,7 +143,7 @@ func testCustomizeImageVerityCosiExtractHelper(t *testing.T, testName string, im
 
 	// Customize image, shrink partitions, and split the partitions into individual files.
 	err = CustomizeImage(buildDir, testDir, &config, baseImage, nil, outImageFilePath, "cosi",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 
 	if !assert.NoError(t, err) {
 		return
@@ -349,7 +349,7 @@ func testCustomizeImageVerityUsrHelper(t *testing.T, testName string, imageType 
 
 	// Customize image.
 	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -359,7 +359,7 @@ func testCustomizeImageVerityUsrHelper(t *testing.T, testName string, imageType 
 	// Recustomize image.
 	// This helps verify that verity-enabled images can be recustomized.
 	err = CustomizeImageWithConfigFile(buildDir, configFile, outImageFilePath, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -435,14 +435,14 @@ func testCustomizeImageVerityUsr2StageHelper(t *testing.T, testName string, imag
 
 	// Stage 1: Create the partitions for verity.
 	err := CustomizeImageWithConfigFile(buildDir, stage1ConfigFile, baseImage, nil, stage1FilePath, "qcow2",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}
 
 	// Stage 2: Enable verity.
 	err = CustomizeImageWithConfigFile(buildDir, stage2ConfigFile, stage1FilePath, nil, stage2FilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -474,7 +474,7 @@ func testCustomizeImageVerityReinitRootHelper(t *testing.T, testName string, ima
 
 	// Stage 1: Initialize verity.
 	err := CustomizeImageWithConfigFile(buildDir, stage1ConfigFile, baseImage, nil, stage1FilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -483,16 +483,16 @@ func testCustomizeImageVerityReinitRootHelper(t *testing.T, testName string, ima
 
 	// Stage 2a: Reinitialize verity.
 	err = CustomizeImageWithConfigFile(buildDir, stage2aConfigFile, stage1FilePath, nil, stage2FilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	verifyRootVerity(t, imageType, imageVersion, buildDir, stage2FilePath)
+	verifyRootVerity(t, imageType, imageVersion, buildDir, stage1FilePath)
 
 	// Stage 2b: Reinitialize verity + hard-reset bootloader.
 	err = CustomizeImageWithConfigFile(buildDir, stage2bConfigFile, stage1FilePath, nil, stage2FilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -523,7 +523,7 @@ func testCustomizeImageVerityReinitUsrHelper(t *testing.T, testName string, imag
 
 	// Stage 1: Initialize verity.
 	err := CustomizeImageWithConfigFile(buildDir, stage1ConfigFile, baseImage, nil, stage1FilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -532,7 +532,7 @@ func testCustomizeImageVerityReinitUsrHelper(t *testing.T, testName string, imag
 
 	// Stage 2: Reinitialize verity.
 	err = CustomizeImageWithConfigFile(buildDir, stage2ConfigFile, stage1FilePath, nil, stage2FilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
@@ -259,7 +259,7 @@ func TestCustomizeImageNopShrink(t *testing.T) {
 	outImageFilePath := filepath.Join(testTempDir, "image.cosi")
 
 	// Customize image.
-	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "cosi", "" /*outputPXEArtifactsDir*/, true)
+	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "cosi", "" /*outputPXEArtifactsDir*/, true, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -352,7 +352,7 @@ func TestCustomizeImageExtractEmptyPartition(t *testing.T) {
 	outImageFilePath := filepath.Join(testTempDir, "image.raw")
 
 	// Customize image.
-	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "cosi", "", false /*useBaseImageRpmRepos*/)
+	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "cosi", "", false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/installedkernelcheck_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/installedkernelcheck_test.go
@@ -20,6 +20,6 @@ func TestCustomizeImageMissingKernel(t *testing.T) {
 
 	// Customize image.
 	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	assert.ErrorContains(t, err, "no installed kernel found")
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/kernelmoduleutils_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/kernelmoduleutils_test.go
@@ -228,7 +228,7 @@ func TestCustomizeImageKernelModules(t *testing.T) {
 
 	// Customize image.
 	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
@@ -48,7 +48,7 @@ func TestCustomizeImageLiveCd1(t *testing.T) {
 
 	// Customize vhdx to ISO, with OS changes.
 	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "iso",
-		pxeArtifactsPathVhdxToIso, true /*useBaseImageRpmRepos*/)
+		pxeArtifactsPathVhdxToIso, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	assert.NoError(t, err)
 
 	// Attach ISO.
@@ -129,7 +129,7 @@ func TestCustomizeImageLiveCd1(t *testing.T) {
 		},
 	}
 	err = CustomizeImage(buildDir, testDir, &config, outImageFilePath, nil, outImageFilePath, "iso",
-		pxeArtifactsPathIsoToIso, false /*useBaseImageRpmRepos*/)
+		pxeArtifactsPathIsoToIso, false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	assert.NoError(t, err)
 
 	// Attach ISO.
@@ -210,7 +210,7 @@ func TestCustomizeImageLiveCd2(t *testing.T) {
 	// Customize vhdx with ISO prereqs.
 	configFile := filepath.Join(testDir, "iso-os-prereqs-config.yaml")
 	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	assert.NoError(t, err)
 
 	// Customize image to ISO, with no OS changes.
@@ -218,13 +218,13 @@ func TestCustomizeImageLiveCd2(t *testing.T) {
 		Iso: &imagecustomizerapi.Iso{},
 	}
 	err = CustomizeImage(buildDir, testDir, &config, outImageFilePath, nil, outIsoFilePath, "iso",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	assert.NoError(t, err)
 
 	// Customize ISO to ISO, with OS changes.
 	configFile = filepath.Join(testDir, "addfiles-config.yaml")
 	err = CustomizeImageWithConfigFile(buildDir, configFile, outIsoFilePath, nil, outIsoFilePath, "iso",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	assert.NoError(t, err)
 
 	// Attach ISO.
@@ -299,7 +299,7 @@ func testCustomizeImageLiveCdIsoNoShimEfi(t *testing.T, testName string, version
 
 	// Customize image.
 	err := CustomizeImage(buildDir, testDir, config, baseImage, nil, outImageFilePath, "iso",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "failed to find the boot efi file")
 }
@@ -322,7 +322,7 @@ func TestCustomizeImageLiveCdIsoNoGrubEfi(t *testing.T) {
 
 	// Customize image.
 	err := CustomizeImage(buildDir, testDir, config, baseImage, nil, outImageFilePath, "iso",
-		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "failed to find the grub efi file")
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/resolvconf_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/resolvconf_test.go
@@ -30,7 +30,7 @@ func TestCustomizeImageResolvConfDelete(t *testing.T) {
 	}
 
 	err := CustomizeImage(buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -93,7 +93,7 @@ func TestCustomizeImageResolvConfRestoreFile(t *testing.T) {
 	}
 
 	err = CustomizeImage(buildDir, testDir, &config, outImageFilePath, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -163,7 +163,7 @@ func TestCustomizeImageResolvConfRestoreSymlink(t *testing.T) {
 	}
 
 	err = CustomizeImage(buildDir, testDir, &config, outImageFilePath, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -201,7 +201,7 @@ func TestCustomizeImageResolvConfNewSymlink(t *testing.T) {
 	}
 
 	err := CustomizeImage(buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/runscripts_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/runscripts_test.go
@@ -23,7 +23,7 @@ func TestCustomizeImageRunScripts(t *testing.T) {
 
 	// Customize image.
 	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/)
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}


### PR DESCRIPTION
<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

Add package snapshot support (p1) allowing users to specify time either in the CLI or configuration file. 
This enables snapshot-based package filtering during installation or update,
ensuring only packages available at that point in time are considered.

Supports:
- A date in `YYYY-MM-DD` format (interpreted as UTC midnight)
- A full RFC 3339 timestamp (e.g., `2024-05-20T23:59:59Z`)

### **Checklist**
- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
