### PR TITLE
Correct the UKI unsigned and signed version the same name.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput.go
@@ -98,15 +98,14 @@ func outputArtifacts(items []imagecustomizerapi.OutputArtifactsItemType,
 					return fmt.Errorf("failed to copy binary from (%s) to (%s):\n%w", srcPath, destPath, err)
 				}
 
-				signedName := replaceSuffix(entry.Name(), ".unsigned.efi", ".signed.efi")
+				signedName := replaceSuffix(entry.Name(), ".efi", ".signed.efi")
 				source := "./" + signedName
 				unsignedSource := "./" + entry.Name()
-				destinationName := replaceSuffix(entry.Name(), ".unsigned.efi", ".efi")
 
 				outputArtifactsMetadata = append(outputArtifactsMetadata, imagecustomizerapi.InjectArtifactMetadata{
 					Partition:      espInjectFilePartition,
 					Source:         source,
-					Destination:    filepath.Join("/", UkiOutputDir, destinationName),
+					Destination:    filepath.Join("/", UkiOutputDir, entry.Name()),
 					UnsignedSource: unsignedSource,
 				})
 			}

--- a/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput_test.go
@@ -164,8 +164,7 @@ func TestOutputAndInjectArtifacts(t *testing.T) {
 
 	// UKI(s)
 	for _, src := range ukiFiles {
-		signedName := filepath.Base(replaceSuffix(src, ".efi", ".signed.efi"))
-		expectedInjectedUKI := filepath.Join(imageConnection.chroot.RootDir(), "EFI", "Linux", signedName)
+		expectedInjectedUKI := filepath.Join(imageConnection.chroot.RootDir(), "EFI", "Linux", filepath.Base(src))
 
 		exists, err = file.PathExists(expectedInjectedUKI)
 		assert.NoError(t, err)

--- a/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput_test.go
@@ -94,9 +94,9 @@ func TestOutputAndInjectArtifacts(t *testing.T) {
 	systemdBootBinary := systemdBootBinaries[0]
 
 	// Detect unsigned UKIs
-	ukiUnsignedFiles, err := filepath.Glob(filepath.Join(outputArtifactsDir, "vmlinuz-*.unsigned.efi"))
+	ukiFiles, err := filepath.Glob(filepath.Join(outputArtifactsDir, "vmlinuz-*.efi"))
 	assert.NoError(t, err)
-	assert.GreaterOrEqual(t, len(ukiUnsignedFiles), 1, "Expected at least one unsigned UKI")
+	assert.GreaterOrEqual(t, len(ukiFiles), 1, "Expected at least one UKI file")
 
 	// Simulate signed boot & systemd-boot
 	marker := "##TEST_MARKER_INJECTED##"
@@ -110,8 +110,8 @@ func TestOutputAndInjectArtifacts(t *testing.T) {
 	}
 
 	// Simulate signed UKIs
-	for _, src := range ukiUnsignedFiles {
-		dst := replaceSuffix(src, ".unsigned.efi", ".signed.efi")
+	for _, src := range ukiFiles {
+		dst := replaceSuffix(src, ".efi", ".signed.efi")
 		err := file.Copy(src, dst)
 		assert.NoError(t, err)
 	}
@@ -163,8 +163,8 @@ func TestOutputAndInjectArtifacts(t *testing.T) {
 	assert.True(t, contains, "Expected injected systemd-boot to exist:\n%s", expectedInjectedSystemdBoot)
 
 	// UKI(s)
-	for _, src := range ukiUnsignedFiles {
-		signedName := filepath.Base(replaceSuffix(src, ".unsigned.efi", ".efi"))
+	for _, src := range ukiFiles {
+		signedName := filepath.Base(replaceSuffix(src, ".efi", ".signed.efi"))
 		expectedInjectedUKI := filepath.Join(imageConnection.chroot.RootDir(), "EFI", "Linux", signedName)
 
 		exists, err = file.PathExists(expectedInjectedUKI)

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki.go
@@ -474,7 +474,7 @@ func buildUki(kernel string, initramfs string, cmdlineFilePath string, osSubrele
 		return fmt.Errorf("failed to save INI file for kernel (%s):\n%w", kernelVersion, err)
 	}
 
-	ukiFullPath := filepath.Join(systemBootPartitionTmpDir, UkiOutputDir, fmt.Sprintf("%s.unsigned.efi", kernel))
+	ukiFullPath := filepath.Join(systemBootPartitionTmpDir, UkiOutputDir, fmt.Sprintf("%s.efi", kernel))
 
 	// Build the UKI using ukify.
 	ukifyCmd := []string{

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki.go
@@ -33,9 +33,8 @@ const (
 	UkiOutputDir          = "EFI/Linux"
 )
 
-// Matches UKI filenames like "vmlinuz-<version>.efi" or "vmlinuz-<version>.unsigned.efi".
-// The ".unsigned" suffix is temporary and will be removed from the UKI filename in a future task.
-var ukiNamePattern = regexp.MustCompile(`^vmlinuz-(.+?)(?:\.unsigned)?\.efi$`)
+// Matches UKI filenames like "vmlinuz-<version>.efi"
+var ukiNamePattern = regexp.MustCompile(`^vmlinuz-(.+)\.efi$`)
 
 func prepareUki(buildDir string, uki *imagecustomizerapi.Uki, imageChroot *safechroot.Chroot) error {
 	var err error


### PR DESCRIPTION
<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

Within the OS image, the unsigned and signed version of a file should have the same name.

Test case:

```
Default Boot Loader Entry:
         type: Boot Loader Specification Type #2 (.efi)
        title: Microsoft Azure Linux 3.0
           id: vmlinuz-6.6.51.1-5.azl3.efi
       source: /boot/efi//EFI/Linux/vmlinuz-6.6.51.1-5.azl3.efi
     sort-key: azurelinux
      version: 3.0.20241005
        linux: /boot/efi//EFI/Linux/vmlinuz-6.6.51.1-5.azl3.efi
```

---

### **Checklist**
- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
