### PR TITLE
Image Customizer: Fix verity partition shrink test

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
@@ -178,7 +178,7 @@ func testCustomizeImageVerityCosiExtractHelper(t *testing.T, testName string, ba
 	// implementation details, and randomness. So, just enforce that the final size is below an arbitary value. Values
 	// were picked by observing values seen during test and adding a good buffer.
 	assert.Greater(t, int64(150*diskutils.MiB), bootStat.Size())
-	assert.Greater(t, int64(650*diskutils.MiB), rootStat.Size())
+	assert.Greater(t, int64(655*diskutils.MiB), rootStat.Size())
 	assert.Greater(t, int64(10*diskutils.MiB), hashStat.Size())
 	assert.Greater(t, int64(150*diskutils.MiB), varStat.Size())
 


### PR DESCRIPTION
In this verity test, we check the shrunk partition sizes against a set of hardcoded values to make sure shrinking took place. 
One of the hardcoded values is now smaller than that actual shrunk size by 2MB. This change increases the hardcoded value by 5MB.

---

### **Checklist**
- [x] Tests added/updated
- [n/a] Documentation updated (if needed)
- [n/a] Code conforms to style guidelines
