### PR TITLE
Image Customizer: Add multi-kernel support for ISO/PXE flows

### DIFF
--- a/test/vmtests/vmtests/test_min_change.py
+++ b/test/vmtests/vmtests/test_min_change.py
@@ -283,7 +283,7 @@ def test_min_change_efi_azl2_iso_output(
     close_list: List[Closeable],
 ) -> None:
     azl_release = 2
-    config_path = TEST_CONFIGS_DIR.joinpath("iso-bootstrap-vm.yaml")
+    config_path = TEST_CONFIGS_DIR.joinpath("iso-bootstrap-vm-azl2.yaml")
     output_format = "iso"
 
     run_min_change_test(
@@ -377,7 +377,7 @@ def test_min_change_legacy_azl2_iso_output(
     close_list: List[Closeable],
 ) -> None:
     azl_release = 2
-    config_path = TEST_CONFIGS_DIR.joinpath("iso-bootstrap-vm.yaml")
+    config_path = TEST_CONFIGS_DIR.joinpath("iso-bootstrap-vm-azl2.yaml")
     output_format = "iso"
 
     run_min_change_test(

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
@@ -4,6 +4,7 @@
 package imagecustomizerlib
 
 import (
+	"fmt"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/imagecustomizerapi"
+	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/initrdutils"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/logger"
@@ -23,14 +25,29 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func createConfig(fileName, kernelParameter string, initramfsType imagecustomizerapi.InitramfsImageType, bootstrapFileUrl string,
-	enableOsConfig, bootstrapPrereqs bool, selinuxMode imagecustomizerapi.SELinuxMode) *imagecustomizerapi.Config {
-	bootstrapRequiredPkgs := []string{}
+func createConfig(t *testing.T, baseImageVersion string, fileName, kernelParameter string, initramfsType imagecustomizerapi.InitramfsImageType,
+	bootstrapFileUrl string, enlargeDisk, enableOsConfig, bootstrapPrereqs, twoKernels bool,
+	selinuxMode imagecustomizerapi.SELinuxMode) *imagecustomizerapi.Config {
+	pkgsToInstall := []string{}
 	if bootstrapPrereqs {
-		bootstrapRequiredPkgs = append(bootstrapRequiredPkgs, "squashfs-tools", "tar", "device-mapper", "curl")
+		pkgsToInstall = append(pkgsToInstall, "squashfs-tools", "tar", "device-mapper", "curl")
 	}
 	if selinuxMode != imagecustomizerapi.SELinuxModeDisabled {
-		bootstrapRequiredPkgs = append(bootstrapRequiredPkgs, "selinux-policy")
+		pkgsToInstall = append(pkgsToInstall, "selinux-policy")
+	}
+
+	if twoKernels {
+		// include an old kernel
+		kernelPackageName := ""
+		switch baseImageVersion {
+		case baseImageVersionAzl2:
+			kernelPackageName = "kernel-5.15.122.1-2.cm2"
+		case baseImageVersionAzl3:
+			kernelPackageName = "kernel-6.6.57.1-6.azl3"
+		default:
+			assert.NoError(t, fmt.Errorf("undefined image version"), "unsupported distro version")
+		}
+		pkgsToInstall = append(pkgsToInstall, kernelPackageName)
 	}
 
 	perms0o644 := imagecustomizerapi.FilePermissions(0o644)
@@ -65,6 +82,62 @@ func createConfig(fileName, kernelParameter string, initramfsType imagecustomize
 		},
 	}
 
+	if enlargeDisk {
+		config.Storage = imagecustomizerapi.Storage{
+			BootType: imagecustomizerapi.BootTypeEfi,
+			Disks: []imagecustomizerapi.Disk{{
+				PartitionTableType: "gpt",
+				Partitions: []imagecustomizerapi.Partition{
+					{
+						Id: "esp",
+						Size: imagecustomizerapi.PartitionSize{
+							Type: imagecustomizerapi.PartitionSizeTypeExplicit,
+							Size: 8 * diskutils.MiB,
+						},
+						Type: imagecustomizerapi.PartitionTypeESP,
+					},
+					{
+						Id: "boot",
+						Size: imagecustomizerapi.PartitionSize{
+							Type: imagecustomizerapi.PartitionSizeTypeExplicit,
+							Size: 512 * diskutils.MiB,
+						},
+					},
+					{
+						Id: "root",
+						Size: imagecustomizerapi.PartitionSize{
+							Type: imagecustomizerapi.PartitionSizeTypeExplicit,
+							Size: 3 * diskutils.GiB,
+						},
+					},
+				},
+			}},
+			FileSystems: []imagecustomizerapi.FileSystem{
+				{
+					DeviceId: "esp",
+					Type:     "vfat",
+					MountPoint: &imagecustomizerapi.MountPoint{
+						Path: "/boot/efi",
+					},
+				},
+				{
+					DeviceId: "boot",
+					Type:     "ext4",
+					MountPoint: &imagecustomizerapi.MountPoint{
+						Path: "/boot",
+					},
+				},
+				{
+					DeviceId: "root",
+					Type:     "ext4",
+					MountPoint: &imagecustomizerapi.MountPoint{
+						Path: "/",
+					},
+				},
+			},
+		}
+	}
+
 	if enableOsConfig {
 		config.OS = &imagecustomizerapi.OS{
 			AdditionalFiles: imagecustomizerapi.AdditionalFileList{
@@ -79,8 +152,12 @@ func createConfig(fileName, kernelParameter string, initramfsType imagecustomize
 				Mode: selinuxMode,
 			},
 			Packages: imagecustomizerapi.Packages{
-				Install: bootstrapRequiredPkgs,
+				Install: pkgsToInstall,
 			},
+		}
+
+		if enlargeDisk {
+			config.OS.BootLoader.ResetType = imagecustomizerapi.ResetBootLoaderTypeHard
 		}
 	}
 
@@ -293,6 +370,52 @@ func VerifyBootstrapPXEArtifacts(t *testing.T, packageInfo *PackageVersionInform
 	assert.Regexp(t, pxeKernelRootArg, pxeGrubCfgContents)
 }
 
+func TestCustomizeImageLiveOSMultiKernel(t *testing.T) {
+	for _, baseImageInfo := range baseImageAll {
+		if *baseImageInfo.Param == "" {
+			continue
+		}
+		t.Run(baseImageInfo.Name, func(t *testing.T) {
+			testCustomizeImageLiveOSMultiKernel(t, "TestCustomizeImageLiveOSMultiKernel"+baseImageInfo.Name, baseImageInfo)
+		})
+	}
+}
+
+func testCustomizeImageLiveOSMultiKernel(t *testing.T, testName string, baseImageInfo testBaseImageInfo) {
+	baseImage := *baseImageInfo.Param
+
+	testTempDir := filepath.Join(tmpDir, testName)
+	buildDir := filepath.Join(testTempDir, "build")
+	outImageFilePath := filepath.Join(testTempDir, defaultIsoImageName)
+
+	// SELinux in Live OS is only supported with azl3
+	selinuxMode := imagecustomizerapi.SELinuxModeEnforcing
+	if baseImageInfo.Version == baseImageVersionAzl2 {
+		selinuxMode = imagecustomizerapi.SELinuxModeDisabled
+	}
+
+	configA := createConfig(t, baseImageInfo.Version, "a.txt", "rd.info", imagecustomizerapi.InitramfsImageTypeBootstrap,
+		"" /*pxe url*/, true /*enlarge disk*/, true /*enable os config*/, true /*bootstrap prereqs*/, true, /*2 kernels*/
+		selinuxMode)
+
+	err := CustomizeImage(buildDir, testDir, configA, baseImage, nil, outImageFilePath,
+		string(imagecustomizerapi.ImageFormatTypeIso), true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	if baseImageInfo.Version == baseImageVersionAzl2 {
+		// Azl2 should fail.
+		if !assert.Error(t, err) {
+			return
+		}
+		if !assert.ErrorContains(t, err, "unsupported number of kernels") {
+			return
+		}
+	} else {
+		// Azl3+ should succeed.
+		if !assert.NoError(t, err) {
+			return
+		}
+	}
+}
+
 // Tests:
 // - raw -> iso {bootstrap} -> iso {bootstrap} -> iso {full-os}
 //
@@ -312,8 +435,9 @@ func TestCustomizeImageLiveOSInitramfs1(t *testing.T) {
 		selinuxMode = imagecustomizerapi.SELinuxModeDisabled
 	}
 
-	configA := createConfig("a.txt", "rd.info", imagecustomizerapi.InitramfsImageTypeBootstrap, "", /*pxe url*/
-		true /*enable os config*/, true /*bootstrap prereqs*/, selinuxMode)
+	configA := createConfig(t, baseImageInfo.Version, "a.txt", "rd.info", imagecustomizerapi.InitramfsImageTypeBootstrap,
+		"" /*pxe url*/, false /*enlarge disk*/, true /*enable os config*/, true /*bootstrap prereqs*/, false, /*2 kernels*/
+		selinuxMode)
 
 	// vhdx {raw} to ISO {bootstrap}, selinux enforcing + bootstrap prereqs
 	err := CustomizeImage(buildDir, testDir, configA, baseImage, nil, outImageFilePath,
@@ -325,8 +449,9 @@ func TestCustomizeImageLiveOSInitramfs1(t *testing.T) {
 	ValidateIsoContent(t, configA, testTempDir, imagecustomizerapi.InitramfsImageTypeBootstrap, outImageFilePath)
 
 	// ISO  {bootstrap} to ISO {bootstrap}, with no OS changes
-	configB := createConfig("b.txt", "rd.debug", imagecustomizerapi.InitramfsImageTypeBootstrap, "", /*pxe url*/
-		false /*enable os config*/, false /*bootstrap prereqs*/, imagecustomizerapi.SELinuxModeDefault)
+	configB := createConfig(t, baseImageInfo.Version, "b.txt", "rd.debug", imagecustomizerapi.InitramfsImageTypeBootstrap,
+		"" /*pxe url*/, false /*enlarge disk*/, false /*enable os config*/, false /*bootstrap prereqs*/, false, /*2 kernels*/
+		imagecustomizerapi.SELinuxModeDefault)
 
 	err = CustomizeImage(buildDir, testDir, configB, outImageFilePath, nil, outImageFilePath,
 		string(imagecustomizerapi.ImageFormatTypeIso), false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
@@ -337,8 +462,9 @@ func TestCustomizeImageLiveOSInitramfs1(t *testing.T) {
 	ValidateIsoContent(t, configB, testTempDir, imagecustomizerapi.InitramfsImageTypeBootstrap, outImageFilePath)
 
 	// - ISO {bootstrap} to ISO {full-os}, with selinux disabled
-	configC := createConfig("c.txt", "rd.shell", imagecustomizerapi.InitramfsImageTypeFullOS, "", /*pxe url*/
-		true /*enable os config*/, false /*bootstrap prereqs*/, imagecustomizerapi.SELinuxModeDisabled)
+	configC := createConfig(t, baseImageInfo.Version, "c.txt", "rd.shell", imagecustomizerapi.InitramfsImageTypeFullOS,
+		"" /*pxe url*/, false /*enlarge disk*/, true /*enable os config*/, false /*bootstrap prereqs*/, false, /*2 kernels*/
+		imagecustomizerapi.SELinuxModeDisabled)
 
 	err = CustomizeImage(buildDir, testDir, configC, outImageFilePath, nil, outImageFilePath,
 		string(imagecustomizerapi.ImageFormatTypeIso), true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
@@ -363,8 +489,9 @@ func TestCustomizeImageLiveOSInitramfs2(t *testing.T) {
 	outImageFilePath := filepath.Join(testTempDir, defaultIsoImageName)
 
 	// vhdx {raw} to ISO {full-os}, with selinux disabled
-	configA := createConfig("a.txt", "rd.info", imagecustomizerapi.InitramfsImageTypeFullOS, "", /*pxe url*/
-		true /*enable os config*/, false /*bootstrap prereqs*/, imagecustomizerapi.SELinuxModeDisabled)
+	configA := createConfig(t, baseImageInfo.Version, "a.txt", "rd.info", imagecustomizerapi.InitramfsImageTypeFullOS,
+		"" /*pxe url*/, false /*enlarge disk*/, true /*enable os config*/, false /*bootstrap prereqs*/, false, /*2 kernels*/
+		imagecustomizerapi.SELinuxModeDisabled)
 
 	err := CustomizeImage(buildDir, testDir, configA, baseImage, nil, outImageFilePath,
 		string(imagecustomizerapi.ImageFormatTypeIso), false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
@@ -375,8 +502,9 @@ func TestCustomizeImageLiveOSInitramfs2(t *testing.T) {
 	ValidateIsoContent(t, configA, testTempDir, imagecustomizerapi.InitramfsImageTypeFullOS, outImageFilePath)
 
 	// ISO  {full-os} to ISO {full-os}, with selinux disabled
-	configB := createConfig("b.txt", "rd.shell", imagecustomizerapi.InitramfsImageTypeFullOS, "", /*pxe url*/
-		true /*enable os config*/, true /*bootstrap prereqs*/, imagecustomizerapi.SELinuxModeDisabled)
+	configB := createConfig(t, baseImageInfo.Version, "b.txt", "rd.shell", imagecustomizerapi.InitramfsImageTypeFullOS,
+		"" /*pxe url*/, false /*enlarge disk*/, true /*enable os config*/, true /*bootstrap prereqs*/, false, /*2 kernels*/
+		imagecustomizerapi.SELinuxModeDisabled)
 
 	err = CustomizeImage(buildDir, testDir, configB, outImageFilePath, nil, outImageFilePath, string(imagecustomizerapi.ImageFormatTypeIso),
 		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
@@ -394,8 +522,9 @@ func TestCustomizeImageLiveOSInitramfs2(t *testing.T) {
 		selinuxMode = imagecustomizerapi.SELinuxModeDisabled
 	}
 
-	configC := createConfig("c.txt", "rd.shell", imagecustomizerapi.InitramfsImageTypeBootstrap, "", /*pxe url*/
-		true /*enable os config*/, true /*bootstrap prereqs*/, selinuxMode)
+	configC := createConfig(t, baseImageInfo.Version, "c.txt", "rd.shell", imagecustomizerapi.InitramfsImageTypeBootstrap,
+		"" /*pxe url*/, false /*enlarge disk*/, true /*enable os config*/, true /*bootstrap prereqs*/, false, /*2 kernels*/
+		selinuxMode)
 
 	err = CustomizeImage(buildDir, testDir, configC, outImageFilePath, nil, outImageFilePath,
 		string(imagecustomizerapi.ImageFormatTypeIso), true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
@@ -409,15 +538,16 @@ func TestCustomizeImageLiveOSInitramfs2(t *testing.T) {
 // Tests:
 // - vhdx {raw} to ISO {full-os}, with selinux enabled -> error
 func TestCustomizeImageLiveOSInitramfs3(t *testing.T) {
-	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
+	baseImage, baseImageInfo := checkSkipForCustomizeDefaultImage(t)
 
 	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageLiveOSInitramfs3")
 	buildDir := filepath.Join(testTempDir, "build")
 	outImageFilePath := filepath.Join(testTempDir, defaultIsoImageName)
 
 	// vhdx {raw} to ISO {full-os}, with selinux disabled
-	configA := createConfig("a.txt", "rd.info", imagecustomizerapi.InitramfsImageTypeFullOS, "", /*pxe url*/
-		true /*enable os config*/, false /*bootstrap prereqs*/, imagecustomizerapi.SELinuxModeEnforcing)
+	configA := createConfig(t, baseImageInfo.Version, "a.txt", "rd.info", imagecustomizerapi.InitramfsImageTypeFullOS,
+		"" /*pxe url*/, false /*enlarge disk*/, true /*enable os config*/, false /*bootstrap prereqs*/, false, /*2 kernels*/
+		imagecustomizerapi.SELinuxModeEnforcing)
 
 	err := CustomizeImage(buildDir, testDir, configA, baseImage, nil, outImageFilePath,
 		string(imagecustomizerapi.ImageFormatTypeIso), true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
@@ -438,8 +568,9 @@ func TestCustomizeImageLiveOSPxe1(t *testing.T) {
 	outImageFilePath := filepath.Join(testTempDir, "pxe-artifacts.tar.gz")
 	pxeBootstrapUrl := "http://my-pxe-server-1/" + defaultIsoImageName
 
-	config := createConfig("a.txt", "rd.info", imagecustomizerapi.InitramfsImageTypeBootstrap, pxeBootstrapUrl,
-		true /*enable os config*/, true /*bootstrap prereqs*/, imagecustomizerapi.SELinuxModeEnforcing)
+	config := createConfig(t, baseImageInfo.Version, "a.txt", "rd.info", imagecustomizerapi.InitramfsImageTypeBootstrap,
+		pxeBootstrapUrl, false /*enlarge disk*/, true /*enable os config*/, true /*bootstrap prereqs*/, false, /*2 kernels*/
+		imagecustomizerapi.SELinuxModeEnforcing)
 
 	err := CustomizeImage(buildDir, testDir, config, baseImage, nil, outImageFilePath,
 		string(imagecustomizerapi.ImageFormatTypePxeTar), true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
@@ -453,14 +584,15 @@ func TestCustomizeImageLiveOSPxe1(t *testing.T) {
 // Tests:
 // - vhdx {raw} to PXE {full-os}, with selinux disabled
 func TestCustomizeImageLiveOSPxe2(t *testing.T) {
-	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
+	baseImage, baseImageInfo := checkSkipForCustomizeDefaultImage(t)
 
 	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageLiveOSPxe2")
 	buildDir := filepath.Join(testTempDir, "build")
 	outImageFilePath := filepath.Join(testTempDir, "pxe-artifacts.tar.gz")
 
-	config := createConfig("a.txt", "rd.info", imagecustomizerapi.InitramfsImageTypeFullOS, "", /*pxe url*/
-		true /*enable os config*/, false /*bootstrap prereqs*/, imagecustomizerapi.SELinuxModeDisabled)
+	config := createConfig(t, baseImageInfo.Version, "a.txt", "rd.info", imagecustomizerapi.InitramfsImageTypeFullOS,
+		"" /*pxe url*/, false /*enlarge disk*/, true /*enable os config*/, false /*bootstrap prereqs*/, false, /*2 kernels*/
+		imagecustomizerapi.SELinuxModeDisabled)
 
 	err := CustomizeImage(buildDir, testDir, config, baseImage, nil, outImageFilePath,
 		string(imagecustomizerapi.ImageFormatTypePxeTar), true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoutils.go
@@ -5,11 +5,12 @@ package imagecustomizerlib
 
 import (
 	"fmt"
+	"os"
+	"runtime"
+
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/safeloopback"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/safemount"
 	"golang.org/x/sys/unix"
-	"os"
-	"runtime"
 )
 
 const (
@@ -40,8 +41,10 @@ const (
 	// In vhd(x)/qcow images, the kernel is named 'vmlinuz-<version>'.
 	// In the ISO image, the kernel is named 'vmlinuz'.
 	vmLinuzPrefix     = "vmlinuz"
+	initramfsPrefix   = "initramfs-"  // Azl3
+	initrdPrefix      = "initrd.img-" // CBL-Mariner
+	isoKernelDir      = "/boot"
 	isoInitrdPath     = "/boot/" + initrdImage
-	isoKernelPath     = "/boot/vmlinuz"
 	isoBootloadersDir = "/efi/boot"
 	isoBootImagePath  = "/boot/grub2/efiboot.img"
 

--- a/toolkit/tools/pkg/imagecustomizerlib/liveospxe.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveospxe.go
@@ -69,7 +69,7 @@ func createPXEArtifacts(buildDir string, outputFormat imagecustomizerapi.ImageFo
 		outputPXEImage = ""
 	}
 
-	err = stageLiveOSFiles(outputFormat, artifactsStore.files, baseConfigPath,
+	err = stageLiveOSFiles(initramfsType, outputFormat, artifactsStore.files, baseConfigPath,
 		additionalIsoFiles, outputPXEArtifactsDir)
 	if err != nil {
 		return fmt.Errorf("failed to stage one or more live os files:\n%w", err)
@@ -90,7 +90,8 @@ func createPXEArtifacts(buildDir string, outputFormat imagecustomizerapi.ImageFo
 		// The iso image file itself must be placed in the PXE folder because
 		// dracut livenet module will download it.
 		artifactsIsoImagePath := filepath.Join(outputPXEArtifactsDir, isoImageName)
-		err = createIsoImage(buildDir, baseConfigPath, artifactsStore.files, additionalIsoFiles, artifactsIsoImagePath)
+		err = createIsoImage(buildDir, baseConfigPath, imagecustomizerapi.InitramfsImageTypeBootstrap,
+			artifactsStore.files, additionalIsoFiles, artifactsIsoImagePath)
 		if err != nil {
 			return fmt.Errorf("failed to create the Iso image.\n%w", err)
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/savedconfigs.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/savedconfigs.go
@@ -62,7 +62,6 @@ func (p *PxeSavedConfigs) IsValid() error {
 }
 
 type OSSavedConfigs struct {
-	KernelVersion            string                         `yaml:"kernelVersion"`
 	DracutPackageInfo        *PackageVersionInformation     `yaml:"dracutPackage"`
 	RequestedSELinuxMode     imagecustomizerapi.SELinuxMode `yaml:"selinuxRequestedMode"`
 	SELinuxPolicyPackageInfo *PackageVersionInformation     `yaml:"selinuxPolicyPackage"`
@@ -131,7 +130,7 @@ func loadSavedConfigs(savedConfigsFilePath string) (savedConfigs *SavedConfigs, 
 }
 
 func updateSavedConfigs(savedConfigsFilePath string, newKernelCommandLine imagecustomizerapi.KernelCommandLine,
-	newBootstrapBaseUrl string, newBootstrapFileUrl string, newKernelVersion string, newDracutPackageInfo *PackageVersionInformation,
+	newBootstrapBaseUrl string, newBootstrapFileUrl string, newDracutPackageInfo *PackageVersionInformation,
 	newRequestedSelinuxMode imagecustomizerapi.SELinuxMode, newSELinuxPackageInfo *PackageVersionInformation,
 ) (outputConfigs *SavedConfigs, err error) {
 	logger.Log.Infof("Updating saved configurations")
@@ -139,7 +138,6 @@ func updateSavedConfigs(savedConfigsFilePath string, newKernelCommandLine imagec
 	outputConfigs.LiveOS.KernelCommandLine = newKernelCommandLine
 	outputConfigs.Pxe.bootstrapBaseUrl = newBootstrapBaseUrl
 	outputConfigs.Pxe.bootstrapFileUrl = newBootstrapFileUrl
-	outputConfigs.OS.KernelVersion = newKernelVersion
 	outputConfigs.OS.DracutPackageInfo = newDracutPackageInfo
 	outputConfigs.OS.RequestedSELinuxMode = newRequestedSelinuxMode
 	outputConfigs.OS.SELinuxPolicyPackageInfo = newSELinuxPackageInfo
@@ -179,10 +177,6 @@ func updateSavedConfigs(savedConfigsFilePath string, newKernelCommandLine imagec
 
 		if newBootstrapFileUrl != "" {
 			outputConfigs.Pxe.bootstrapBaseUrl = ""
-		}
-
-		if newKernelVersion == "" {
-			outputConfigs.OS.KernelVersion = inputConfigs.OS.KernelVersion
 		}
 
 		// newOSDracutVersion can be nil if the input is an ISO and the

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/iso-bootstrap-vm-azl2.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/iso-bootstrap-vm-azl2.yaml
@@ -8,8 +8,6 @@ os:
     - "selinux=0"
   packages:
     install:
-    # multi-kernel test
-    - kernel-6.6.57.1-6.azl3
     # iso required packages
     - squashfs-tools
     - tar

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/iso-full-os-vm.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/iso-full-os-vm.yaml
@@ -8,6 +8,8 @@ os:
     - "selinux=0"
   packages:
     install:
+    # multi-kernel test
+    - kernel-6.6.57.1-6.azl3
     # iso required packages
     - squashfs-tools
     - tar

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/os-vm-config-arm64.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/os-vm-config-arm64.yaml
@@ -6,4 +6,7 @@ os:
   packages:
     install:
     - dracut-virtio
-
+  packages:
+    install:
+    # multi-kernel test
+    - kernel-6.6.57.1-6.azl3

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/os-vm-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/os-vm-config.yaml
@@ -3,3 +3,7 @@ os:
     # Enable DHCP client on all of the physical NICs.
   - source: files/89-ethernet.network
     destination: /etc/systemd/network/89-ethernet.network
+  packages:
+    install:
+    # multi-kernel test
+    - kernel-6.6.57.1-6.azl3


### PR DESCRIPTION
This change ensures that the version suffixes are not stripped from the kernel and initrd image paths in the grub.cfg file. It also ensure the conversion from full OS initramfs to bootstrap initramfs images works correctly with multiple kernels.

Checklist
- [x] Tests added/updated
- [n/a] Documentation updated (if needed)
- [x] Code conforms to style guidelines
