### PR TITLE
GitHub Actions: Automatically detect when release is the latest.

### DIFF
--- a/.github/workflows/binary-build.yml
+++ b/.github/workflows/binary-build.yml
@@ -15,6 +15,9 @@ on:
       arch:
         required: true
         type: string
+    outputs:
+      isLatestRelease:
+        value: ${{ jobs.build.outputs.isLatestRelease }}
 
 env:
   EXPECTED_GO_VERSION: "1.24.1"
@@ -25,6 +28,8 @@ jobs:
     runs-on: ${{ inputs.arch == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     permissions:
       contents: read
+    outputs:
+      isLatestRelease: ${{ steps.build.outputs.isLatestRelease }}
     steps:
     - name: checkout
       uses: actions/checkout@v4
@@ -101,17 +106,22 @@ jobs:
         fi
 
     - name: Build binary
+      id: build
       run: |
         set -x
+
+        IS_LATEST_RELEASE=false
 
         # Create version suffix.
         case "${{ inputs.publishType }}" in
           "official")
             PRERELEASE_PARAM="IMAGE_CUSTOMIZER_VERSION_PREVIEW="
+            IS_LATEST_RELEASE="true"
             ;;
           "patch")
             PATCH_VERSION="$(python3 ./repo/.github/workflows/scripts/next_patch_version.py)"
             PRERELEASE_PARAM="IMAGE_CUSTOMIZER_VERSION_PREVIEW= IMAGE_CUSTOMIZER_VERSION=$PATCH_VERSION"
+            IS_LATEST_RELEASE="$(python3 ./repo/.github/workflows/scripts/is_latest_release.py "v${PATCH_VERSION}")"
             ;;
           "preview")
             PRERELEASE_PARAM="IMAGE_CUSTOMIZER_VERSION_PREVIEW=-preview.${{github.run_id}}"
@@ -123,6 +133,8 @@ jobs:
             PRERELEASE_PARAM="IMAGE_CUSTOMIZER_VERSION_PREVIEW=-dev.${{github.run_id}}"
             ;;
         esac
+
+        echo "isLatestRelease=$IS_LATEST_RELEASE" >> "$GITHUB_OUTPUT"
 
         pushd repo/toolkit
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ on:
       publishType:
         required: true
         type: string
+    outputs:
+      isLatestRelease:
+        value: ${{ jobs.binary-build-amd64.outputs.isLatestRelease }}
 
 jobs:
   binary-build-amd64:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -8,7 +8,11 @@ permissions:
   contents: write
 
 on:
-  workflow_call: {}
+  workflow_call:
+    inputs:
+      isLatestRelease:
+        required: true
+        type: string
 
 jobs:
   publish-release:
@@ -48,4 +52,9 @@ jobs:
         mv ../out/binary-amd64/imagecustomizer.tar.gz ../release/imagecustomizer-amd64.tar.gz
         mv ../out/binary-arm64/imagecustomizer.tar.gz ../release/imagecustomizer-arm64.tar.gz
 
