### PR TITLE
Image Customizer: Reinit root verity + hard-reset bootloader.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
@@ -7,11 +7,13 @@ import (
 	"time"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/imagecustomizerapi"
+	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
 )
 
 func doOsCustomizations(buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
 	imageConnection *ImageConnection, rpmsSources []string, useBaseImageRpmRepos bool, partitionsCustomized bool,
-	imageUuid string) error {
+	imageUuid string, partUuidToFstabEntry map[string]diskutils.FstabEntry,
+) error {
 	var err error
 
 	imageChroot := imageConnection.Chroot()
@@ -71,7 +73,7 @@ func doOsCustomizations(buildDir string, baseConfigPath string, config *imagecus
 		}
 	}
 
-	err = handleBootLoader(baseConfigPath, config, imageConnection)
+	err = handleBootLoader(baseConfigPath, config, imageConnection, partUuidToFstabEntry)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
@@ -467,9 +467,10 @@ func testCustomizeImageVerityReinitRootHelper(t *testing.T, testName string, ima
 	testTempDir := filepath.Join(tmpDir, testName)
 	buildDir := filepath.Join(testTempDir, "build")
 	stage1ConfigFile := filepath.Join(testDir, "verity-config.yaml")
-	stage2ConfigFile := filepath.Join(testDir, "verity-reinit.yaml")
-	stage1FilePath := filepath.Join(testTempDir, "image.raw")
-	stage2FilePath := filepath.Join(testTempDir, "image.raw")
+	stage2aConfigFile := filepath.Join(testDir, "verity-reinit.yaml")
+	stage2bConfigFile := filepath.Join(testDir, "verity-reinit-bootloader-reset.yaml")
+	stage1FilePath := filepath.Join(testTempDir, "image1.raw")
+	stage2FilePath := filepath.Join(testTempDir, "image2.raw")
 
 	// Stage 1: Initialize verity.
 	err := CustomizeImageWithConfigFile(buildDir, stage1ConfigFile, baseImage, nil, stage1FilePath, "raw",
@@ -478,10 +479,19 @@ func testCustomizeImageVerityReinitRootHelper(t *testing.T, testName string, ima
 		return
 	}
 
+	verifyRootVerity(t, imageType, imageVersion, buildDir, stage1FilePath)
+
+	// Stage 2a: Reinitialize verity.
+	err = CustomizeImageWithConfigFile(buildDir, stage2aConfigFile, stage1FilePath, nil, stage2FilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
+	if !assert.NoError(t, err) {
+		return
+	}
+
 	verifyRootVerity(t, imageType, imageVersion, buildDir, stage2FilePath)
 
-	// Stage 2: Reinitialize verity.
-	err = CustomizeImageWithConfigFile(buildDir, stage2ConfigFile, stage1FilePath, nil, stage2FilePath, "raw",
+	// Stage 2b: Reinitialize verity + hard-reset bootloader.
+	err = CustomizeImageWithConfigFile(buildDir, stage2bConfigFile, stage1FilePath, nil, stage2FilePath, "raw",
 		"" /*outputPXEArtifactsDir*/, true /*useBaseImageRpmRepos*/)
 	if !assert.NoError(t, err) {
 		return

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -840,7 +840,7 @@ func customizeImageHelper(buildDir string, baseConfigPath string, config *imagec
 
 	// Do the actual customizations.
 	err = doOsCustomizations(buildDir, baseConfigPath, config, imageConnection, rpmsSources,
-		useBaseImageRpmRepos, partitionsCustomized, imageUuidStr)
+		useBaseImageRpmRepos, partitionsCustomized, imageUuidStr, partUuidToFstabEntry)
 
 	// Out of disk space errors can be difficult to diagnose.
 	// So, warn about any partitions with low free space.

--- a/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
@@ -663,39 +663,6 @@ func parseExtendedSourcePartition(source string) (ExtendedMountIdentifierType, s
 	return ExtendedMountIdentifierTypeDefault, "", err
 }
 
-func findRootMountIdTypeFromFstabFile(imageConnection *ImageConnection,
-) (imagecustomizerapi.MountIdentifierType, error) {
-	fstabPath := filepath.Join(imageConnection.chroot.RootDir(), "etc/fstab")
-
-	// Read the fstab file.
-	fstabEntries, err := diskutils.ReadFstabFile(fstabPath)
-	if err != nil {
-		return imagecustomizerapi.MountIdentifierTypeDefault, err
-	}
-
-	rootMountMatches := sliceutils.FindMatches(fstabEntries, func(fstabEntry diskutils.FstabEntry) bool {
-		return fstabEntry.Target == "/"
-	})
-	if len(rootMountMatches) < 1 {
-		err := fmt.Errorf("failed to find root mount (/) in fstab file")
-		return imagecustomizerapi.MountIdentifierTypeDefault, err
-	}
-	if len(rootMountMatches) > 1 {
-		err := fmt.Errorf("too many root mounts (/) in fstab file")
-		return imagecustomizerapi.MountIdentifierTypeDefault, err
-	}
-
-	rootMount := rootMountMatches[0]
-
-	rootMountIdType, _, err := parseSourcePartition(rootMount.Source)
-	if err != nil {
-		err := fmt.Errorf("failed to get mount ID type of root (/) from fstab file:\n%w", err)
-		return imagecustomizerapi.MountIdentifierTypeDefault, err
-	}
-
-	return rootMountIdType, nil
-}
-
 func getImageBootType(imageConnection *ImageConnection) (imagecustomizerapi.BootType, error) {
 	diskPartitions, err := diskutils.GetDiskPartitions(imageConnection.Loopback().DevicePath())
 	if err != nil {

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-reinit-bootloader-reset.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-reinit-bootloader-reset.yaml
@@ -1,0 +1,21 @@
+previewFeatures:
+- reinitialize-verity
+
+os:
+  bootloader:
+    resetType: hard-reset
+
+  kernelCommandLine:
+    extraCommandLine:
+    - "rd.info"
+
+  additionalFiles:
+  - content: |
+      cat, dog, elephant, squirrel
+    destination: /usr/local/share/animals.txt
+
+  users:
+  - name: root
+    password:
+      type: plain-text
+      value: hello

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-reinit-bootloader-reset.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-reinit-bootloader-reset.yaml
@@ -13,9 +13,3 @@ os:
   - content: |
       cat, dog, elephant, squirrel
     destination: /usr/local/share/animals.txt
-
-  users:
-  - name: root
-    password:
-      type: plain-text
-      value: hello

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-reinit.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-reinit.yaml
@@ -6,9 +6,3 @@ os:
   - content: |
       cat, dog, elephant, squirrel
     destination: /usr/local/share/animals.txt
-
-  users:
-  - name: root
-    password:
-      type: plain-text
-      value: hello


### PR DESCRIPTION
Fix a bug where Image Customizer fails if the user recustomizes a root verity enabled image, without customizing partitions, but still hard-resetting the bootloader. The bug was simply that the bootloader hard-reset logic didn't know how to handle `/dev/mapper` paths in `/etc/fstab` file.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
