### PR TITLE
Make base image input to functional tests more generic.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestOutputAndInjectArtifacts(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionAzl3)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	ukifyExists, err := file.CommandExists("ukify")
 	assert.NoError(t, err)

--- a/toolkit/tools/pkg/imagecustomizerlib/customizebootloader_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizebootloader_test.go
@@ -13,25 +13,22 @@ import (
 )
 
 func TestCustomizeImageMultiKernel(t *testing.T) {
-	for _, version := range supportedAzureLinuxVersions {
-		t.Run(string(version), func(t *testing.T) {
-			testCustomizeImageMultiKernel(t, "TestCustomizeImageMultiKernel"+string(version),
-				baseImageTypeCoreEfi, version)
+	for _, baseImageInfo := range baseImageAll {
+		t.Run(baseImageInfo.Name, func(t *testing.T) {
+			testCustomizeImageMultiKernel(t, "TestCustomizeImageMultiKernel"+baseImageInfo.Name, baseImageInfo)
 		})
 	}
 }
 
-func testCustomizeImageMultiKernel(t *testing.T, testName string, imageType baseImageType,
-	imageVersion baseImageVersion,
-) {
-	baseImage := checkSkipForCustomizeImage(t, imageType, imageVersion)
+func testCustomizeImageMultiKernel(t *testing.T, testName string, baseImageInfo testBaseImageInfo) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	testTmpDir := filepath.Join(tmpDir, testName)
 	buildDir := filepath.Join(testTmpDir, "build")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
 	configFile := ""
-	switch imageVersion {
+	switch baseImageInfo.Version {
 	case baseImageVersionAzl2:
 		configFile = filepath.Join(testDir, "multikernel-azl2.yaml")
 
@@ -60,7 +57,7 @@ func testCustomizeImageMultiKernel(t *testing.T, testName string, imageType base
 	linuxCommandRegex := regexp.MustCompile(`linux.* console=tty0 console=ttyS0 `)
 	matches := linuxCommandRegex.FindAllString(grubCfgContents, -1)
 
-	switch imageVersion {
+	switch baseImageInfo.Version {
 	case baseImageVersionAzl2:
 		// AZL2's default grub.cfg file doesn't support multiple kernels.
 		assert.GreaterOrEqual(t, len(matches), 1, "grub.cfg:\n%s", grubCfgContents)

--- a/toolkit/tools/pkg/imagecustomizerlib/customizefiles_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizefiles_test.go
@@ -71,7 +71,7 @@ func TestCopyAdditionalFiles(t *testing.T) {
 }
 
 func TestCustomizeImageAdditionalFiles(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageAdditionalFiles")
 	buildDir := filepath.Join(testTmpDir, "build")
@@ -117,7 +117,7 @@ func TestCustomizeImageAdditionalFiles(t *testing.T) {
 }
 
 func TestCustomizeImageAdditionalFilesInfiniteFile(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageAdditionalFilesInfiniteFile")
 	buildDir := filepath.Join(testTmpDir, "build")
@@ -193,7 +193,7 @@ func TestCopyAdditionalDirs(t *testing.T) {
 }
 
 func TestCustomizeImageAdditionalDirs(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageAdditionalDirs")
 	buildDir := filepath.Join(testTmpDir, "build")
@@ -222,7 +222,7 @@ func TestCustomizeImageAdditionalDirs(t *testing.T) {
 }
 
 func TestCustomizeImageAdditionalDirsInfiniteFile(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageAdditionalDirsInfiniteFile")
 	buildDir := filepath.Join(testTmpDir, "build")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizehostname_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizehostname_test.go
@@ -39,7 +39,7 @@ func TestUpdateHostname(t *testing.T) {
 }
 
 func TestCustomizeImageHostname(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageHostname")
 	buildDir := filepath.Join(testTmpDir, "build")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeoverlays_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeoverlays_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestCustomizeImageOverlays(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageOverlays")
 	buildDir := filepath.Join(testTempDir, "build")
@@ -79,7 +79,7 @@ func TestCustomizeImageOverlays(t *testing.T) {
 }
 
 func TestCustomizeImageOverlaysSELinux(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageOverlaysSELinux")
 	buildDir := filepath.Join(testTempDir, "build")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
@@ -277,8 +277,6 @@ func TestCustomizeImageKernelCommandLine(t *testing.T) {
 }
 
 func testCustomizeImageKernelCommandLineHelper(t *testing.T, testName string, baseImageInfo testBaseImageInfo) {
-	var err error
-
 	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	buildDir := filepath.Join(tmpDir, testName)
@@ -286,7 +284,7 @@ func testCustomizeImageKernelCommandLineHelper(t *testing.T, testName string, ba
 	outImageFilePath := filepath.Join(buildDir, "image.qcow2")
 
 	// Customize image.
-	err = CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
+	err := CustomizeImageWithConfigFile(buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
 		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	if !assert.NoError(t, err) {
 		return

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeselinux_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeselinux_test.go
@@ -14,18 +14,15 @@ import (
 )
 
 func TestCustomizeImageSELinux(t *testing.T) {
-	for _, version := range supportedAzureLinuxVersions {
-		t.Run(string(version), func(t *testing.T) {
-			testCustomizeImageSELinuxHelper(t, "TestCustomizeImageSELinux"+string(version), baseImageTypeCoreEfi,
-				version)
+	for _, baseImageInfo := range baseImageAll {
+		t.Run(baseImageInfo.Name, func(t *testing.T) {
+			testCustomizeImageSELinuxHelper(t, "TestCustomizeImageSELinux"+baseImageInfo.Name, baseImageInfo)
 		})
 	}
 }
 
-func testCustomizeImageSELinuxHelper(t *testing.T, testName string, imageType baseImageType,
-	imageVersion baseImageVersion,
-) {
-	baseImage := checkSkipForCustomizeImage(t, imageType, imageVersion)
+func testCustomizeImageSELinuxHelper(t *testing.T, testName string, baseImageInfo testBaseImageInfo) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	testTmpDir := filepath.Join(tmpDir, testName)
 	buildDir := filepath.Join(testTmpDir, "build")
@@ -111,18 +108,15 @@ func testCustomizeImageSELinuxHelper(t *testing.T, testName string, imageType ba
 }
 
 func TestCustomizeImageSELinuxAndPartitions(t *testing.T) {
-	for _, version := range supportedAzureLinuxVersions {
-		t.Run(string(version), func(t *testing.T) {
-			testCustomizeImageSELinuxAndPartitionsHelper(t, "TestCustomizeImageSELinuxAndPartitions"+string(version),
-				baseImageTypeCoreEfi, version)
+	for _, baseImageInfo := range baseImageAll {
+		t.Run(baseImageInfo.Name, func(t *testing.T) {
+			testCustomizeImageSELinuxAndPartitionsHelper(t, "TestCustomizeImageSELinuxAndPartitions"+baseImageInfo.Name, baseImageInfo)
 		})
 	}
 }
 
-func testCustomizeImageSELinuxAndPartitionsHelper(t *testing.T, testName string, imageType baseImageType,
-	imageVersion baseImageVersion,
-) {
-	baseImage := checkSkipForCustomizeImage(t, imageType, imageVersion)
+func testCustomizeImageSELinuxAndPartitionsHelper(t *testing.T, testName string, baseImageInfo testBaseImageInfo) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	testTmpDir := filepath.Join(tmpDir, testName)
 	buildDir := filepath.Join(testTmpDir, "build")
@@ -172,7 +166,7 @@ func testCustomizeImageSELinuxAndPartitionsHelper(t *testing.T, testName string,
 }
 
 func TestCustomizeImageSELinuxNoPolicy(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageSELinuxNoPolicy")
 	buildDir := filepath.Join(testTmpDir, "build")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeservices_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeservices_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestCustomizeImageServicesEnableDisable(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageServicesEnableDisable")
 	buildDir := filepath.Join(testTmpDir, "build")
@@ -45,7 +45,7 @@ func TestCustomizeImageServicesEnableDisable(t *testing.T) {
 }
 
 func TestCustomizeImageServicesEnableUnknown(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageServicesEnableUnknown")
 	buildDir := filepath.Join(testTmpDir, "build")
@@ -69,7 +69,7 @@ func TestCustomizeImageServicesEnableUnknown(t *testing.T) {
 }
 
 func TestCustomizeImageServicesDisableUnknown(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageServicesDisableUnknown")
 	buildDir := filepath.Join(testTmpDir, "build")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
@@ -14,9 +14,8 @@ import (
 )
 
 func TestCustomizeImageVerityUsrUki(t *testing.T) {
-	imageType := baseImageTypeCoreEfi
-	imageVersion := baseImageVersionAzl3
-	baseImage := checkSkipForCustomizeImage(t, imageType, imageVersion)
+	baseImageInfo := testBaseImageAzl3CoreEfi
+	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	ukifyExists, err := file.CommandExists("ukify")
 	assert.NoError(t, err)

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeusers_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeusers_test.go
@@ -25,7 +25,7 @@ var (
 )
 
 func TestCustomizeImageUsers(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageUsers")
 	buildDir := filepath.Join(testTmpDir, "build")
@@ -144,7 +144,7 @@ func TestCustomizeImageUsers(t *testing.T) {
 }
 
 func TestCustomizeImageUsersExitingUserHomeDir(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageUsers")
 	buildDir := filepath.Join(testTmpDir, "build")
@@ -168,7 +168,7 @@ func TestCustomizeImageUsersExitingUserHomeDir(t *testing.T) {
 }
 
 func TestCustomizeImageUsersExitingUserUid(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageUsers")
 	buildDir := filepath.Join(testTmpDir, "build")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
@@ -22,18 +22,15 @@ import (
 )
 
 func TestCustomizeImageVerity(t *testing.T) {
-	for _, version := range supportedAzureLinuxVersions {
-		t.Run(string(version), func(t *testing.T) {
-			testCustomizeImageVerityHelper(t, "TestCustomizeImageVerity"+string(version), baseImageTypeCoreEfi,
-				version)
+	for _, baseImageInfo := range baseImageAll {
+		t.Run(baseImageInfo.Name, func(t *testing.T) {
+			testCustomizeImageVerityHelper(t, "TestCustomizeImageVerity"+baseImageInfo.Name, baseImageInfo)
 		})
 	}
 }
 
-func testCustomizeImageVerityHelper(t *testing.T, testName string, imageType baseImageType,
-	imageVersion baseImageVersion,
-) {
-	baseImage := checkSkipForCustomizeImage(t, imageType, imageVersion)
+func testCustomizeImageVerityHelper(t *testing.T, testName string, baseImageInfo testBaseImageInfo) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	testTempDir := filepath.Join(tmpDir, testName)
 	buildDir := filepath.Join(testTempDir, "build")
@@ -47,7 +44,7 @@ func testCustomizeImageVerityHelper(t *testing.T, testName string, imageType bas
 		return
 	}
 
-	verifyRootVerity(t, imageType, imageVersion, buildDir, outImageFilePath)
+	verifyRootVerity(t, baseImageInfo, buildDir, outImageFilePath)
 
 	// Recustomize the image.
 	err = CustomizeImageWithConfigFile(buildDir, configFile, outImageFilePath, nil, outImageFilePath, "raw",
@@ -56,10 +53,10 @@ func testCustomizeImageVerityHelper(t *testing.T, testName string, imageType bas
 		return
 	}
 
-	verifyRootVerity(t, imageType, imageVersion, buildDir, outImageFilePath)
+	verifyRootVerity(t, baseImageInfo, buildDir, outImageFilePath)
 }
 
-func verifyRootVerity(t *testing.T, imageType baseImageType, imageVersion baseImageVersion, buildDir string,
+func verifyRootVerity(t *testing.T, baseImageInfo testBaseImageInfo, buildDir string,
 	outImageFilePath string,
 ) {
 	// Connect to customized image.
@@ -102,7 +99,7 @@ func verifyRootVerity(t *testing.T, imageType baseImageType, imageVersion baseIm
 	rootDevice := partitionDevPath(imageConnection, 3)
 	hashDevice := partitionDevPath(imageConnection, 4)
 	verifyVerityGrub(t, bootPath, rootDevice, hashDevice, "PARTUUID="+partitions[3].PartUuid,
-		"PARTUUID="+partitions[4].PartUuid, "root", "rd.info", imageVersion, "panic-on-corruption")
+		"PARTUUID="+partitions[4].PartUuid, "root", "rd.info", baseImageInfo, "panic-on-corruption")
 
 	err = imageConnection.CleanClose()
 	if !assert.NoError(t, err) {
@@ -111,18 +108,15 @@ func verifyRootVerity(t *testing.T, imageType baseImageType, imageVersion baseIm
 }
 
 func TestCustomizeImageVerityCosiShrinkExtract(t *testing.T) {
-	for _, version := range supportedAzureLinuxVersions {
-		t.Run(string(version), func(t *testing.T) {
-			testCustomizeImageVerityCosiExtractHelper(t, "TestCustomizeImageVerityShrinkExtract"+string(version),
-				baseImageTypeCoreEfi, version)
+	for _, baseImageInfo := range baseImageAll {
+		t.Run(baseImageInfo.Name, func(t *testing.T) {
+			testCustomizeImageVerityCosiExtractHelper(t, "TestCustomizeImageVerityShrinkExtract"+baseImageInfo.Name, baseImageInfo)
 		})
 	}
 }
 
-func testCustomizeImageVerityCosiExtractHelper(t *testing.T, testName string, imageType baseImageType,
-	imageVersion baseImageVersion,
-) {
-	baseImage := checkSkipForCustomizeImage(t, imageType, imageVersion)
+func testCustomizeImageVerityCosiExtractHelper(t *testing.T, testName string, baseImageInfo testBaseImageInfo) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	testTempDir := filepath.Join(tmpDir, testName)
 	buildDir := filepath.Join(testTempDir, "build")
@@ -214,11 +208,11 @@ func testCustomizeImageVerityCosiExtractHelper(t *testing.T, testName string, im
 
 	// Verify that verity is configured correctly.
 	verifyVerityGrub(t, bootMountPath, rootDevice.DevicePath(), hashDevice.DevicePath(), "PARTLABEL=root",
-		"PARTLABEL=roothash", "root", "rd.info", imageVersion, "panic-on-corruption")
+		"PARTLABEL=roothash", "root", "rd.info", baseImageInfo, "panic-on-corruption")
 }
 
 func verifyVerityGrub(t *testing.T, bootPath string, dataDevice string, hashDevice string, dataId string, hashId string,
-	verityType string, extraCommandLine string, imageVersion baseImageVersion, corruptionOption string,
+	verityType string, extraCommandLine string, baseImageInfo testBaseImageInfo, corruptionOption string,
 ) {
 	// Extract kernel command line args.
 	grubCfgPath := filepath.Join(bootPath, "/grub2/grub.cfg")
@@ -240,7 +234,7 @@ func verifyVerityGrub(t *testing.T, bootPath string, dataDevice string, hashDevi
 
 	// Verity extra command line args.
 	recoveryCount := 0
-	if imageVersion == baseImageVersionAzl3 {
+	if baseImageInfo.Version == baseImageVersionAzl3 {
 		// Count the number of recovery menu items there are.
 		// These menu items won't contain the extra command line args.
 		recoveryCount = strings.Count(grubCfgContents, "(recovery mode)")
@@ -335,18 +329,15 @@ func verifyVerityHelper(t *testing.T, kernelArgsList []string, dataDevice string
 }
 
 func TestCustomizeImageVerityUsr(t *testing.T) {
-	for _, version := range supportedAzureLinuxVersions {
-		t.Run(string(version), func(t *testing.T) {
-			testCustomizeImageVerityUsrHelper(t, "TestCustomizeImageVerityUsr"+string(version), baseImageTypeCoreEfi,
-				version)
+	for _, baseImageInfo := range baseImageAll {
+		t.Run(baseImageInfo.Name, func(t *testing.T) {
+			testCustomizeImageVerityUsrHelper(t, "TestCustomizeImageVerityUsr"+baseImageInfo.Name, baseImageInfo)
 		})
 	}
 }
 
-func testCustomizeImageVerityUsrHelper(t *testing.T, testName string, imageType baseImageType,
-	imageVersion baseImageVersion,
-) {
-	baseImage := checkSkipForCustomizeImage(t, imageType, imageVersion)
+func testCustomizeImageVerityUsrHelper(t *testing.T, testName string, baseImageInfo testBaseImageInfo) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	testTempDir := filepath.Join(tmpDir, testName)
 	buildDir := filepath.Join(testTempDir, "build")
@@ -360,7 +351,7 @@ func testCustomizeImageVerityUsrHelper(t *testing.T, testName string, imageType 
 		return
 	}
 
-	verityUsrVerity(t, imageType, imageVersion, buildDir, outImageFilePath, "")
+	verityUsrVerity(t, baseImageInfo, buildDir, outImageFilePath, "")
 
 	// Recustomize image.
 	// This helps verify that verity-enabled images can be recustomized.
@@ -370,10 +361,10 @@ func testCustomizeImageVerityUsrHelper(t *testing.T, testName string, imageType 
 		return
 	}
 
-	verityUsrVerity(t, imageType, imageVersion, buildDir, outImageFilePath, "")
+	verityUsrVerity(t, baseImageInfo, buildDir, outImageFilePath, "")
 }
 
-func verityUsrVerity(t *testing.T, imageType baseImageType, imageVersion baseImageVersion, buildDir string,
+func verityUsrVerity(t *testing.T, baseImageInfo testBaseImageInfo, buildDir string,
 	outImageFilePath string, corruptionOption string,
 ) {
 	// Connect to usr verity image.
@@ -415,22 +406,19 @@ func verityUsrVerity(t *testing.T, imageType baseImageType, imageVersion baseIma
 	usrDevice := partitionDevPath(imageConnection, 3)
 	hashDevice := partitionDevPath(imageConnection, 4)
 	verifyVerityGrub(t, bootPath, usrDevice, hashDevice, "UUID="+partitions[3].Uuid,
-		"UUID="+partitions[4].Uuid, "usr", "rd.info", imageVersion, corruptionOption)
+		"UUID="+partitions[4].Uuid, "usr", "rd.info", baseImageInfo, corruptionOption)
 }
 
 func TestCustomizeImageVerityUsr2Stage(t *testing.T) {
-	for _, version := range supportedAzureLinuxVersions {
-		t.Run(string(version), func(t *testing.T) {
-			testCustomizeImageVerityUsr2StageHelper(t, "testCustomizeImageVerityUsr2Stage"+string(version), baseImageTypeCoreEfi,
-				version)
+	for _, baseImageInfo := range baseImageAll {
+		t.Run(baseImageInfo.Name, func(t *testing.T) {
+			testCustomizeImageVerityUsr2StageHelper(t, "testCustomizeImageVerityUsr2Stage"+baseImageInfo.Name, baseImageInfo)
 		})
 	}
 }
 
-func testCustomizeImageVerityUsr2StageHelper(t *testing.T, testName string, imageType baseImageType,
-	imageVersion baseImageVersion,
-) {
-	baseImage := checkSkipForCustomizeImage(t, imageType, imageVersion)
+func testCustomizeImageVerityUsr2StageHelper(t *testing.T, testName string, baseImageInfo testBaseImageInfo) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	testTempDir := filepath.Join(tmpDir, testName)
 	buildDir := filepath.Join(testTempDir, "build")
@@ -453,22 +441,19 @@ func testCustomizeImageVerityUsr2StageHelper(t *testing.T, testName string, imag
 		return
 	}
 
-	verityUsrVerity(t, imageType, imageVersion, buildDir, stage2FilePath, "panic-on-corruption")
+	verityUsrVerity(t, baseImageInfo, buildDir, stage2FilePath, "panic-on-corruption")
 }
 
 func TestCustomizeImageVerityReinitRoot(t *testing.T) {
-	for _, version := range supportedAzureLinuxVersions {
-		t.Run(string(version), func(t *testing.T) {
-			testCustomizeImageVerityReinitRootHelper(t, "TestCustomizeImageVerityReinitRoot"+string(version),
-				baseImageTypeCoreEfi, version)
+	for _, baseImageInfo := range baseImageAll {
+		t.Run(baseImageInfo.Name, func(t *testing.T) {
+			testCustomizeImageVerityReinitRootHelper(t, "TestCustomizeImageVerityReinitRoot"+baseImageInfo.Name, baseImageInfo)
 		})
 	}
 }
 
-func testCustomizeImageVerityReinitRootHelper(t *testing.T, testName string, imageType baseImageType,
-	imageVersion baseImageVersion,
-) {
-	baseImage := checkSkipForCustomizeImage(t, imageType, imageVersion)
+func testCustomizeImageVerityReinitRootHelper(t *testing.T, testName string, baseImageInfo testBaseImageInfo) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	testTempDir := filepath.Join(tmpDir, testName)
 	buildDir := filepath.Join(testTempDir, "build")
@@ -485,7 +470,7 @@ func testCustomizeImageVerityReinitRootHelper(t *testing.T, testName string, ima
 		return
 	}
 
-	verifyRootVerity(t, imageType, imageVersion, buildDir, stage1FilePath)
+	verifyRootVerity(t, baseImageInfo, buildDir, stage1FilePath)
 
 	// Stage 2a: Reinitialize verity.
 	err = CustomizeImageWithConfigFile(buildDir, stage2aConfigFile, stage1FilePath, nil, stage2FilePath, "raw",
@@ -494,7 +479,7 @@ func testCustomizeImageVerityReinitRootHelper(t *testing.T, testName string, ima
 		return
 	}
 
-	verifyRootVerity(t, imageType, imageVersion, buildDir, stage1FilePath)
+	verifyRootVerity(t, baseImageInfo, buildDir, stage1FilePath)
 
 	// Stage 2b: Reinitialize verity + hard-reset bootloader.
 	err = CustomizeImageWithConfigFile(buildDir, stage2bConfigFile, stage1FilePath, nil, stage2FilePath, "raw",
@@ -503,22 +488,19 @@ func testCustomizeImageVerityReinitRootHelper(t *testing.T, testName string, ima
 		return
 	}
 
-	verifyRootVerity(t, imageType, imageVersion, buildDir, stage2FilePath)
+	verifyRootVerity(t, baseImageInfo, buildDir, stage2FilePath)
 }
 
 func TestCustomizeImageVerityReinitUsr(t *testing.T) {
-	for _, version := range supportedAzureLinuxVersions {
-		t.Run(string(version), func(t *testing.T) {
-			testCustomizeImageVerityReinitUsrHelper(t, "TestCustomizeImageVerityReinitUsr"+string(version),
-				baseImageTypeCoreEfi, version)
+	for _, baseImageInfo := range baseImageAll {
+		t.Run(baseImageInfo.Name, func(t *testing.T) {
+			testCustomizeImageVerityReinitUsrHelper(t, "TestCustomizeImageVerityReinitUsr"+baseImageInfo.Name, baseImageInfo)
 		})
 	}
 }
 
-func testCustomizeImageVerityReinitUsrHelper(t *testing.T, testName string, imageType baseImageType,
-	imageVersion baseImageVersion,
-) {
-	baseImage := checkSkipForCustomizeImage(t, imageType, imageVersion)
+func testCustomizeImageVerityReinitUsrHelper(t *testing.T, testName string, baseImageInfo testBaseImageInfo) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	testTempDir := filepath.Join(tmpDir, testName)
 	buildDir := filepath.Join(testTempDir, "build")
@@ -534,7 +516,7 @@ func testCustomizeImageVerityReinitUsrHelper(t *testing.T, testName string, imag
 		return
 	}
 
-	verityUsrVerity(t, imageType, imageVersion, buildDir, stage1FilePath, "")
+	verityUsrVerity(t, baseImageInfo, buildDir, stage1FilePath, "")
 
 	// Stage 2: Reinitialize verity.
 	err = CustomizeImageWithConfigFile(buildDir, stage2ConfigFile, stage1FilePath, nil, stage2FilePath, "raw",
@@ -543,5 +525,5 @@ func testCustomizeImageVerityReinitUsrHelper(t *testing.T, testName string, imag
 		return
 	}
 
-	verityUsrVerity(t, imageType, imageVersion, buildDir, stage2FilePath, "")
+	verityUsrVerity(t, baseImageInfo, buildDir, stage2FilePath, "")
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
@@ -251,7 +251,7 @@ func verifySkippableFrameMetadataFromFile(partitionFilepath string, magicNumber 
 func TestCustomizeImageNopShrink(t *testing.T) {
 	var err error
 
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	configFile := filepath.Join(testDir, "consume-space.yaml")
 	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageNopShrink")
@@ -344,7 +344,7 @@ func TestCustomizeImageNopShrink(t *testing.T) {
 func TestCustomizeImageExtractEmptyPartition(t *testing.T) {
 	var err error
 
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageExtractEmptyPartition")
 	buildDir := filepath.Join(testTempDir, "build")

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -50,7 +50,7 @@ var (
 func TestCustomizeImageEmptyConfig(t *testing.T) {
 	var err error
 
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	buildDir := filepath.Join(tmpDir, "TestCustomizeImageEmptyConfig")
 	outImageFilePath := filepath.Join(buildDir, "image.vhd")
@@ -68,7 +68,7 @@ func TestCustomizeImageEmptyConfig(t *testing.T) {
 }
 
 func TestCustomizeImageVhd(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageVhd")
 	buildDir := filepath.Join(testTmpDir, "build")
@@ -532,7 +532,7 @@ func TestCustomizeImage_InputImageFileSelection(t *testing.T) {
 	config := &imagecustomizerapi.Config{}
 
 	inputImageFileFake := filepath.Join(buildDir, "doesnotexist.xxx")
-	inputImageFileReal := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	inputImageFileReal, _ := checkSkipForCustomizeDefaultImage(t)
 
 	inputImageFile := inputImageFileReal
 	rpmSources := []string{}
@@ -579,7 +579,7 @@ func TestCustomizeImage_InputImageFileAsRelativePath(t *testing.T) {
 	config := &imagecustomizerapi.Config{}
 
 	inputImageFileAbsoluteFake := filepath.Join(buildDir, "doesnotexist.xxx")
-	inputImageFileAbsoluteReal := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	inputImageFileAbsoluteReal, _ := checkSkipForCustomizeDefaultImage(t)
 
 	cwd, err := os.Getwd()
 	assert.NoError(t, err)
@@ -642,7 +642,7 @@ func TestCustomizeImage_InputImageFileAsRelativePath(t *testing.T) {
 func TestCustomizeImageKernelCommandLineAdd(t *testing.T) {
 	var err error
 
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	buildDir := filepath.Join(tmpDir, "TestCustomizeImageKernelCommandLine")
 	outImageFilePath := filepath.Join(buildDir, "image.vhd")
@@ -691,7 +691,7 @@ func TestCustomizeImage_OutputImageFileSelection(t *testing.T) {
 	buildDir := filepath.Join(tmpDir, "TestCustomizeImage_OutputImageFileSelection")
 	baseConfigPath := buildDir
 	config := &imagecustomizerapi.Config{}
-	inputImageFile := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	inputImageFile, _ := checkSkipForCustomizeDefaultImage(t)
 	rpmSources := []string{}
 
 	outputImageFileAsArgument := filepath.Join(buildDir, "image-as-arg.vhd")
@@ -739,7 +739,7 @@ func TestCustomizeImage_OutputImageFileAsRelativePath(t *testing.T) {
 	buildDir := filepath.Join(tmpDir, "TestCustomizeImage_OutputImageFileAsRelativePathOnCommandLine")
 	baseConfigPath := buildDir
 	config := &imagecustomizerapi.Config{}
-	inputImageFile := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	inputImageFile, _ := checkSkipForCustomizeDefaultImage(t)
 	rpmSources := []string{}
 
 	outputImageFileAbsolute := filepath.Join(buildDir, "image.vhdx")
@@ -780,7 +780,7 @@ func TestCustomizeImage_OutputImageFileAsRelativePath(t *testing.T) {
 }
 
 func TestCustomizeImage_OutputImageFormatSelection(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	buildDir := filepath.Join(tmpDir, "TestCustomizeImage_OutputImageFormatSelection")
 	outputImageFile := filepath.Join(buildDir, "image.dat")

--- a/toolkit/tools/pkg/imagecustomizerlib/installedkernelcheck_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/installedkernelcheck_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestCustomizeImageMissingKernel(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageMissingKernel")
 	buildDir := filepath.Join(testTmpDir, "build")

--- a/toolkit/tools/pkg/imagecustomizerlib/kernelmoduleutils_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/kernelmoduleutils_test.go
@@ -219,7 +219,7 @@ func TestRemoveModuleFromDisableList(t *testing.T) {
 }
 
 func TestCustomizeImageKernelModules(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageKernelModules")
 	buildDir := filepath.Join(testTmpDir, "build")

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
@@ -300,7 +300,7 @@ func VerifyBootstrapPXEArtifacts(t *testing.T, packageInfo *PackageVersionInform
 // - ISO  {bootstrap}  to ISO {bootstrap}    , with no OS changes
 // - ISO  {bootstrap}  to ISO {full-os}      , with selinux disabled
 func TestCustomizeImageLiveOSInitramfs1(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, baseImageInfo := checkSkipForCustomizeDefaultImage(t)
 
 	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageLiveOSInitramfs1")
 	buildDir := filepath.Join(testTempDir, "build")
@@ -308,7 +308,7 @@ func TestCustomizeImageLiveOSInitramfs1(t *testing.T) {
 
 	// SELinux in Live OS is only supported with azl3
 	selinuxMode := imagecustomizerapi.SELinuxModeEnforcing
-	if baseImageVersionDefault == baseImageVersionAzl2 {
+	if baseImageInfo.Version == baseImageVersionAzl2 {
 		selinuxMode = imagecustomizerapi.SELinuxModeDisabled
 	}
 
@@ -356,7 +356,7 @@ func TestCustomizeImageLiveOSInitramfs1(t *testing.T) {
 // - ISO  {full-os}    to ISO {full-os}      , with selinux disabled
 // - ISO  {full-os}    to ISO {bootstrap}    , with selinux enforcing + bootstrap prereqs
 func TestCustomizeImageLiveOSInitramfs2(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, baseImageInfo := checkSkipForCustomizeDefaultImage(t)
 
 	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageLiveOSInitramfs2")
 	buildDir := filepath.Join(testTempDir, "build")
@@ -390,7 +390,7 @@ func TestCustomizeImageLiveOSInitramfs2(t *testing.T) {
 
 	// SELinux in Live OS is only supported with azl3
 	selinuxMode := imagecustomizerapi.SELinuxModeEnforcing
-	if baseImageVersionDefault == baseImageVersionAzl2 {
+	if baseImageInfo.Version == baseImageVersionAzl2 {
 		selinuxMode = imagecustomizerapi.SELinuxModeDisabled
 	}
 
@@ -409,7 +409,7 @@ func TestCustomizeImageLiveOSInitramfs2(t *testing.T) {
 // Tests:
 // - vhdx {raw} to ISO {full-os}, with selinux enabled -> error
 func TestCustomizeImageLiveOSInitramfs3(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageLiveOSInitramfs3")
 	buildDir := filepath.Join(testTempDir, "build")
@@ -427,10 +427,11 @@ func TestCustomizeImageLiveOSInitramfs3(t *testing.T) {
 // Tests:
 // - vhdx {raw} to PXE {bootstrap}, with selinux enforcing
 func TestCustomizeImageLiveOSPxe1(t *testing.T) {
-	if baseImageVersionDefault == baseImageVersionAzl2 {
+	baseImage, baseImageInfo := checkSkipForCustomizeDefaultImage(t)
+
+	if baseImageInfo.Version == baseImageVersionAzl2 {
 		t.Skip("Skipping - PXE bootstrap is not supported for Azure Linux 2")
 	}
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
 
 	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageLiveOSPxe1")
 	buildDir := filepath.Join(testTempDir, "build")
@@ -452,7 +453,7 @@ func TestCustomizeImageLiveOSPxe1(t *testing.T) {
 // Tests:
 // - vhdx {raw} to PXE {full-os}, with selinux disabled
 func TestCustomizeImageLiveOSPxe2(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageLiveOSPxe2")
 	buildDir := filepath.Join(testTempDir, "build")
@@ -471,25 +472,22 @@ func TestCustomizeImageLiveOSPxe2(t *testing.T) {
 }
 
 func TestCustomizeImageLiveOSIsoNoShimEfi(t *testing.T) {
-	for _, version := range supportedAzureLinuxVersions {
-
-		t.Run(string(version), func(t *testing.T) {
-			testCustomizeImageLiveOSIsoNoShimEfi(t, "TestCustomizeImageLiveCdIsoNoShimEfi"+string(version),
-				version)
+	for _, baseImageInfo := range baseImageAll {
+		t.Run(baseImageInfo.Name, func(t *testing.T) {
+			testCustomizeImageLiveOSIsoNoShimEfi(t, "TestCustomizeImageLiveCdIsoNoShimEfi"+baseImageInfo.Name, baseImageInfo)
 		})
-
 	}
 }
 
-func testCustomizeImageLiveOSIsoNoShimEfi(t *testing.T, testName string, version baseImageVersion) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, version)
+func testCustomizeImageLiveOSIsoNoShimEfi(t *testing.T, testName string, baseImageInfo testBaseImageInfo) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	buildDir := filepath.Join(tmpDir, testName)
 	outImageFilePath := filepath.Join(buildDir, defaultIsoImageName)
 	shimPackage := "shim"
 
 	// For arm64 and baseImageVersionAzl2, the shim package is shim-unsigned.
-	if runtime.GOARCH == "arm64" && version == baseImageVersionAzl2 {
+	if runtime.GOARCH == "arm64" && baseImageInfo.Distro == baseImageDistroAzureLinux && baseImageInfo.Version == baseImageVersionAzl2 {
 		shimPackage = "shim-unsigned"
 	}
 
@@ -511,7 +509,7 @@ func testCustomizeImageLiveOSIsoNoShimEfi(t *testing.T, testName string, version
 }
 
 func TestCustomizeImageLiveOSIsoNoGrubEfi(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	buildDir := filepath.Join(tmpDir, "TestCustomizeImageLiveOSIsoNoGrubEfi")
 	outImageFilePath := filepath.Join(buildDir, defaultIsoImageName)

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
@@ -487,7 +487,7 @@ func testCustomizeImageLiveOSIsoNoShimEfi(t *testing.T, testName string, baseIma
 	shimPackage := "shim"
 
 	// For arm64 and baseImageVersionAzl2, the shim package is shim-unsigned.
-	if runtime.GOARCH == "arm64" && baseImageInfo.Distro == baseImageDistroAzureLinux && baseImageInfo.Version == baseImageVersionAzl2 {
+	if runtime.GOARCH == "arm64" && baseImageInfo.Version == baseImageVersionAzl2 {
 		shimPackage = "shim-unsigned"
 	}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/resolvconf_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/resolvconf_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestCustomizeImageResolvConfDelete(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageResolvConfDelete")
 	buildDir := filepath.Join(testTmpDir, "build")
@@ -51,7 +51,7 @@ func TestCustomizeImageResolvConfDelete(t *testing.T) {
 }
 
 func TestCustomizeImageResolvConfRestoreFile(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageResolvConfRestoreFile")
 	buildDir := filepath.Join(testTmpDir, "build")
@@ -122,7 +122,7 @@ func TestCustomizeImageResolvConfRestoreFile(t *testing.T) {
 }
 
 func TestCustomizeImageResolvConfRestoreSymlink(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageResolvConfRestoreSymlink")
 	buildDir := filepath.Join(testTmpDir, "build")
@@ -185,7 +185,7 @@ func TestCustomizeImageResolvConfRestoreSymlink(t *testing.T) {
 }
 
 func TestCustomizeImageResolvConfNewSymlink(t *testing.T) {
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageResolvConfNewSymlink")
 	buildDir := filepath.Join(testTmpDir, "build")

--- a/toolkit/tools/pkg/imagecustomizerlib/runscripts_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/runscripts_test.go
@@ -14,7 +14,7 @@ import (
 func TestCustomizeImageRunScripts(t *testing.T) {
 	var err error
 
-	baseImage := checkSkipForCustomizeImage(t, baseImageTypeCoreEfi, baseImageVersionDefault)
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageRunScripts")
 	buildDir := filepath.Join(testTmpDir, "build")


### PR DESCRIPTION
1. Change base image info from a set of parameters to a combined struct. This will make it eaiser to pass the info around. It also makes it easier to add additional properties.

2. Change the default base image from a constant to a priority list. This will make it easier to manually run the image independent tests on other images.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
