### PR TITLE
Support UKI enabled base image customization.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
@@ -264,9 +264,15 @@ func verifyVerityUki(t *testing.T, espPath string, dataDevice string,
 	corruptionOption string,
 ) {
 	// Extract kernel command line args.
-	kernelArgsList, err := extractKernelCmdlineFromUkiEfis(espPath, buildDir)
+	kernelToArgs, err := extractKernelCmdlineFromUkiEfis(espPath, buildDir)
 	if !assert.NoError(t, err) {
 		return
+	}
+
+	// Convert map[string]string → []string
+	kernelArgsList := make([]string, 0, len(kernelToArgs))
+	for _, args := range kernelToArgs {
+		kernelArgsList = append(kernelArgsList, args)
 	}
 
 	// Verify verity

--- a/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
@@ -482,16 +482,23 @@ func extractKernelCmdlineFromUki(espPartition *diskutils.PartitionInfo,
 	}
 	defer espPartitionMount.Close()
 
-	cmdlineContents, err := extractKernelCmdlineFromUkiEfis(tmpDirEsp, buildDir)
+	kernelToArgs, err := extractKernelCmdlineFromUkiEfis(tmpDirEsp, buildDir)
 	if err != nil {
 		return nil, err
 	}
 
-	if len(cmdlineContents) == 0 {
+	if len(kernelToArgs) == 0 {
 		return nil, os.ErrNotExist
 	}
 
-	tokens, err := grub.TokenizeConfig(string(cmdlineContents[0]))
+	// Assumes only one UKI is needed, uses the first entry in the map.
+	var firstCmdline string
+	for _, cmdline := range kernelToArgs {
+		firstCmdline = cmdline
+		break
+	}
+
+	tokens, err := grub.TokenizeConfig(firstCmdline)
 	if err != nil {
 		return nil, fmt.Errorf("failed to tokenize kernel command-line from UKI: %w", err)
 	}
@@ -509,7 +516,7 @@ func extractKernelCmdlineFromUki(espPartition *diskutils.PartitionInfo,
 	return args, nil
 }
 
-func extractKernelCmdlineFromUkiEfis(espPath string, buildDir string) ([]string, error) {
+func extractKernelCmdlineFromUkiEfis(espPath string, buildDir string) (map[string]string, error) {
 	cmdlinePath := filepath.Join(buildDir, "cmdline.txt")
 
 	espLinuxPath := filepath.Join(espPath, UkiOutputDir)
@@ -518,8 +525,13 @@ func extractKernelCmdlineFromUkiEfis(espPath string, buildDir string) ([]string,
 		return nil, fmt.Errorf("failed to search for UKI images in ESP partition:\n%w", err)
 	}
 
-	cmdlineContents := []string(nil)
+	kernelToArgsString := make(map[string]string)
 	for _, ukiFile := range ukiFiles {
+		kernelName, err := getKernelNameFromUki(ukiFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to extract kernel name from UKI file (%s):\n%w", ukiFile, err)
+		}
+
 		_, _, err = shell.Execute("objcopy", "--dump-section", ".cmdline="+cmdlinePath, ukiFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to dump kernel cmdline args from UKI (%s):\n%w", ukiFile, err)
@@ -530,10 +542,10 @@ func extractKernelCmdlineFromUkiEfis(espPath string, buildDir string) ([]string,
 			return nil, fmt.Errorf("failed to read kernel cmdline args from dumped file (%s):\n%w", ukiFile, err)
 		}
 
-		cmdlineContents = append(cmdlineContents, string(cmdlineContent))
+		kernelToArgsString[kernelName] = string(cmdlineContent)
 	}
 
-	return cmdlineContents, nil
+	return kernelToArgsString, nil
 }
 
 func extractKernelCmdlineFromGrub(bootPartition *diskutils.PartitionInfo,
@@ -547,7 +559,7 @@ func extractKernelCmdlineFromGrub(bootPartition *diskutils.PartitionInfo,
 	defer bootPartitionMount.Close()
 
 	grubCfgPath := filepath.Join(tmpDirBoot, DefaultGrubCfgPath)
-	kernelToArgs, err := extracKernelCmdlineFromGrubFile(grubCfgPath)
+	kernelToArgs, err := extractKernelCmdlineFromGrubFile(grubCfgPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read grub.cfg:\n%w", err)
 	}
@@ -568,7 +580,7 @@ func extractKernelCmdlineFromGrub(bootPartition *diskutils.PartitionInfo,
 
 // Extracts the kernel args for each kernel from the grub.cfg file.
 // Returns a mapping from kernel version to list of kernel args.
-func extracKernelCmdlineFromGrubFile(grubCfgPath string) (map[string][]grubConfigLinuxArg, error) {
+func extractKernelCmdlineFromGrubFile(grubCfgPath string) (map[string][]grubConfigLinuxArg, error) {
 	grubCfgContent, err := file.Read(grubCfgPath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read grub.cfg file at (%s):\n%w", grubCfgPath, err)


### PR DESCRIPTION
<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

In `prepareUki()`, when `copyUkiFiles()` is called, it attempts to find the `kernel` and its `initramfs` under the boot partition. Once found, they are placed under `UkiBuildDir` for later use when building the `UKI` with `ukify`. Additionally, `getKernelToInitramfsMap()` also heavily depends on the `kernel` and `initramfs` being present in the boot partition. This function is invoked twice: during both `prepareUki()` and `createUki()`. Therefore, `cleanupBootPartition()` should not have to be released into main yet, as we are still in the process of making the boot partition optional.

Another issue blocking main from customizing a UKI-enabled base image is the ability to read the latest kernel arguments from an existing UKI. I have extended the logic - following the structure of `extractKernelCmdline()` in `partitionutils.go` - to make UKI customization more robust, enabling `kernel-to-args` mapping to be extracted from either `grub.cfg` or an existing UKI.

---

### **Checklist**
- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
