### PR TITLE
Allow functional tests to run against baremetal image.

### DIFF
--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -2029,22 +2029,21 @@ func SELinuxRelabelFiles(installChroot safechroot.ChrootInterface, mountPointToF
 		err = installChroot.UnsafeRun(func() error {
 			// We only want to print basic info, filter out the real output unless at trace level (Execute call handles that)
 			files := 0
-			lastFile := ""
 			onStdout := func(line string) {
 				files++
-				lastFile = line
 				if (files % 1000) == 0 {
-					ReportActionf("SELinux: labelled %d files", files)
+					logger.Log.Debugf("SELinux: labelled %d files", files)
 				}
 			}
 			err := shell.NewExecBuilder("setfiles", "-m", "-v", "-r", targetRootPath, fileContextPath, targetPath).
 				StdoutCallback(onStdout).
 				LogLevel(logrus.TraceLevel, logrus.WarnLevel).
+				ErrorStderrLines(1).
 				Execute()
 			if err != nil {
-				return fmt.Errorf("failed while labeling files (last file: %s) %w", lastFile, err)
+				return fmt.Errorf("setfiles failed:\n%w", err)
 			}
-			ReportActionf("SELinux: labelled %d files", files)
+			logger.Log.Debugf("SELinux: labelled %d files", files)
 			return err
 		})
 		if err != nil {

--- a/toolkit/tools/pkg/imagecustomizerlib/main_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/main_test.go
@@ -71,7 +71,7 @@ var (
 		Version:   baseImageVersionAzl3,
 		Variant:   baseImageVariantBareMetal,
 		ParamName: "base-image-bare-metal-azl3",
-		Param:     baseImageBateMetalAzl3,
+		Param:     baseImageBareMetalAzl3,
 	}
 
 	baseImageAll = []testBaseImageInfo{
@@ -93,7 +93,7 @@ var (
 	baseImageCoreEfiAzl2   = flag.String("base-image-core-efi-azl2", "", "An Azure Linux 2.0 core-efi image to use as a base image.")
 	baseImageCoreEfiAzl3   = flag.String("base-image-core-efi-azl3", "", "An Azure Linux 3.0 core-efi image to use as a base image.")
 	baseImageBareMetalAzl2 = flag.String("base-image-bare-metal-azl2", "", "An Azure Linux 2.0 bare-metal image to use as a base image.")
-	baseImageBateMetalAzl3 = flag.String("base-image-bare-metal-azl3", "", "An Azure Linux 3.0 bare-metal image to use as a base image.")
+	baseImageBareMetalAzl3 = flag.String("base-image-bare-metal-azl3", "", "An Azure Linux 3.0 bare-metal image to use as a base image.")
 )
 
 var (

--- a/toolkit/tools/pkg/imagecustomizerlib/main_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/main_test.go
@@ -24,7 +24,8 @@ const (
 	baseImageVersionAzl3 = "3.0"
 
 	// Azure Linux variants
-	baseImageVariantCoreEfi = "core-efi"
+	baseImageVariantCoreEfi   = "core-efi"
+	baseImageVariantBareMetal = "bare-metal"
 )
 
 type testBaseImageInfo struct {
@@ -55,20 +56,44 @@ var (
 		Param:     baseImageCoreEfiAzl3,
 	}
 
+	testBaseImageAzl2BareMetal = testBaseImageInfo{
+		Name:      "AzureLinux2BareMetal",
+		Distro:    baseImageDistroAzureLinux,
+		Version:   baseImageVersionAzl2,
+		Variant:   baseImageVariantBareMetal,
+		ParamName: "base-image-bare-metal-azl2",
+		Param:     baseImageBareMetalAzl2,
+	}
+
+	testBaseImageAzl3BareMetal = testBaseImageInfo{
+		Name:      "AzureLinux3BareMetal",
+		Distro:    baseImageDistroAzureLinux,
+		Version:   baseImageVersionAzl3,
+		Variant:   baseImageVariantBareMetal,
+		ParamName: "base-image-bare-metal-azl3",
+		Param:     baseImageBateMetalAzl3,
+	}
+
 	baseImageAll = []testBaseImageInfo{
 		testBaseImageAzl2CoreEfi,
 		testBaseImageAzl3CoreEfi,
+		testBaseImageAzl2BareMetal,
+		testBaseImageAzl3BareMetal,
 	}
 
 	defaultBaseImagePriorityList = []testBaseImageInfo{
 		testBaseImageAzl2CoreEfi,
+		testBaseImageAzl2BareMetal,
 		testBaseImageAzl3CoreEfi,
+		testBaseImageAzl3BareMetal,
 	}
 )
 
 var (
-	baseImageCoreEfiAzl2 = flag.String("base-image-core-efi-azl2", "", "An Azure Linux 2.0 core-efi image to use as a base image.")
-	baseImageCoreEfiAzl3 = flag.String("base-image-core-efi-azl3", "", "An Azure Linux 3.0 core-efi image to use as a base image.")
+	baseImageCoreEfiAzl2   = flag.String("base-image-core-efi-azl2", "", "An Azure Linux 2.0 core-efi image to use as a base image.")
+	baseImageCoreEfiAzl3   = flag.String("base-image-core-efi-azl3", "", "An Azure Linux 3.0 core-efi image to use as a base image.")
+	baseImageBareMetalAzl2 = flag.String("base-image-bare-metal-azl2", "", "An Azure Linux 2.0 bare-metal image to use as a base image.")
+	baseImageBateMetalAzl3 = flag.String("base-image-bare-metal-azl3", "", "An Azure Linux 3.0 bare-metal image to use as a base image.")
 )
 
 var (

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/multikernel-azl2.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/multikernel-azl2.yaml
@@ -1,4 +1,32 @@
+# Ensure disk size is large enough for multiple kernels.
+storage:
+  disks:
+  - partitionTableType: gpt
+    partitions:
+    - id: esp
+      type: esp
+      size: 8M
+
+    - id: rootfs
+      size: 4G
+
+  bootType: efi
+
+  filesystems:
+  - deviceId: esp
+    type: fat32
+    mountPoint:
+      path: /boot/efi
+      options: umask=0077
+
+  - deviceId: rootfs
+    type: ext4
+    mountPoint: /
+
 os:
+  bootloader:
+    resetType: hard-reset
+
   packages:
     install:
     - kernel-5.15.167.1-2.cm2

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/multikernel-azl3.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/multikernel-azl3.yaml
@@ -1,4 +1,32 @@
+# Ensure disk size is large enough for multiple kernels.
+storage:
+  disks:
+  - partitionTableType: gpt
+    partitions:
+    - id: esp
+      type: esp
+      size: 8M
+
+    - id: rootfs
+      size: 4G
+
+  bootType: efi
+
+  filesystems:
+  - deviceId: esp
+    type: fat32
+    mountPoint:
+      path: /boot/efi
+      options: umask=0077
+
+  - deviceId: rootfs
+    type: ext4
+    mountPoint: /
+
 os:
+  bootloader:
+    resetType: hard-reset
+
   packages:
     install:
     - kernel-6.6.57.1-7.azl3

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/selinux-enforcing-removepackages.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/selinux-enforcing-removepackages.yaml
@@ -1,0 +1,7 @@
+os:
+  selinux:
+    mode: enforcing
+
+  packages:
+    remove:
+    - selinux-policy

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-2stage-prepare.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-2stage-prepare.yaml
@@ -62,6 +62,7 @@ os:
     install:
     - openssh-server
     - veritysetup
+    - device-mapper
     - vim
 
   services:


### PR DESCRIPTION
1. Allow baremetal image as a input to the functional tests.

2. Add storage expansion to the multikernel tests' config files since the baremetal images are small and the kernel packages are large.

3. Ensure all verity configs include the `device-mapper` package.

4. Improve the error message of the `setfiles` call.

5. Fix `TestCustomizeImageSELinuxNoPolicy` when running against base image that has SELinux enabled.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
