### PR TITLE
Enable Image Customizer Error Telemetry 

### DIFF
--- a/toolkit/tools/imagecustomizer/main.go
+++ b/toolkit/tools/imagecustomizer/main.go
@@ -86,13 +86,13 @@ func main() {
 
 	switch parseContext.Command() {
 	case "customize":
-		err := customizeImage(ctx, cli.Customize)
+		err = customizeImage(ctx, cli.Customize)
 		if err != nil {
 			logger.Log.Errorf("image customization failed:\n%v", err)
 		}
 
 	case "inject-files":
-		err := injectFiles(ctx, cli.InjectFiles)
+		err = injectFiles(ctx, cli.InjectFiles)
 		if err != nil {
 			logger.Log.Errorf("inject-files failed:\n%v", err)
 		}
@@ -102,6 +102,9 @@ func main() {
 	}
 
 	if err != nil {
+		if err := telemetry.ShutdownTelemetry(ctx); err != nil {
+			logger.Log.Warnf("Failed to shutdown telemetry: %v", err)
+		}
 		os.Exit(1)
 	}
 }

--- a/toolkit/tools/imagecustomizer/main.go
+++ b/toolkit/tools/imagecustomizer/main.go
@@ -5,8 +5,8 @@ package main
 
 import (
 	"context"
-	"log"
 	"maps"
+	"os"
 	"strings"
 
 	"github.com/alecthomas/kong"
@@ -88,17 +88,21 @@ func main() {
 	case "customize":
 		err := customizeImage(ctx, cli.Customize)
 		if err != nil {
-			log.Fatalf("image customization failed:\n%v", err)
+			logger.Log.Errorf("image customization failed:\n%v", err)
 		}
 
 	case "inject-files":
 		err := injectFiles(ctx, cli.InjectFiles)
 		if err != nil {
-			log.Fatalf("inject-files failed:\n%v", err)
+			logger.Log.Errorf("inject-files failed:\n%v", err)
 		}
 
 	default:
 		panic(parseContext.Command())
+	}
+
+	if err != nil {
+		os.Exit(1)
 	}
 }
 

--- a/toolkit/tools/internal/telemetry/telemetry.go
+++ b/toolkit/tools/internal/telemetry/telemetry.go
@@ -55,9 +55,23 @@ func InitTelemetry(disableTelemetry bool, toolVersion string) error {
 	return nil
 }
 
+// ForceFlush attempts to flush any pending spans to the exporter
+func ForceFlush(ctx context.Context) error {
+	err := otel.GetTracerProvider().(*sdktrace.TracerProvider).ForceFlush(ctx)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 func ShutdownTelemetry(ctx context.Context) error {
 	if shutdownFn == nil {
 		return nil
 	}
+
+	if err := ForceFlush(ctx); err != nil {
+		logger.Log.Warnf("Failed to flush telemetry spans: %v", err)
+	}
+
 	return shutdownFn(ctx)
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -245,11 +245,8 @@ func CustomizeImage(ctx context.Context, buildDir string, baseConfigPath string,
 	)
 	defer func() {
 		if err != nil {
-			span.RecordError(err)
-			span.SetStatus(codes.Error, err.Error())
-			span.SetAttributes(
-				attribute.String("error.message", err.Error()),
-			)
+			span.RecordError(fmt.Errorf("image customization failed"))
+			span.SetStatus(codes.Error, "image customization failed")
 		}
 		span.End()
 	}()

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -26,6 +26,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"golang.org/x/sys/unix"
 )
 
@@ -237,14 +238,23 @@ func cleanUp(ic *ImageCustomizerParameters) error {
 func CustomizeImage(ctx context.Context, buildDir string, baseConfigPath string, config *imagecustomizerapi.Config, inputImageFile string,
 	rpmsSources []string, outputImageFile string, outputImageFormat string,
 	useBaseImageRpmRepos bool, packageSnapshotTime string,
-) error {
+) (err error) {
 	ctx, span := otel.GetTracerProvider().Tracer(OtelTracerName).Start(ctx, "customize_image")
 	span.SetAttributes(
 		attribute.String("output_image_format", string(outputImageFormat)),
 	)
-	defer span.End()
+	defer func() {
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			span.SetAttributes(
+				attribute.String("error.message", err.Error()),
+			)
+		}
+		span.End()
+	}()
 
-	err := ValidateConfig(ctx, baseConfigPath, config, inputImageFile, rpmsSources, outputImageFile, outputImageFormat, useBaseImageRpmRepos, packageSnapshotTime, false)
+	err = ValidateConfig(ctx, baseConfigPath, config, inputImageFile, rpmsSources, outputImageFile, outputImageFormat, useBaseImageRpmRepos, packageSnapshotTime, false)
 	if err != nil {
 		return fmt.Errorf("invalid image config:\n%w", err)
 	}


### PR DESCRIPTION

<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

Enable error telemetry for imagecustomizer as well as flushing all telemetry before shutdown. 

Needed to add event logic to telemetry hopper because error spans are structured and processed a bit differently.

For errors, we are keeping a generic error message in the span for now, to prevent any accidental collection of user data through returned error strings. In a follow-up effort, we'll have a structured Error Type that would be included in the span's error field.

---

### **Checklist**
- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
