### PR TITLE
Refactor legacy boot functional tests.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
@@ -27,15 +27,6 @@ func TestCustomizeImagePartitions(t *testing.T) {
 	}
 }
 
-func TestCustomizeImagePartitionsLegacyToEfi(t *testing.T) {
-	for _, version := range supportedAzureLinuxVersions {
-		t.Run(string(version), func(t *testing.T) {
-			testCustomizeImagePartitionsToEfi(t, "TestCustomizeImagePartitionsLegacyToEfi"+string(version),
-				baseImageTypeCoreLegacy, version)
-		})
-	}
-}
-
 func testCustomizeImagePartitionsToEfi(t *testing.T, testName string, imageType baseImageType,
 	imageVersion baseImageVersion,
 ) {
@@ -53,6 +44,10 @@ func testCustomizeImagePartitionsToEfi(t *testing.T, testName string, imageType 
 		return
 	}
 
+	verifyEfiPartitionsImage(t, outImageFilePath, imageVersion, buildDir)
+}
+
+func verifyEfiPartitionsImage(t *testing.T, outImageFilePath string, imageVersion baseImageVersion, buildDir string) {
 	// Check output file type.
 	checkFileType(t, outImageFilePath, "raw")
 
@@ -196,7 +191,7 @@ func TestCustomizeImagePartitionsSizeOnly(t *testing.T) {
 	assert.Equal(t, uint64(2*diskutils.GiB), partitions[3].SizeInBytes)
 }
 
-func TestCustomizeImagePartitionsEfiToLegacy(t *testing.T) {
+func TestCustomizeImagePartitionsLegacy(t *testing.T) {
 	// Skip this test on arm64 because the legacy bootloader is not supported.
 	if runtime.GOARCH == "arm64" {
 		t.Skip("Skipping legacy test for arm64")
@@ -204,38 +199,52 @@ func TestCustomizeImagePartitionsEfiToLegacy(t *testing.T) {
 
 	for _, version := range supportedAzureLinuxVersions {
 		t.Run(string(version), func(t *testing.T) {
-			testCustomizeImagePartitionsToLegacy(t, "TestCustomizeImagePartitionsEfiToLegacy"+string(version),
+			testCustomizeImagePartitionsLegacy(t, "TestCustomizeImagePartitionsLegacy"+string(version),
 				baseImageTypeCoreEfi, version)
 		})
 	}
 }
 
-func TestCustomizeImagePartitionsLegacy(t *testing.T) {
-	for _, version := range supportedAzureLinuxVersions {
-		t.Run(string(version), func(t *testing.T) {
-			testCustomizeImagePartitionsToLegacy(t, "TestCustomizeImagePartitionsLegacy"+string(version),
-				baseImageTypeCoreLegacy, version)
-		})
-	}
-}
-
-func testCustomizeImagePartitionsToLegacy(t *testing.T, testName string, imageType baseImageType,
+func testCustomizeImagePartitionsLegacy(t *testing.T, testName string, imageType baseImageType,
 	imageVersion baseImageVersion,
 ) {
 	baseImage := checkSkipForCustomizeImage(t, imageType, imageVersion)
 
 	testTmpDir := filepath.Join(tmpDir, testName)
 	buildDir := filepath.Join(testTmpDir, "build")
-	configFile := filepath.Join(testDir, "legacyboot-config.yaml")
-	outImageFilePath := filepath.Join(buildDir, "image.raw")
+	legacybootConfigFile := filepath.Join(testDir, "legacyboot-config.yaml")
+	efiConfigFile := filepath.Join(testDir, "partitions-config.yaml")
+	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
-	// Customize image.
-	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
+	// Convert to legacy image.
+	err := CustomizeImageWithConfigFile(buildDir, legacybootConfigFile, baseImage, nil, outImageFilePath, "raw",
 		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return
 	}
 
+	verifyLegacyBootImage(t, outImageFilePath, imageVersion, buildDir)
+
+	// Recustomize legacy image.
+	err = CustomizeImageWithConfigFile(buildDir, legacybootConfigFile, outImageFilePath, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	verifyLegacyBootImage(t, outImageFilePath, imageVersion, buildDir)
+
+	// Convert back to EFI image.
+	err = CustomizeImageWithConfigFile(buildDir, efiConfigFile, outImageFilePath, nil, outImageFilePath, "raw",
+		"" /*outputPXEArtifactsDir*/, false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	verifyEfiPartitionsImage(t, outImageFilePath, imageVersion, buildDir)
+}
+
+func verifyLegacyBootImage(t *testing.T, outImageFilePath string, imageVersion baseImageVersion, buildDir string) {
 	// Check output file type.
 	checkFileType(t, outImageFilePath, "raw")
 

--- a/toolkit/tools/pkg/imagecustomizerlib/main_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/main_test.go
@@ -19,8 +19,7 @@ import (
 type baseImageType string
 
 const (
-	baseImageTypeCoreEfi    baseImageType = "core-efi"
-	baseImageTypeCoreLegacy baseImageType = "core-legacy"
+	baseImageTypeCoreEfi baseImageType = "core-efi"
 )
 
 type baseImageVersion string
@@ -35,10 +34,8 @@ const (
 )
 
 var (
-	baseImageCoreEfiAzl2    = flag.String("base-image-core-efi-azl2", "", "A core-efi 2.0 image to use as a base image.")
-	baseImageCoreEfiAzl3    = flag.String("base-image-core-efi-azl3", "", "A core-efi 3.0 image to use as a base image.")
-	baseImageCoreLegacyAzl2 = flag.String("base-image-core-legacy-azl2", "", "A core-legacy 2.0 image to use as a base image.")
-	baseImageCoreLegacyAzl3 = flag.String("base-image-core-legacy-azl3", "", "A core-legacy 3.0 image to use as a base image.")
+	baseImageCoreEfiAzl2 = flag.String("base-image-core-efi-azl2", "", "A core-efi 2.0 image to use as a base image.")
+	baseImageCoreEfiAzl3 = flag.String("base-image-core-efi-azl3", "", "A core-efi 3.0 image to use as a base image.")
 )
 
 var (
@@ -109,15 +106,6 @@ func getImageParamAndName(baseImageType baseImageType, baseImageVersion baseImag
 
 		case baseImageVersionAzl3:
 			return baseImageCoreEfiAzl3, "base-image-core-efi-azl3"
-		}
-
-	case baseImageTypeCoreLegacy:
-		switch baseImageVersion {
-		case baseImageVersionAzl2:
-			return baseImageCoreLegacyAzl2, "base-image-core-legacy-azl2"
-
-		case baseImageVersionAzl3:
-			return baseImageCoreLegacyAzl3, "base-image-core-legacy-azl3"
 		}
 	}
 


### PR DESCRIPTION
Stop taking legacy boot images as input. Instead, convert an UEFI image to legacy boot and use that to test legacy boot customization.

This change is being made in preparation of a future change that will allow the functional tests to be runnable against more image types.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
