### PR TITLE
Image Customizer: Iso: re-populate the /boot folder without the --no-…

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
@@ -57,12 +57,20 @@ func copyFilesIntoNewDisk(existingImageChroot *safechroot.Chroot, newImageChroot
 }
 
 func copyPartitionFiles(sourceRoot, targetRoot string) error {
+	return copyPartitionFilesWithOptions(sourceRoot, targetRoot, true /*noClobber*/)
+}
+
+func copyPartitionFilesWithOptions(sourceRoot, targetRoot string, noClobber bool) error {
 	// Notes:
 	// `-a` ensures unix permissions, extended attributes (including SELinux), and sub-directories (-r) are copied.
 	// `--no-dereference` ensures that symlinks are copied as symlinks.
 	copyArgs := []string{
-		"--verbose", "--no-clobber", "-a", "--no-dereference", "--sparse", "always",
+		"--verbose", "-a", "--no-dereference", "--sparse", "always",
 		sourceRoot, targetRoot,
+	}
+
+	if noClobber {
+		copyArgs = append(copyArgs, "--no-clobber")
 	}
 
 	err := shell.NewExecBuilder("cp", copyArgs...).

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
@@ -440,7 +440,7 @@ func testCustomizeImageLiveOSKeepKdumpFilesA(t *testing.T, testName string, base
 	//       Input: base vhdx
 	//	       kdumpBootFiles=keep
 	//         boot/initramfs-6.6.65.1-2.azl3kdump.img exists
-	//         boot/vmlinuz-6.6.65.1-2.azl3 exist
+	//         boot/vmlinuz-6.6.65.1-2.azl3 exists
 	//       Expected: {full-os}/boot/{initramfs + kernel}
 	//
 	// This test case ensures we can exclude the kdump files from the /boot folder clean-up.


### PR DESCRIPTION
…clobber option

We are disabling the --no-clobber option since the target boot folder may have common files already from the previous steps. This can happen when kdump boot files are set to 'keep' in the input iso which will result in two copies of the kernel vmlinux file:
- one from the iso media
- one from the full OS image (next to the initramfs kdump.img file). When the OS is being re-constructed, the attempt to re-copy the kernel vmlinuz file will fail if we use --no-clobber. So, we disable it here while copying the boot files from the artifacts.

<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

---

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] Code conforms to style guidelines
