### PR TITLE
Container build: Improve incremental updates.

### DIFF
--- a/toolkit/tools/imagecustomizer/container/imagecustomizer.Dockerfile
+++ b/toolkit/tools/imagecustomizer/container/imagecustomizer.Dockerfile
@@ -18,10 +18,12 @@ RUN tdnf update -y && \
       python3 python3-pip jq oras && \
    tdnf clean all
 
-COPY . /
-
 # Create virtual environment and install Python dependencies for telemetry
+COPY ./usr/local/bin/requirements.txt /usr/local/bin/requirements.txt
 RUN python3 -m venv /opt/telemetry-venv && \
    /opt/telemetry-venv/bin/pip install --no-cache-dir -r /usr/local/bin/requirements.txt
+
+# Copy binaries.
+COPY . /
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
When building the container, ensure the venv creation is done before the binaries are copied into the container. This make incremental builds of the container substantially faster since the venv doesn't need to be recreated every time the binary is updated.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
