### PR TITLE
Patch release GitHub action.

### DIFF
--- a/.github/workflows/binary-build.yml
+++ b/.github/workflows/binary-build.yml
@@ -30,6 +30,8 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: repo
+        # Patch releases need the full history to find the latest tag.
+        fetch-depth: ${{ inputs.publishType == 'patch' && '0' || '1' }}
 
     - name: setup go 1.x
       uses: actions/setup-go@v5
@@ -106,6 +108,10 @@ jobs:
         case "${{ inputs.publishType }}" in
           "official")
             PRERELEASE_PARAM="IMAGE_CUSTOMIZER_VERSION_PREVIEW="
+            ;;
+          "patch")
+            PATCH_VERSION="$(python3 ./repo/.github/workflows/scripts/next_patch_version.py)"
+            PRERELEASE_PARAM="IMAGE_CUSTOMIZER_VERSION_PREVIEW= IMAGE_CUSTOMIZER_VERSION=$PATCH_VERSION"
             ;;
           "preview")
             PRERELEASE_PARAM="IMAGE_CUSTOMIZER_VERSION_PREVIEW=-preview.${{github.run_id}}"

--- a/.github/workflows/fork-release-branch.yml
+++ b/.github/workflows/fork-release-branch.yml
@@ -4,7 +4,7 @@
 name: Fork release branch
 
 permissions:
-  # Create release branch and publish release.
+  # Create release branch.
   contents: write
 
 on:
@@ -15,7 +15,7 @@ jobs:
     name: Fork release branch
     runs-on: ubuntu-latest
     permissions:
-      # Create release branch and publish release.
+      # Create release branch.
       contents: write
     steps:
     - name: Checkout
@@ -27,14 +27,13 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         path: out
+        name: version
 
     - name: Fork release branch
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         set -x
 
-        VERSION=$(<"out/version/version.txt")
+        VERSION=$(<"out/version.txt")
         MINOR_VERSION="$(grep -oP '^[0-9]+\.[0-9]+' <<< "$VERSION")"
 
         pushd ./repo
@@ -43,15 +42,3 @@ jobs:
         MINOR_VERSION_BRANCH="release/v${MINOR_VERSION}"
         git checkout -b "$MINOR_VERSION_BRANCH"
         git push --set-upstream origin "$MINOR_VERSION_BRANCH"
