### PR TITLE
Don't apply noexec mount flag during customization.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
@@ -392,16 +392,24 @@ func testCustomizeImageNewUUIDsHelper(t *testing.T, testName string, imageType b
 		imageVersion)
 }
 
-func verifyFstabEntries(t *testing.T, imageConnection *ImageConnection, mountPoints []mountPoint,
-	partitions map[int]diskutils.PartitionInfo,
-) {
+func getFilteredFstabEntries(t *testing.T, imageConnection *ImageConnection) []diskutils.FstabEntry {
 	fstabPath := filepath.Join(imageConnection.Chroot().RootDir(), "/etc/fstab")
 	fstabEntries, err := diskutils.ReadFstabFile(fstabPath)
 	if !assert.NoError(t, err, "read /etc/fstab") {
-		return
+		return nil
 	}
 
 	filteredFstabEntries := filterOutSpecialPartitions(fstabEntries)
+	return filteredFstabEntries
+}
+
+func verifyFstabEntries(t *testing.T, imageConnection *ImageConnection, mountPoints []mountPoint,
+	partitions map[int]diskutils.PartitionInfo,
+) {
+	filteredFstabEntries := getFilteredFstabEntries(t, imageConnection)
+	if filteredFstabEntries == nil {
+		return
+	}
 
 	if !assert.Equalf(t, len(mountPoints), len(filteredFstabEntries), "/etc/fstab entries count: %v", filteredFstabEntries) {
 		return

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/unix"
@@ -80,4 +81,59 @@ func TestCustomizeImageVerityUsrUki(t *testing.T) {
 	usrHashDevice := partitionDevPath(imageConnection, 4)
 	verifyVerityUki(t, espPath, usrDevice, usrHashDevice, "PARTUUID="+partitions[3].PartUuid,
 		"PARTUUID="+partitions[4].PartUuid, "usr", buildDir, "rd.info", "panic-on-corruption")
+
+	expectedFstabEntries := []diskutils.FstabEntry{
+		{
+			Source:     "PARTUUID=" + partitions[5].PartUuid,
+			Target:     "/",
+			FsType:     "ext4",
+			Options:    "noexec",
+			VfsOptions: 0x8,
+			FsOptions:  "",
+			Freq:       0,
+			PassNo:     1,
+		},
+		{
+			Source:     "PARTUUID=" + partitions[2].PartUuid,
+			Target:     "/boot",
+			FsType:     "ext4",
+			Options:    "defaults",
+			VfsOptions: 0x0,
+			FsOptions:  "",
+			Freq:       0,
+			PassNo:     2,
+		},
+		{
+			Source:     "PARTUUID=" + partitions[1].PartUuid,
+			Target:     "/boot/efi",
+			FsType:     "vfat",
+			Options:    "umask=0077",
+			VfsOptions: 0x0,
+			FsOptions:  "umask=0077",
+			Freq:       0,
+			PassNo:     2,
+		},
+		{
+			Source:     "/dev/mapper/usr",
+			Target:     "/usr",
+			FsType:     "ext4",
+			Options:    "ro",
+			VfsOptions: 0x1,
+			FsOptions:  "",
+			Freq:       0,
+			PassNo:     2,
+		},
+		{
+			Source:     "PARTUUID=" + partitions[6].PartUuid,
+			Target:     "/var",
+			FsType:     "ext4",
+			Options:    "defaults",
+			VfsOptions: 0x0,
+			FsOptions:  "",
+			Freq:       0,
+			PassNo:     2,
+		},
+	}
+	filteredFstabEntries := getFilteredFstabEntries(t, imageConnection)
+	assert.Equal(t, expectedFstabEntries, filteredFstabEntries)
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
@@ -58,6 +58,11 @@ func TestCustomizeImageVerityUsrUki(t *testing.T) {
 			FileSystemType: "ext4",
 			Flags:          unix.MS_RDONLY,
 		},
+		{
+			PartitionNum:   6,
+			Path:           "/var",
+			FileSystemType: "ext4",
+		},
 	}
 
 	imageConnection, err := connectToImage(buildDir, outImageFilePath, false /*includeDefaultMounts*/, mountPoints)

--- a/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
@@ -215,7 +215,9 @@ func fstabEntriesToMountPoints(fstabEntries []diskutils.FstabEntry, diskPartitio
 		}
 
 		// Unset read-only flag so that read-only partitions can be customized.
-		vfsOptions := fstabEntry.VfsOptions & ^diskutils.MountFlags(unix.MS_RDONLY)
+		// Unset noexec flag so that if rootfs is set as noexec, image can still be customized. For example, allowing
+		// grub2-mkconfig to be called.
+		vfsOptions := fstabEntry.VfsOptions & ^diskutils.MountFlags(unix.MS_RDONLY|unix.MS_NOEXEC)
 
 		var mountPoint *safechroot.MountPoint
 		if fstabEntry.Target == "/" {

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-uki.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-uki.yaml
@@ -20,7 +20,10 @@ storage:
       size: 100M
 
     - id: root
-      size: 2G
+      size: 500M
+
+    - id: var
+      size: 1G
 
   verity:
   - id: verityusr
@@ -42,13 +45,19 @@ storage:
 
   - deviceId: root
     type: ext4
-    mountPoint: /
+    mountPoint:
+      path: /
+      options: noexec
 
   - deviceId: verityusr
     type: ext4
     mountPoint:
       path: /usr
       options: ro
+
+  - deviceId: var
+    type: ext4
+    mountPoint: /var
 
 os:
   bootloader:
@@ -66,6 +75,23 @@ os:
     - grub2-efi-binary
 
     install:
+    - openssh-server
     - veritysetup
     - systemd-boot
     - device-mapper
+
+  users:
+  - name: root
+    password:
+      type: plain-text
+      value: hello
+
+scripts:
+  postCustomization:
+  - content: |
+      set -eux
+
+      # Move iptables script off of the / partition, so that the iptables service can run even though / has the noexec
+      # mount flag.
+      mv /etc/systemd/scripts /usr/bin/
+      ln -sr /usr/bin/scripts /etc/systemd/scripts


### PR DESCRIPTION
If the user applies the `noexec` to a partition's mount options, then add `noexec` to the `/etc/fstab` file but don't apply `noexec` during customization. This allows scripts like `grub2-mkconfig` to run during customization.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
