### PR TITLE
MIC: LiveOS: Skip generating the ISO boot image if it is not needed

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -565,13 +565,13 @@ func convertWriteableFormatToOutputImage(ic *ImageCustomizerParameters, inputIso
 			err := createLiveOSFromRaw(ic.buildDirAbs, ic.configPath, inputIsoArtifacts, requestedSELinuxMode,
 				ic.config.Iso, ic.config.Pxe, ic.rawImageFile, ic.outputImageFormat, ic.outputImageFile)
 			if err != nil {
-				return fmt.Errorf("failed to create LiveOS iso image:\n%w", err)
+				return fmt.Errorf("failed to create Live OS artifacts:\n%w", err)
 			}
 		} else {
 			err := repackageLiveOS(ic.buildDirAbs, ic.configPath, ic.config.Iso, ic.config.Pxe,
 				inputIsoArtifacts, ic.outputImageFormat, ic.outputImageFile)
 			if err != nil {
-				return fmt.Errorf("failed to create LiveOS iso image:\n%w", err)
+				return fmt.Errorf("failed to create Live OS artifacts:\n%w", err)
 			}
 		}
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisogrub.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisogrub.go
@@ -33,7 +33,7 @@ func updateGrubCfgForLiveOS(inputContentString string, initramfsImageType imagec
 	searchCommand := fmt.Sprintf(searchCommandTemplate, isogenerator.DefaultVolumeId)
 	inputContentString, err := replaceSearchCommandAll(inputContentString, searchCommand)
 	if err != nil {
-		return "", fmt.Errorf("failed to update the search command in the iso grub.cfg:\n%w", err)
+		return "", fmt.Errorf("failed to update the search command in the live OS grub.cfg:\n%w", err)
 	}
 
 	grubMkconfigEnabled := isGrubMkconfigConfig(inputContentString)
@@ -41,33 +41,33 @@ func updateGrubCfgForLiveOS(inputContentString string, initramfsImageType imagec
 		var oldLinuxPath string
 		inputContentString, oldLinuxPath, err = setLinuxPath(inputContentString, isoKernelPath)
 		if err != nil {
-			return "", fmt.Errorf("failed to update the kernel file path in the iso grub.cfg:\n%w", err)
+			return "", fmt.Errorf("failed to update the kernel file path in the live OS grub.cfg:\n%w", err)
 		}
 
 		inputContentString, err = replaceToken(inputContentString, oldLinuxPath, isoKernelPath)
 		if err != nil {
-			return "", fmt.Errorf("failed to update all the kernel file path occurances in the iso grub.cfg:\n%w", err)
+			return "", fmt.Errorf("failed to update all the kernel file path occurances in the live OS grub.cfg:\n%w", err)
 		}
 
 		var oldInitrdPath string
 		inputContentString, oldInitrdPath, err = setInitrdPath(inputContentString, isoInitrdPath)
 		if err != nil {
-			return "", fmt.Errorf("failed to update the initrd file path in the iso grub.cfg:\n%w", err)
+			return "", fmt.Errorf("failed to update the initrd file path in the live OS grub.cfg:\n%w", err)
 		}
 
 		inputContentString, err = replaceToken(inputContentString, oldInitrdPath, isoInitrdPath)
 		if err != nil {
-			return "", fmt.Errorf("failed to update all the initrd file path occurances in the iso grub.cfg:\n%w", err)
+			return "", fmt.Errorf("failed to update all the initrd file path occurances in the live OS grub.cfg:\n%w", err)
 		}
 	} else {
 		inputContentString, _, err = setLinuxOrInitrdPathAll(inputContentString, linuxCommand, isoKernelPath, true /*allowMultiple*/)
 		if err != nil {
-			return "", fmt.Errorf("failed to update the kernel file path in the iso grub.cfg:\n%w", err)
+			return "", fmt.Errorf("failed to update the kernel file path in the live OS grub.cfg:\n%w", err)
 		}
 
 		inputContentString, _, err = setLinuxOrInitrdPathAll(inputContentString, initrdCommand, isoInitrdPath, true /*allowMultiple*/)
 		if err != nil {
-			return "", fmt.Errorf("failed to update the initrd file path in the iso grub.cfg:\n%w", err)
+			return "", fmt.Errorf("failed to update the initrd file path in the live OS grub.cfg:\n%w", err)
 		}
 	}
 
@@ -79,7 +79,7 @@ func updateGrubCfgForLiveOS(inputContentString string, initramfsImageType imagec
 		newArgs := []string{}
 		inputContentString, err = updateKernelCommandLineArgsAll(inputContentString, argsToRemove, newArgs)
 		if err != nil {
-			return "", fmt.Errorf("failed to update the root kernel argument in the iso grub.cfg:\n%w", err)
+			return "", fmt.Errorf("failed to update the root kernel argument in the live OS grub.cfg:\n%w", err)
 		}
 	case imagecustomizerapi.InitramfsImageTypeBootstrap:
 		// Add Dracut live os parameters
@@ -101,7 +101,7 @@ func updateGrubCfgForLiveOS(inputContentString string, initramfsImageType imagec
 
 	inputContentString, err = appendKernelCommandLineArgsAll(inputContentString, additionalKernelCommandline)
 	if err != nil {
-		return "", fmt.Errorf("failed to update the kernel arguments with the LiveOS configuration and user configuration in the iso grub.cfg:\n%w", err)
+		return "", fmt.Errorf("failed to update the kernel arguments with the LiveOS configuration and user configuration in the live OS grub.cfg:\n%w", err)
 	}
 
 	return inputContentString, nil
@@ -162,7 +162,7 @@ func updateGrubCfgForPxe(inputContentString string, initramfsImageType imagecust
 // that the call does not need to call it multiple times.
 func updateGrubCfg(inputGrubCfgPath string, outputFormat imagecustomizerapi.ImageFormatType, initramfsImageType imagecustomizerapi.InitramfsImageType,
 	disableSELinux bool, savedConfigs *SavedConfigs, outputIsoGrubCfgPath, outputPxeGrubCfgPath string) error {
-	logger.Log.Infof("Updating ISO grub.cfg")
+	logger.Log.Infof("Updating grub.cfg")
 
 	inputContentString, err := file.Read(inputGrubCfgPath)
 	if err != nil {

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoimages.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoimages.go
@@ -210,10 +210,6 @@ func stageLiveOSFiles(outputFormat imagecustomizerapi.ImageFormatType, filesStor
 
 	artifactsToLiveOSMap := []StageFile{
 		{
-			sourcePath:    filesStore.isoBootImagePath,
-			targetRelPath: "boot/grub2",
-		},
-		{
 			sourcePath:    filesStore.vmlinuzPath,
 			targetRelPath: "boot",
 		},
@@ -225,6 +221,11 @@ func stageLiveOSFiles(outputFormat imagecustomizerapi.ImageFormatType, filesStor
 
 	switch outputFormat {
 	case imagecustomizerapi.ImageFormatTypeIso:
+		artifactsToLiveOSMap = append(artifactsToLiveOSMap,
+			StageFile{
+				sourcePath:    filesStore.isoBootImagePath,
+				targetRelPath: "boot/grub2",
+			})
 		artifactsToLiveOSMap = append(artifactsToLiveOSMap,
 			StageFile{
 				sourcePath:    filesStore.isoGrubCfgPath,

--- a/toolkit/tools/pkg/imagecustomizerlib/liveospxe.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveospxe.go
@@ -101,7 +101,7 @@ func createPXEArtifacts(buildDir string, outputFormat imagecustomizerapi.ImageFo
 		artifactsRootfsPath := filepath.Join(artifactsRootfsDir, liveOSImage)
 		err = os.Remove(artifactsRootfsPath)
 		if err != nil {
-			return fmt.Errorf("failed to remove (%s) while cleaning up intermediate files:\n%w", artifactsRootfsPath, err)
+			return fmt.Errorf("failed to remove root file system image (%s) while cleaning up intermediate files:\n%w", artifactsRootfsPath, err)
 		}
 
 		err = os.RemoveAll(artifactsRootfsDir)
@@ -138,12 +138,6 @@ func createPXEArtifacts(buildDir string, outputFormat imagecustomizerapi.ImageFo
 		return fmt.Errorf("failed to remove folder (%s):\n%w", isoEFIDir, err)
 	}
 
-	// Remove boot image required for ISO images
-	err = os.Remove(artifactsStore.files.isoBootImagePath)
-	if err != nil {
-		return fmt.Errorf("failed to remove (%s) while cleaning up intermediate files:\n%w", artifactsStore.files.isoBootImagePath, err)
-	}
-
 	// If a tar.gz is requested, create the archive
 	if outputFormat == imagecustomizerapi.ImageFormatTypePxeTar {
 		err = tarutils.CreateTarGzArchive(outputPXEArtifactsDir, outputPXEImage)
@@ -153,7 +147,7 @@ func createPXEArtifacts(buildDir string, outputFormat imagecustomizerapi.ImageFo
 
 		err = os.RemoveAll(outputPXEArtifactsDir)
 		if err != nil {
-			return fmt.Errorf("failed to remove (%s) while cleaning up intermediate files:\n%w", outputPXEArtifactsDir, err)
+			return fmt.Errorf("failed to remove pxe artifacts staging folder (%s) while cleaning up intermediate files:\n%w", outputPXEArtifactsDir, err)
 		}
 	}
 


### PR DESCRIPTION
When creating a bootable ISO media, the bootloader files (shim and grub) must be packaged into an image (/boot/grub2/efiboot.img) and specified to the mkisofs tool. This is required to enable a bootable ISO media.

However, this is not needed for the PXE scenario since the bootloader is found/obtained by a different mechanism.

This change updates the Image Customizer tool to only generate and include the efiboot.img if an iso will be generated (i.e. if the output format is iso - or the output format is pxe and bootstrap initramfs is specified).

<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

---

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] Code conforms to style guidelines