-
-        # Push release tag.
-        TAG="v${VERSION}"
-        git tag "$TAG"
-        git push origin tag "$TAG"
-
-        # Create release.
-        mkdir -p ../release
-        mv ../out/binary-amd64/imagecustomizer.tar.gz ../release/imagecustomizer-amd64.tar.gz
-        mv ../out/binary-arm64/imagecustomizer.tar.gz ../release/imagecustomizer-arm64.tar.gz
-
-        gh release create "${TAG}" ../release/*

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -1,0 +1,51 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+name: Publish release
+
+permissions:
+  # Create release tag and publish release.
+  contents: write
+
+on:
+  workflow_call: {}
+
+jobs:
+  publish-release:
+    name: Publish release
+    runs-on: ubuntu-latest
+    permissions:
+      # Create release tag and publish release.
+      contents: write
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        path: repo
+
+    - name: Download build artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: out
+
+    - name: Publish release
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -x
+
+        VERSION=$(<"out/version/version.txt")
+
+        pushd ./repo
+
+        # Push release tag.
+        TAG="v${VERSION}"
+        git tag "$TAG"
+        git push origin tag "$TAG"
+
+        # Create release.
+        mkdir -p ../release
+        mv ../out/binary-amd64/imagecustomizer.tar.gz ../release/imagecustomizer-amd64.tar.gz
+        mv ../out/binary-arm64/imagecustomizer.tar.gz ../release/imagecustomizer-arm64.tar.gz
+
+        gh release create "${TAG}" ../release/*

--- a/.github/workflows/release-minor-version.yml
+++ b/.github/workflows/release-minor-version.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-name: Build, test, publish, and fork new major/minor version
+name: Release (major/minor)
 
 permissions:
   # Push release branch and publish release.
@@ -25,6 +25,11 @@ jobs:
 
   publish-container:
     uses: ./.github/workflows/publish-container.yml
+    needs:
+    - build
+
+  publish-release:
+    uses: ./.github/workflows/publish-release.yml
     needs:
     - build
 

--- a/.github/workflows/release-patch-version.yml
+++ b/.github/workflows/release-patch-version.yml
@@ -1,14 +1,15 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-name: Release (preview)
+name: Release (patch)
 
 permissions:
-  contents: read
-  # "Keyless" container signing
-  id-token: write
+  # Push release branch and publish release.
+  contents: write
   # Publish to GHCR.
   packages: write
+  # "Keyless" container signing
+  id-token: write
 
 on:
   # Allow pipeline to be run manually.
@@ -18,9 +19,14 @@ jobs:
   build:
     uses: ./.github/workflows/build.yml
     with:
-      publishType: preview
+      publishType: patch
 
   publish-container:
     uses: ./.github/workflows/publish-container.yml
+    needs:
+    - build
+
+  publish-release:
+    uses: ./.github/workflows/publish-release.yml
     needs:
     - build

--- a/.github/workflows/scripts/bump_minor_version.py
+++ b/.github/workflows/scripts/bump_minor_version.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import os
 from pathlib import Path
 import re

--- a/.github/workflows/scripts/bump_minor_version.py
+++ b/.github/workflows/scripts/bump_minor_version.py
@@ -10,7 +10,7 @@ def main():
     with open(VERSION_MAKEFILE_PATH, "r") as file:
         version_makefile = file.read()
 
-    regex = re.compile(r"^image_customizer_version \?= ([0-9]+)\.([0-9]+)\.([0-9]+)$", re.MULTILINE)
+    regex = re.compile(r"^IMAGE_CUSTOMIZER_VERSION \?= ([0-9]+)\.([0-9]+)\.([0-9]+)$", re.MULTILINE)
 
     match = regex.search(version_makefile)
     if match is None:
@@ -24,7 +24,7 @@ def main():
     minor += 1
     patch = 0
 
-    version_makefile = regex.sub(f"image_customizer_version ?= {major}.{minor}.{patch}", version_makefile, count=1)
+    version_makefile = regex.sub(f"IMAGE_CUSTOMIZER_VERSION ?= {major}.{minor}.{patch}", version_makefile, count=1)
 
     with open(VERSION_MAKEFILE_PATH, "w") as file:
         file.write(version_makefile)

--- a/.github/workflows/scripts/next_patch_version.py
+++ b/.github/workflows/scripts/next_patch_version.py
@@ -1,0 +1,63 @@
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+SCRIPT_DIR = Path(os.path.realpath(__file__)).parent
+REPO_DIR = (SCRIPT_DIR / "../../../").resolve()
+VERSION_MAKEFILE_PATH = REPO_DIR / "toolkit/scripts/build_tag_imagecustomizer.mk"
+
+def main():
+    makefileVersion = getMakefileVersion()
+
+    versions = getVersionTags()
+    if len(versions) <= 0:
+        print(f"No previous tags found", file=sys.stderr)
+        exit(2)
+
+    mostRecentVersion = versions[0]
+
+    if mostRecentVersion[0] != makefileVersion[0] or mostRecentVersion[1] != makefileVersion[1]:
+        print(f"Makefile and most recent major/minor version s don't match: {makefileVersion} vs. {mostRecentVersion}", file=sys.stderr)
+        exit(3)
+
+    newPatchVersion = (mostRecentVersion[0], mostRecentVersion[1], mostRecentVersion[2]+1)
+    print(f"{newPatchVersion[0]}.{newPatchVersion[1]}.{newPatchVersion[2]}")
+
+def getMakefileVersion():
+    with open(VERSION_MAKEFILE_PATH, "r") as file:
+        version_makefile = file.read()
+
+    makefileRegex = re.compile(r"^IMAGE_CUSTOMIZER_VERSION \?= ([0-9]+)\.([0-9]+)\.([0-9]+)$", re.MULTILINE)
+
+    match = makefileRegex.search(version_makefile)
+    if match is None:
+        print(f"Failed to parse makefile ({VERSION_MAKEFILE_PATH})")
+        exit(1)
+
+    makefileVersion = (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+    return makefileVersion
+
+def getVersionTags():
+    tagListProc = subprocess.run(
+        ["git", "-C", REPO_DIR, "tag", "--list", "v*", "--merged"],
+        text=True, check=True, capture_output=True)
+    strTags = tagListProc.stdout.splitlines()
+
+    versionRegex = re.compile(r"^v([0-9]+)\.([0-9]+)\.([0-9]+)$", re.MULTILINE)
+
+    versions=[]
+    for strTag in strTags:
+        match = versionRegex.match(strTag)
+        if match is None:
+            continue
+
+        version = (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+        versions.append(version)
+
+    versions.sort(reverse=True)
+    return versions
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/scripts/next_patch_version.py
+++ b/.github/workflows/scripts/next_patch_version.py
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
 import os
 from pathlib import Path
 import re
@@ -19,7 +22,7 @@ def main():
     mostRecentVersion = versions[0]
 
     if mostRecentVersion[0] != makefileVersion[0] or mostRecentVersion[1] != makefileVersion[1]:
-        print(f"Makefile and most recent major/minor version s don't match: {makefileVersion} vs. {mostRecentVersion}", file=sys.stderr)
+        print(f"Makefile and most recent major/minor versions don't match: {makefileVersion} vs. {mostRecentVersion}", file=sys.stderr)
         exit(3)
 
     newPatchVersion = (mostRecentVersion[0], mostRecentVersion[1], mostRecentVersion[2]+1)

--- a/toolkit/scripts/build_tag_imagecustomizer.mk
+++ b/toolkit/scripts/build_tag_imagecustomizer.mk
@@ -4,12 +4,12 @@
 # Azure Linux Image Customizer version.
 # This is using semantic versioning.
 #
-# image_customizer_version should have the format:
+# IMAGE_CUSTOMIZER_VERSION should have the format:
 #
 #   <major>.<minor>.<patch>
 #
 # and should hold the value of the next (or current) official release, not the previous official
 # release.
-image_customizer_version ?= 0.15.0
+IMAGE_CUSTOMIZER_VERSION ?= 0.14.0
 IMAGE_CUSTOMIZER_VERSION_PREVIEW ?= -dev.$(DATETIME_AS_VERSION)+$(GIT_COMMIT_ID)
-image_customizer_full_version := $(image_customizer_version)$(IMAGE_CUSTOMIZER_VERSION_PREVIEW)
+image_customizer_full_version := $(IMAGE_CUSTOMIZER_VERSION)$(IMAGE_CUSTOMIZER_VERSION_PREVIEW)

--- a/toolkit/scripts/build_tag_imagecustomizer.mk
+++ b/toolkit/scripts/build_tag_imagecustomizer.mk
@@ -10,6 +10,6 @@
 #
 # and should hold the value of the next (or current) official release, not the previous official
 # release.
-IMAGE_CUSTOMIZER_VERSION ?= 0.14.0
+IMAGE_CUSTOMIZER_VERSION ?= 0.15.0
 IMAGE_CUSTOMIZER_VERSION_PREVIEW ?= -dev.$(DATETIME_AS_VERSION)+$(GIT_COMMIT_ID)
 image_customizer_full_version := $(IMAGE_CUSTOMIZER_VERSION)$(IMAGE_CUSTOMIZER_VERSION_PREVIEW)


### PR DESCRIPTION
Create a GitHub action workflow for building and publishing patch releases. These are mostly the same as major/minor releases but they don't fork a release branch and they don't use Makefile for the version. Instead patch releases auto-generate the next release version based on the previous git tags.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