-        gh release create "${TAG}" ../release/*
+        gh release create --latest="${{ inputs.isLatestRelease }}" "${TAG}" ../release/*
+
+        # Push to stable branch.
+        if [ "${{ inputs.isLatestRelease }}" == "true" ]; then
+          git push --force origin HEAD:stable
+        fi

--- a/.github/workflows/release-minor-version.yml
+++ b/.github/workflows/release-minor-version.yml
@@ -30,6 +30,8 @@ jobs:
 
   publish-release:
     uses: ./.github/workflows/publish-release.yml
+    with:
+      isLatestRelease: true
     needs:
     - build
 

--- a/.github/workflows/release-patch-version.yml
+++ b/.github/workflows/release-patch-version.yml
@@ -28,5 +28,7 @@ jobs:
 
   publish-release:
     uses: ./.github/workflows/publish-release.yml
+    with:
+      isLatestRelease: ${{ needs.build.outputs.isLatestRelease }}
     needs:
     - build

--- a/.github/workflows/scripts/bump_minor_version.py
+++ b/.github/workflows/scripts/bump_minor_version.py
@@ -1,36 +1,21 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-import os
-from pathlib import Path
-import re
-
-SCRIPT_DIR = Path(os.path.realpath(__file__)).parent
-REPO_DIR = (SCRIPT_DIR / "../../../").resolve()
-VERSION_MAKEFILE_PATH = REPO_DIR / "toolkit/scripts/build_tag_imagecustomizer.mk"
+from version_utils import readMakefileVersion, parseMakefileVersion, MAKEFILE_VERSION_REGEX, VERSION_MAKEFILE_PATH
 
 def main():
-    with open(VERSION_MAKEFILE_PATH, "r") as file:
-        version_makefile = file.read()
-
-    regex = re.compile(r"^IMAGE_CUSTOMIZER_VERSION \?= ([0-9]+)\.([0-9]+)\.([0-9]+)$", re.MULTILINE)
-
-    match = regex.search(version_makefile)
-    if match is None:
-        raise RuntimeError(f"Failed to parse makefile ({VERSION_MAKEFILE_PATH})")
-
-    major = int(match.group(1))
-    minor = int(match.group(2))
-    patch = int(match.group(3))
+    versionMakefileContents = readMakefileVersion()
+    (major, minor, patch) = parseMakefileVersion(versionMakefileContents)
 
     # Bump version
     minor += 1
     patch = 0
 
-    version_makefile = regex.sub(f"IMAGE_CUSTOMIZER_VERSION ?= {major}.{minor}.{patch}", version_makefile, count=1)
+    versionMakefileContents = MAKEFILE_VERSION_REGEX.sub(f"IMAGE_CUSTOMIZER_VERSION ?= {major}.{minor}.{patch}",
+        versionMakefileContents, count=1)
 
     with open(VERSION_MAKEFILE_PATH, "w") as file:
-        file.write(version_makefile)
+        file.write(versionMakefileContents)
 
     print(f"{major}.{minor}.{patch}")
 

--- a/.github/workflows/scripts/is_latest_release.py
+++ b/.github/workflows/scripts/is_latest_release.py
@@ -1,0 +1,27 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import argparse
+
+from version_utils import getVersionTags, tryParseVersion
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('version')
+    args = parser.parse_args()
+
+    version = tryParseVersion(args.version)
+    if version is None:
+        raise Exception(f"Failed to parse version ({args.version})")
+
+    versions = getVersionTags(merged=False)
+
+    isLatestVersion = all(version >= other for other in versions)
+
+    if isLatestVersion:
+        print("true")
+    else:
+        print("false")
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/scripts/is_latest_release.py
+++ b/.github/workflows/scripts/is_latest_release.py
@@ -14,9 +14,9 @@ def main():
     if version is None:
         raise Exception(f"Failed to parse version ({args.version})")
 
-    versions = getVersionTags(merged=False)
+    publishedVersions = getVersionTags(merged=False)
 
-    isLatestVersion = all(version >= other for other in versions)
+    isLatestVersion = all(version >= publishedVersion for publishedVersion in publishedVersions)
 
     if isLatestVersion:
         print("true")

--- a/.github/workflows/scripts/next_patch_version.py
+++ b/.github/workflows/scripts/next_patch_version.py
@@ -1,20 +1,14 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-import os
-from pathlib import Path
-import re
-import subprocess
 import sys
 
-SCRIPT_DIR = Path(os.path.realpath(__file__)).parent
-REPO_DIR = (SCRIPT_DIR / "../../../").resolve()
-VERSION_MAKEFILE_PATH = REPO_DIR / "toolkit/scripts/build_tag_imagecustomizer.mk"
+from version_utils import getMakefileVersion, getVersionTags
 
 def main():
     makefileVersion = getMakefileVersion()
 
-    versions = getVersionTags()
+    versions = getVersionTags(merged=True)
     if len(versions) <= 0:
         print(f"No previous tags found", file=sys.stderr)
         exit(2)
@@ -27,40 +21,6 @@ def main():
 
     newPatchVersion = (mostRecentVersion[0], mostRecentVersion[1], mostRecentVersion[2]+1)
     print(f"{newPatchVersion[0]}.{newPatchVersion[1]}.{newPatchVersion[2]}")
-
-def getMakefileVersion():
-    with open(VERSION_MAKEFILE_PATH, "r") as file:
-        version_makefile = file.read()
-
-    makefileRegex = re.compile(r"^IMAGE_CUSTOMIZER_VERSION \?= ([0-9]+)\.([0-9]+)\.([0-9]+)$", re.MULTILINE)
-
-    match = makefileRegex.search(version_makefile)
-    if match is None:
-        print(f"Failed to parse makefile ({VERSION_MAKEFILE_PATH})")
-        exit(1)
-
-    makefileVersion = (int(match.group(1)), int(match.group(2)), int(match.group(3)))
-    return makefileVersion
-
-def getVersionTags():
-    tagListProc = subprocess.run(
-        ["git", "-C", REPO_DIR, "tag", "--list", "v*", "--merged"],
-        text=True, check=True, capture_output=True)
-    strTags = tagListProc.stdout.splitlines()
-
-    versionRegex = re.compile(r"^v([0-9]+)\.([0-9]+)\.([0-9]+)$", re.MULTILINE)
-
-    versions=[]
-    for strTag in strTags:
-        match = versionRegex.match(strTag)
-        if match is None:
-            continue
-
-        version = (int(match.group(1)), int(match.group(2)), int(match.group(3)))
-        versions.append(version)
-
-    versions.sort(reverse=True)
-    return versions
 
 if __name__ == "__main__":
     main()

--- a/.github/workflows/scripts/version_utils.py
+++ b/.github/workflows/scripts/version_utils.py
@@ -1,0 +1,63 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import os
+from pathlib import Path
+import subprocess
+import re
+
+SCRIPT_DIR = Path(os.path.realpath(__file__)).parent
+REPO_DIR = (SCRIPT_DIR / "../../../").resolve()
+VERSION_MAKEFILE_PATH = REPO_DIR / "toolkit/scripts/build_tag_imagecustomizer.mk"
+
+VERSION_REGEX = re.compile(r"^v([0-9]+)\.([0-9]+)\.([0-9]+)$", re.MULTILINE)
+MAKEFILE_VERSION_REGEX = re.compile(r"^IMAGE_CUSTOMIZER_VERSION \?= ([0-9]+)\.([0-9]+)\.([0-9]+)$", re.MULTILINE)
+
+def readMakefileVersion():
+    with open(VERSION_MAKEFILE_PATH, "r") as file:
+        versionMakefileContents = file.read()
+    return versionMakefileContents
+
+def parseMakefileVersion(versionMakefileContents):
+    makefileRegex = re.compile(r"^IMAGE_CUSTOMIZER_VERSION \?= ([0-9]+)\.([0-9]+)\.([0-9]+)$", re.MULTILINE)
+
+    match = makefileRegex.search(versionMakefileContents)
+    if match is None:
+        raise Exception(f"Failed to parse makefile ({VERSION_MAKEFILE_PATH})")
+
+    makefileVersion = (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+    return makefileVersion
+
+def getMakefileVersion():
+    versionMakefileContents = readMakefileVersion()
+    makefileVersion = parseMakefileVersion(versionMakefileContents)
+    return makefileVersion
+
+def getVersionTags(merged):
+    args = ["git", "-C", REPO_DIR, "tag", "--list", "v*"]
+    if merged:
+        args.append("--merged")
+    
+    tagListProc = subprocess.run(args, text=True, check=True, capture_output=True)
+    strTags = tagListProc.stdout.splitlines()
+
+    versionRegex = re.compile(r"^v([0-9]+)\.([0-9]+)\.([0-9]+)$", re.MULTILINE)
+
+    versions=[]
+    for strTag in strTags:
+        version = tryParseVersion(strTag)
+        if version is None:
+            continue
+
+        versions.append(version)
+
+    versions.sort(reverse=True)
+    return versions
+
+def tryParseVersion(versionStr):
+    match = VERSION_REGEX.match(versionStr)
+    if match is None:
+        return None
+
+    version = (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+    return version


### PR DESCRIPTION
Add logic that automatically detects when a release is the latest release. This is used both for marking the GitHub release as the latest release and for knowing when to update the `stable` branch.

This change also refactors the GitHub Python helper scripts so that they share common functionality.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
