### PR TITLE
Minor fixes and enhancements to COSI 1.1 support

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput.go
@@ -362,7 +362,12 @@ func prepareImageConversionData(rawImageFile string, buildDir string,
 	}
 	defer imageConnection.Close()
 
-	osRelease, osPackages, err := collectOSInfo(imageConnection)
+	osRelease, err := extractOSRelease(imageConnection)
+	if err != nil {
+		return nil, nil, "", nil, [UuidSize]byte{}, "", err
+	}
+
+	osPackages, err := collectOSInfo(imageConnection)
 	if err != nil {
 		return nil, nil, "", nil, [UuidSize]byte{}, "", err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/cosicommon.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/cosicommon.go
@@ -311,6 +311,10 @@ func getArchitectureForCosi() string {
 }
 
 func getAllPackagesFromChroot(imageConnection *ImageConnection) ([]OsPackage, error) {
+	if !isPackageInstalled(imageConnection.Chroot(), "rpm") {
+		return nil, fmt.Errorf("'rpm' is not installed in the image to enable package listing for COSI output. You may add it via the 'packages:' section in your configuration YAML")
+	}
+
 	var out string
 	err := imageConnection.Chroot().UnsafeRun(func() error {
 		var err error


### PR DESCRIPTION
<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

- When extracting OS package for COSI images and rpm package is not installed in base image, fail the build with an error message
- Moved collectOSInfo logic after customization is done.
- Updated customizeImageHelper to collect OS info only for COSI format.

---

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] Code conforms to style guidelines
