### PR TITLE
Ensure new verity and re-init verity don't conflict.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
@@ -431,7 +431,7 @@ func updateUkiKernelArgsForVerity(verityMetadata []verityDeviceMetadata,
 }
 
 func validateVerityMountPaths(imageConnection *ImageConnection, config *imagecustomizerapi.Config,
-	partUuidToFstabEntry map[string]diskutils.FstabEntry,
+	partUuidToFstabEntry map[string]diskutils.FstabEntry, baseImageVerityMetadata []verityDeviceMetadata,
 ) error {
 	if config.Storage.VerityPartitionsType != imagecustomizerapi.VerityPartitionsUsesExisting {
 		// Either:
@@ -460,6 +460,16 @@ func validateVerityMountPaths(imageConnection *ImageConnection, config *imagecus
 			return fmt.Errorf("verity (%s) hash partition not found:\n%w", verity.Id, err)
 		}
 
+		err = ensurePartitionNotAlreadyInUse(dataPartition.PartUuid, baseImageVerityMetadata)
+		if err != nil {
+			return fmt.Errorf("verity (%s) data partition is invalid:\n%w", verity.Id, err)
+		}
+
+		err = ensurePartitionNotAlreadyInUse(hashPartition.PartUuid, baseImageVerityMetadata)
+		if err != nil {
+			return fmt.Errorf("verity (%s) hash partition is invalid:\n%w", verity.Id, err)
+		}
+
 		dataFstabEntry, found := partUuidToFstabEntry[dataPartition.PartUuid]
 		if !found {
 			return fmt.Errorf("verity's (%s) data partition's fstab entry not found", verity.Id)
@@ -484,6 +494,21 @@ func validateVerityMountPaths(imageConnection *ImageConnection, config *imagecus
 	err = imagecustomizerapi.ValidateVerityMounts(config.Storage.Verity, verityDeviceMountPoint)
 	if err != nil {
 		return err
+	}
+
+	return nil
+}
+
+// Check if the partition is already being used for something else.
+func ensurePartitionNotAlreadyInUse(partUuid string, baseImageVerityMetadata []verityDeviceMetadata) error {
+	for _, verityMetadata := range baseImageVerityMetadata {
+		if partUuid == verityMetadata.dataPartUuid {
+			return fmt.Errorf("partition already in use as existing verity device's (%s) data partition", verityMetadata.name)
+		}
+
+		if partUuid == verityMetadata.hashPartUuid {
+			return fmt.Errorf("partition already in use as existing verity device's (%s) hash partition", verityMetadata.name)
+		}
 	}
 
 	return nil

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
@@ -424,8 +424,10 @@ func testCustomizeImageVerityUsr2StageHelper(t *testing.T, testName string, base
 	buildDir := filepath.Join(testTempDir, "build")
 	stage1ConfigFile := filepath.Join(testDir, "verity-2stage-prepare.yaml")
 	stage2ConfigFile := filepath.Join(testDir, "verity-2stage-enable.yaml")
-	stage1FilePath := filepath.Join(testTempDir, "image.qcow2")
-	stage2FilePath := filepath.Join(testTempDir, "image.raw")
+	stage3ConfigFile := filepath.Join(testDir, "verity-2stage-bad-reinit.yaml")
+	stage1FilePath := filepath.Join(testTempDir, "image1.qcow2")
+	stage2FilePath := filepath.Join(testTempDir, "image2.raw")
+	stage3FilePath := filepath.Join(testTempDir, "image3.vhdx")
 
 	// Stage 1: Create the partitions for verity.
 	err := CustomizeImageWithConfigFile(buildDir, stage1ConfigFile, baseImage, nil, stage1FilePath, "qcow2",
@@ -442,6 +444,12 @@ func testCustomizeImageVerityUsr2StageHelper(t *testing.T, testName string, base
 	}
 
 	verityUsrVerity(t, baseImageInfo, buildDir, stage2FilePath, "panic-on-corruption")
+
+	// Stage 3: Re-apply verity settings.
+	err = CustomizeImageWithConfigFile(buildDir, stage3ConfigFile, stage2FilePath, nil, stage3FilePath, "vhdx",
+		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	assert.ErrorContains(t, err, "verity (verityusr) data partition is invalid")
+	assert.ErrorContains(t, err, "partition already in use as existing verity device's (usr) data partition")
 }
 
 func TestCustomizeImageVerityReinitRoot(t *testing.T) {

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -914,7 +914,7 @@ func customizeImageHelper(buildDir string, baseConfigPath string, config *imagec
 		return nil
 	})
 
-	err = validateVerityMountPaths(imageConnection, config, partUuidToFstabEntry)
+	err = validateVerityMountPaths(imageConnection, config, partUuidToFstabEntry, baseImageVerityMetadata)
 	if err != nil {
 		return nil, nil, "", nil, fmt.Errorf("verity validation failed:\n%w", err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-2stage-bad-reinit.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-2stage-bad-reinit.yaml
@@ -1,0 +1,16 @@
+previewFeatures:
+- reinitialize-verity
+
+storage:
+  verity:
+  - id: verityusr
+    name: usr
+    dataDevice:
+      idType: part-label
+      id: usr
+    hashDevice:
+      idType: part-label
+      id: usrhash
+    corruptionOption: panic
+    dataDeviceMountIdType: uuid
+    hashDeviceMountIdType: uuid


### PR DESCRIPTION
Reinitialize verity and 2-stage verity can be used at the same time but we don't currently handle the case where they are both used on the same partitions. This change detects when this happens and reports an error.

In the future, we could consider allowing some form of verity settings override functionality. But we can consider that feature if and when it is requested by a user.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
