### PR TITLE
OSModifier: Restore SELinux config file update for UKI-based boot

### DIFF
--- a/toolkit/tools/pkg/osmodifierlib/modifierutils.go
+++ b/toolkit/tools/pkg/osmodifierlib/modifierutils.go
@@ -179,6 +179,11 @@ func handleSELinux(selinuxMode imagecustomizerapi.SELinuxMode, bootCustomizer *i
 		return err
 	}
 
+	err = imagecustomizerlib.UpdateSELinuxModeInConfigFile(selinuxMode, dummyChroot)
+	if err != nil {
+		return fmt.Errorf("failed to update /etc/selinux/config:\n%w", err)
+	}
+
 	// No need to set SELinux labels here as in trident there is reset labels at the end
 	return nil
 }


### PR DESCRIPTION
<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

This PR restores a missing call to UpdateSELinuxModeInConfigFile() in the SELinux setup logic. It was unintentionally removed earlier.

---

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] Code conforms to style guidelines
