### PR TITLE
Move additionalFiles after add/update users.

### DIFF
--- a/docs/imagecustomizer/api/configuration.md
+++ b/docs/imagecustomizer/api/configuration.md
@@ -38,11 +38,11 @@ The top level type for the YAML file is the [config](./configuration/config.md) 
 
 4. Update hostname. ([hostname](./configuration/os.md#hostname-string))
 
-5. Copy additional files. ([additionalFiles](./configuration/os.md#additionalfiles-additionalfile))
+5. Add/update users. ([users](./configuration/os.md#users-user))
 
 6. Copy additional directories. ([additionalDirs](./configuration/os.md#additionaldirs-dirconfig))
 
-7. Add/update users. ([users](./configuration/os.md#users-user))
+7. Copy additional files. ([additionalFiles](./configuration/os.md#additionalfiles-additionalfile))
 
 8. Enable/disable services. ([services](./configuration/os.md#services-services))
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
@@ -40,17 +40,17 @@ func doOsCustomizations(buildDir string, baseConfigPath string, config *imagecus
 		return err
 	}
 
+	err = AddOrUpdateUsers(config.OS.Users, baseConfigPath, imageChroot)
+	if err != nil {
+		return err
+	}
+
 	err = copyAdditionalDirs(baseConfigPath, config.OS.AdditionalDirs, imageChroot)
 	if err != nil {
 		return err
 	}
 
 	err = copyAdditionalFiles(baseConfigPath, config.OS.AdditionalFiles, imageChroot)
-	if err != nil {
-		return err
-	}
-
-	err = AddOrUpdateUsers(config.OS.Users, baseConfigPath, imageChroot)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/add-user-files.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/add-user-files.yaml
@@ -1,0 +1,9 @@
+os:
+  users:
+  - name: test
+    uid: 1000
+
+  additionalFiles:
+  - destination: /home/test/platypus
+    content:
+      Egg-laying mammal


### PR DESCRIPTION
Move the additionalFiles and additionalDirs file copy operations to be after the user add/update operation. This will prevent the file copy operation from accidentally creating a user's home directory, which can result in the directory ownership and permissions being wrong.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
