### PR TITLE
Create release workflow.

### DIFF
--- a/.github/workflows/fork-release-branch.yml
+++ b/.github/workflows/fork-release-branch.yml
@@ -1,0 +1,57 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+name: Fork release branch
+
+permissions:
+  # Create release branch and publish release.
+  contents: write
+
+on:
+  workflow_call: {}
+
+jobs:
+  fork-branch:
+    name: Fork release branch
+    runs-on: ubuntu-latest
+    permissions:
+      # Create release branch and publish release.
+      contents: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        path: repo
+
+    - name: Download build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: out
+
+    - name: Fork release branch
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -x
+
+        VERSION=$(<"out/version/version.txt")
+        MINOR_VERSION="$(grep -oP '^[0-9]+\.[0-9]+' <<< "$VERSION")"
+
+        pushd ./repo
+
+        # Push new release branch.
+        MINOR_VERSION_BRANCH="release/v${MINOR_VERSION}"
+        git checkout -b "$MINOR_VERSION_BRANCH"
+        git push --set-upstream origin "$MINOR_VERSION_BRANCH"
+
+        # Push release tag.
+        TAG="v${VERSION}"
+        git tag "$TAG"
+        git push origin tag "$TAG"
+
+        # Create release.
+        mkdir -p ../release
+        mv ../out/binary-amd64/imagecustomizer.tar.gz ../release/imagecustomizer-amd64.tar.gz
+        mv ../out/binary-arm64/imagecustomizer.tar.gz ../release/imagecustomizer-arm64.tar.gz
+
+        gh release create "${TAG}" ../release/*

--- a/.github/workflows/open-bump-version-pr.yml
+++ b/.github/workflows/open-bump-version-pr.yml
@@ -1,0 +1,57 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+name: Fork release branch
+
+permissions:
+  # Create release branch and publish release.
+  contents: write
+  # Publish PR.
+  #pull-requests: write
+
+on:
+  workflow_call: {}
+
+jobs:
+  fork-branch:
+    name: Open bump version PR
+    runs-on: ubuntu-latest
+    permissions:
+      # Create release branch and publish release.
+      contents: write
+      # Publish PR.
+      #pull-requests: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        path: repo
+
+    - name: Open bump version PR
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -x
+
+        git config --global user.name 'github-actions[bot]'
+        git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+
+        pushd ./repo
+
+        # Switch to main branch.
+        git fetch --depth=1 --prune origin main
+        git checkout origin/main
+
+        # Bump version.
+        NEXT_MINOR_VERSION="$(python3 .github/workflows/scripts/bump_minor_version.py)"
+
+        # Commit and push.
+        BUMP_VERSION_BRANCH="workflows/bumpVersion${NEXT_MINOR_VERSION}"
+        git checkout -b "${BUMP_VERSION_BRANCH}"
+
+        git add -A
+        git commit -m "Bump version to v${NEXT_MINOR_VERSION}"
+        git push -u origin "${BUMP_VERSION_BRANCH}"
+
+        # Open PR.
+        #gh pr create -B main -H "${BUMP_VERSION_BRANCH}" --title "Bump version to v${NEXT_MINOR_VERSION}" --body ""

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -1,0 +1,52 @@
+name: Publish container to GHCR
+
+permissions:
+  # Publish to GHCR.
+  packages: write
+  # Create release branch and publish release.
+  contents: write
+
+on:
+  workflow_call: {}
+
+jobs:
+  publish-container:
+    name: Publish container
+    runs-on: ubuntu-latest
+    permissions:
+      # Publish to GHCR.
+      packages: write
+    steps:
+    - name: Download build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: out
+
+    - name: Login to GHCR
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+    - name: Publish container
+      run: |
+        set -x
+        VERSION=$(<"out/version/version.txt")
+
+        DOCKER_FULL_PATH="ghcr.io/${{ github.repository_owner }}/imagecustomizer:$VERSION"
+
+        for HOST_ARCH in amd64 arm64
+        do
+          # Import the image from the tarball.
+          OUTPUT="$(docker image load -i "out/container-$HOST_ARCH/imagecustomizer.tar.gz" 2>&1)"
+          TARBALL_TAG="$(echo $OUTPUT | awk '{print $3}')"
+
+          DOCKER_ARCH_FULL_PATH="$DOCKER_FULL_PATH-$HOST_ARCH"
+
+          # Push arch specific tag.
+          docker tag "$TARBALL_TAG" "$DOCKER_ARCH_FULL_PATH"
+          docker push "$DOCKER_ARCH_FULL_PATH"
+
+          # Create multi-arch manifest.
+          docker manifest create "$DOCKER_FULL_PATH" --amend "$DOCKER_ARCH_FULL_PATH"
+        done
+
+        # Push multi-arch manifest.
+        docker manifest push "$DOCKER_FULL_PATH"

--- a/.github/workflows/release-minor-version.yml
+++ b/.github/workflows/release-minor-version.yml
@@ -17,7 +17,7 @@ jobs:
   build:
     uses: ./.github/workflows/build.yml
     with:
-      publishType: production
+      publishType: official
 
   publish-container:
     uses: ./.github/workflows/publish-container.yml

--- a/.github/workflows/release-minor-version.yml
+++ b/.github/workflows/release-minor-version.yml
@@ -1,0 +1,35 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+name: Build, test, publish, and fork new major/minor version
+
+permissions:
+  contents: write
+  packages: write
+  # Publish PR.
+  #pull-requests: write
+
+on:
+  # Allow pipeline to be run manually.
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    with:
+      publishType: production
+
+  publish-container:
+    uses: ./.github/workflows/publish-container.yml
+    needs:
+    - build
+
+  fork-release-branch:
+    uses: ./.github/workflows/fork-release-branch.yml
+    needs:
+    - build
+
+  open-bump-version-pr:
+    uses: ./.github/workflows/open-bump-version-pr.yml
+    needs:
+    - build

--- a/.github/workflows/release-preview-version.yml
+++ b/.github/workflows/release-preview-version.yml
@@ -1,0 +1,24 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+name: Build and publish preview release
+
+permissions:
+  contents: read
+  # Publish to GHCR.
+  packages: write
+
+on:
+  # Allow pipeline to be run manually.
+  workflow_dispatch: {}
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    with:
+      publishType: preview
+
+  publish-container:
+    uses: ./.github/workflows/publish-container.yml
+    needs:
+    - build

--- a/.github/workflows/scripts/bump_minor_version.py
+++ b/.github/workflows/scripts/bump_minor_version.py
@@ -1,0 +1,35 @@
+import os
+from pathlib import Path
+import re
+
+SCRIPT_DIR = Path(os.path.realpath(__file__)).parent
+REPO_DIR = (SCRIPT_DIR / "../../../").resolve()
+VERSION_MAKEFILE_PATH = REPO_DIR / "toolkit/scripts/build_tag_imagecustomizer.mk"
+
+def main():
+    with open(VERSION_MAKEFILE_PATH, "r") as file:
+        version_makefile = file.read()
+
+    regex = re.compile(r"^image_customizer_version \?= ([0-9]+)\.([0-9]+)\.([0-9]+)$", re.MULTILINE)
+
+    match = regex.search(version_makefile)
+    if match is None:
+        raise RuntimeError(f"Failed to parse makefile ({VERSION_MAKEFILE_PATH})")
+
+    major = int(match.group(1))
+    minor = int(match.group(2))
+    patch = int(match.group(3))
+
+    # Bump version
+    minor += 1
+    patch = 0
+
+    version_makefile = regex.sub(f"image_customizer_version ?= {major}.{minor}.{patch}", version_makefile, count=1)
+
+    with open(VERSION_MAKEFILE_PATH, "w") as file:
+        file.write(version_makefile)
+
+    print(f"{major}.{minor}.{patch}")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Create a GitHub action workflow for publishing a new minor version.

This workflow automatically handles:

- Building the binary and container.
- Publishing the container.
- Forking the release branch.
- Tagging the release commit.
- Creating a GitHub release, which contains the binaries.
- Creating the bump version commit for main. Unfortunately, policy prevents workflows from creating a PR. But just creating the commit is still useful.

In the future, this pipeline will run all the tests before publishing the release.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
