### PR TITLE
Image Customizer: Enable selinux in iso vm tests

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/iso-bootstrap-vm.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/iso-bootstrap-vm.yaml
@@ -2,10 +2,7 @@ iso:
   initramfsType: bootstrap
 os:
   selinux:
-    mode: disabled
-  kernelCommandLine:
-    extraCommandLine:
-    - "selinux=0"
+    mode: enforcing
   packages:
     install:
     # multi-kernel test
@@ -15,6 +12,9 @@ os:
     - tar
     - device-mapper
     - curl
+    # Required packages for SELinux.
+    - selinux-policy
+    - selinux-policy-modules
 
   additionalFiles:
     # Enable DHCP client on all of the physical NICs.


### PR DESCRIPTION
Image Customizer: Enable selinux in iso vm tests

- [x] Tests added/updated
- [n/a] Documentation updated (if needed)
- [x] Code conforms to style guidelines
