### PR TITLE
Dependency adjust for Verity and UKI.

### DIFF
--- a/docs/imagecustomizer/how-to/verity-and-uki.md
+++ b/docs/imagecustomizer/how-to/verity-and-uki.md
@@ -90,8 +90,7 @@ the future.
        install:
        - veritysetup
        - systemd-boot
-       - efibootmgr
-       - lvm2
+       - device-mapper
     ```
 
 2. Run Image Customizer to create the image file.

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki.go
@@ -144,8 +144,7 @@ func validateUkiDependencies(imageChroot *safechroot.Chroot) error {
 	// The following packages are required for the UKI feature:
 	// - "systemd-boot": Checked as a package dependency here to ensure installation,
 	//    but additional configuration is handled elsewhere in the UKI workflow.
-	// - "efibootmgr": Used for managing EFI boot entries.
-	requiredRpms := []string{"systemd-boot", "efibootmgr"}
+	requiredRpms := []string{"systemd-boot"}
 
 	// Iterate over each required package and check if it's installed.
 	for _, pkg := range requiredRpms {

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
@@ -325,7 +325,9 @@ func parseSystemdVerityOptions(options string) (imagecustomizerapi.CorruptionOpt
 }
 
 func validateVerityDependencies(imageChroot *safechroot.Chroot) error {
-	requiredRpms := []string{"lvm2"}
+	// "device-mapper" is required for dm-verity support because it provides "dmsetup",
+	// which Dracut needs to install the "dm" module (a dependency of "systemd-veritysetup").
+	requiredRpms := []string{"device-mapper"}
 
 	// Iterate over each required package and check if it's installed.
 	for _, pkg := range requiredRpms {

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/artifacts-output.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/artifacts-output.yaml
@@ -58,7 +58,6 @@ os:
     - grub2-efi-binary
     install:
     - systemd-boot
-    - efibootmgr
     - openssh-server
 
   services:

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-config.yaml
@@ -65,7 +65,7 @@ os:
     - openssh-server
     - veritysetup
     - vim
-    - lvm2
+    - device-mapper
 
   additionalFiles:
     # Change the directory that the sshd-keygen service writes the SSH host keys to.

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-partition-labels.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-partition-labels.yaml
@@ -69,7 +69,7 @@ os:
     - openssh-server
     - veritysetup
     - vim
-    - lvm2
+    - device-mapper
 
   additionalFiles:
     # Change the directory that the sshd-keygen service writes the SSH host keys to.

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-config.yaml
@@ -67,7 +67,7 @@ os:
     - openssh-server
     - veritysetup
     - vim
-    - lvm2
+    - device-mapper
 
   services:
     enable:

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-uki.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-uki.yaml
@@ -68,5 +68,4 @@ os:
     install:
     - veritysetup
     - systemd-boot
-    - efibootmgr
-    - lvm2
+    - device-mapper


### PR DESCRIPTION
<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

This PR removes `efibootmgr` since it was only used during UKI development and is not needed at runtime. It also replaces `lvm2` with `device-mapper` as the correct minimal dependency for Verity support.

---

### **Checklist**
- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
