### PR TITLE
Image Customizer: fixing a crash in pxe build flow

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -101,7 +101,7 @@ func buildLiveOSConfig(inputArtifactsStore *IsoArtifactsStore, isoConfig *imagec
 			config.initramfsType = pxeConfig.InitramfsType
 			config.bootstrapBaseUrl = pxeConfig.BootstrapBaseUrl
 			config.bootstrapFileUrl = pxeConfig.BootstrapFileUrl
-			config.kdumpBootFiles = isoConfig.KdumpBootFiles
+			config.kdumpBootFiles = pxeConfig.KdumpBootFiles
 		}
 
 		config.initramfsType, convertingInitramfsType = resolveInitramfsType(inputArtifactsStore, config.initramfsType,


### PR DESCRIPTION
The PXE flow got broken with the recent changes to accommodate kdump files. The problem comes from a typo where we are referencing the iso configuration in the pxe context where it may be nil and hence causes a crash.

- [-] Tests added/updated
- [n/a] Documentation updated (if needed)
- [x] Code conforms to style guidelines
