### PR TITLE
Fix for when verity hash partition is referenced by UUID.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
@@ -408,8 +408,8 @@ func verityUsrVerity(t *testing.T, imageType baseImageType, imageVersion baseIma
 	bootPath := filepath.Join(imageConnection.chroot.RootDir(), "/boot")
 	usrDevice := partitionDevPath(imageConnection, 3)
 	hashDevice := partitionDevPath(imageConnection, 4)
-	verifyVerityGrub(t, bootPath, usrDevice, hashDevice, "PARTUUID="+partitions[3].PartUuid,
-		"PARTUUID="+partitions[4].PartUuid, "usr", "rd.info", imageVersion, corruptionOption)
+	verifyVerityGrub(t, bootPath, usrDevice, hashDevice, "UUID="+partitions[3].Uuid,
+		"UUID="+partitions[4].Uuid, "usr", "rd.info", imageVersion, corruptionOption)
 }
 
 func TestCustomizeImageVerityUsr2Stage(t *testing.T) {

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -949,12 +949,6 @@ func customizeVerityImageHelper(buildDir string, config *imagecustomizerapi.Conf
 			return nil, err
 		}
 
-		// Refresh disk partitions after running veritysetup so that the hash partition's UUID is correct.
-		diskPartitions, err = diskutils.GetDiskPartitions(loopback.DevicePath())
-		if err != nil {
-			return nil, err
-		}
-
 		metadata := verityDeviceMetadata{
 			name:                  verityConfig.Name,
 			rootHash:              rootHash,
@@ -967,6 +961,18 @@ func customizeVerityImageHelper(buildDir string, config *imagecustomizerapi.Conf
 		verityMetadata = append(verityMetadata, metadata)
 	}
 
+	// Refresh disk partitions after running veritysetup so that the hash partition's UUID is correct.
+	err = diskutils.RefreshPartitions(loopback.DevicePath())
+	if err != nil {
+		return nil, err
+	}
+
+	diskPartitions, err = diskutils.GetDiskPartitions(loopback.DevicePath())
+	if err != nil {
+		return nil, err
+	}
+
+	// Update kernel args.
 	isUki := config.OS.Uki != nil
 	err = updateKernelArgsForVerity(buildDir, diskPartitions, verityMetadata, isUki)
 	if err != nil {

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-config.yaml
@@ -24,6 +24,8 @@ storage:
     name: usr
     dataDeviceId: usr
     hashDeviceId: usrhash
+    dataDeviceMountIdType: uuid
+    hashDeviceMountIdType: uuid
     corruptionOption: io-error
 
   filesystems:


### PR DESCRIPTION
Ensure the hash partition's UUID is refreshed and reread after `veritysetup format` is called. This ensures that if the partition is identified by UUID, then the UUID will be correct in kernel args.

Also, for a regression test, change the existing usr-verity test so that the verity partitions are referenced by UUID. The root-verity test will continue to handle the PARTUUID case.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
