### PR TITLE
Fix LiveOS build.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
@@ -16,7 +16,7 @@ import (
 func customizePartitionsUsingFileCopy(buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
 	buildImageFile string, newBuildImageFile string,
 ) (map[string]string, error) {
-	existingImageConnection, _, _, _, err := connectToExistingImage(buildImageFile, buildDir, "imageroot", false)
+	existingImageConnection, _, _, err := connectToExistingImage(buildImageFile, buildDir, "imageroot", false)
 	if err != nil {
 		return nil, err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -858,12 +858,17 @@ func customizeImageHelper(buildDir string, baseConfigPath string, config *imagec
 ) (map[string]diskutils.FstabEntry, []verityDeviceMetadata, string, []OsPackage, error) {
 	logger.Log.Debugf("Customizing OS")
 
-	imageConnection, partUuidToFstabEntry, baseImageVerityMetadata, osPackages, err := connectToExistingImage(rawImageFile,
+	imageConnection, partUuidToFstabEntry, baseImageVerityMetadata, err := connectToExistingImage(rawImageFile,
 		buildDir, "imageroot", true)
 	if err != nil {
 		return nil, nil, "", nil, err
 	}
 	defer imageConnection.Close()
+
+	osPackages, err := getAllPackagesFromChroot(imageConnection)
+	if err != nil {
+		return nil, nil, "", nil, err
+	}
 
 	// Extract OS release info from rootfs for COSI
 	osRelease, err := extractOSRelease(imageConnection)

--- a/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
@@ -21,22 +21,17 @@ import (
 type installOSFunc func(imageChroot *safechroot.Chroot) error
 
 func connectToExistingImage(imageFilePath string, buildDir string, chrootDirName string, includeDefaultMounts bool,
-) (*ImageConnection, map[string]diskutils.FstabEntry, []verityDeviceMetadata, []OsPackage, error) {
+) (*ImageConnection, map[string]diskutils.FstabEntry, []verityDeviceMetadata, error) {
 	imageConnection := NewImageConnection()
 
 	partUuidToMountPath, verityMetadata, err := connectToExistingImageHelper(imageConnection, imageFilePath, buildDir,
 		chrootDirName, includeDefaultMounts)
 	if err != nil {
 		imageConnection.Close()
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	packages, err := getAllPackagesFromChroot(imageConnection)
-	if err != nil {
-		return nil, nil, nil, nil, err
-	}
-
-	return imageConnection, partUuidToMountPath, verityMetadata, packages, nil
+	return imageConnection, partUuidToMountPath, verityMetadata, nil
 }
 
 func connectToExistingImageHelper(imageConnection *ImageConnection, imageFilePath string,

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -178,7 +178,7 @@ func createLiveOSFromRawHelper(buildDir, baseConfigPath string, inputArtifactsSt
 	}()
 
 	logger.Log.Debugf("Connecting to raw image (%s)", rawImageFile)
-	rawImageConnection, _, _, _, err := connectToExistingImage(rawImageFile, isoBuildDir, "readonly-rootfs-mount", false /*includeDefaultMounts*/)
+	rawImageConnection, _, _, err := connectToExistingImage(rawImageFile, isoBuildDir, "readonly-rootfs-mount", false /*includeDefaultMounts*/)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The `rpm` command needs `/dev` to run. So, move the package list retrieval outside of the `connectToExistingImage` function so that it only runs where it is needed.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
