### PR TITLE
VMTests suite: Use libvirt API to read console logs.

### DIFF
--- a/test/vmtests/vmtests/test_min_change.py
+++ b/test/vmtests/vmtests/test_min_change.py
@@ -111,11 +111,11 @@ def run_min_change_test(
     vm_name = test_instance_name
 
     vm_spec = VmSpec(vm_name, 4096, 4, vm_image, target_boot_type, secure_boot)
-    domain_xml = create_libvirt_domain_xml(libvirt_conn, vm_spec, vm_console_log_file_path)
+    domain_xml = create_libvirt_domain_xml(libvirt_conn, vm_spec)
 
     logging.debug(f"\n\ndomain_xml            = {domain_xml}\n\n")
 
-    vm = LibvirtVm(vm_name, domain_xml, libvirt_conn)
+    vm = LibvirtVm(vm_name, domain_xml, vm_console_log_file_path, libvirt_conn)
     close_list.append(vm)
 
     # Start VM.

--- a/test/vmtests/vmtests/utils/libvirt_console_logger.py
+++ b/test/vmtests/vmtests/utils/libvirt_console_logger.py
@@ -1,0 +1,137 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+from threading import Event
+from typing import IO, Any, Optional, Union
+
+import libvirt  # type: ignore
+
+from . import libvirt_events_thread
+
+
+# Reads serial console log from libvirt VM and writes it to a file.
+class LibvirtConsoleLogger:
+    def __init__(self) -> None:
+        self._stream_completed = Event()
+        self._console_stream: Optional[libvirt.virStream] = None
+        self._console_stream_callback_started = False
+        self._console_stream_callback_added = False
+        self._log_file: Optional[IO[Any]] = None
+
+    # Attach logger to a libvirt VM.
+    def attach(
+        self,
+        domain: libvirt.virDomain,
+        log_file_path: str,
+    ) -> None:
+        # Open the log file.
+        self._log_file = open(log_file_path, "ab")
+
+        # Open the libvirt console stream.
+        console_stream = domain.connect().newStream(libvirt.VIR_STREAM_NONBLOCK)
+        domain.openConsole(
+            None,
+            console_stream,
+            libvirt.VIR_DOMAIN_CONSOLE_FORCE | libvirt.VIR_DOMAIN_CONSOLE_SAFE,
+        )
+        self._console_stream = console_stream
+
+        libvirt_events_thread.run_callback(self._register_console_callbacks)
+        self._console_stream_callback_started = True
+
+    # Close the logger.
+    def close(self, abort: bool = True) -> None:
+        # Check if attach() run successfully.
+        if self._console_stream_callback_started:
+            if abort:
+                # Close the stream on libvirt callbacks thread.
+                libvirt_events_thread.run_callback(self._close_stream, True)
+
+            # Wait for stream to close.
+            self._stream_completed.wait()
+
+        else:
+            if self._console_stream:
+                self._console_stream.abort()
+
+            if self._log_file:
+                self._log_file.close()
+
+    # Wait until the stream closes.
+    # Typically used when gracefully shutting down a VM.
+    def wait_for_close(self) -> None:
+        if self._console_stream_callback_started:
+            self._stream_completed.wait()
+
+    # Register the console stream events.
+    # Threading: Must only be called on libvirt events thread.
+    def _register_console_callbacks(self) -> None:
+        # Attach callback for stream events.
+        assert self._console_stream
+        self._console_stream.eventAddCallback(
+            libvirt.VIR_STREAM_EVENT_READABLE | libvirt.VIR_STREAM_EVENT_ERROR | libvirt.VIR_STREAM_EVENT_HANGUP,
+            self._stream_event,
+            None,
+        )
+        self._console_stream_callback_added = True
+
+    # Handles events for the console stream.
+    # Threading: Must only be called on libvirt events thread.
+    def _stream_event(self, stream: libvirt.virStream, events: Union[int, bytes], context: Any) -> None:
+        if events & libvirt.VIR_STREAM_EVENT_READABLE:
+            # Data is available to be read.
+            while True:
+                try:
+                    data = stream.recv(libvirt.virStorageVol.streamBufSize)
+                except libvirt.libvirtError:
+                    # An error occured. So, close the stream.
+                    self._close_stream(True)
+                    break
+
+                if data == -2:
+                    # No more data available at the moment.
+                    assert self._log_file
+                    self._log_file.flush()
+                    break
+
+                if len(data) == 0:
+                    # EOF reached.
+                    self._close_stream(False)
+                    break
+
+                assert self._log_file
+                self._log_file.write(data)
+
+                # Ideally we would also write to logging here.
+                # But the console bytes aren't sent in full lines.
+                # So, buffering and line splitting would need to be implemented manually.
+
+        if events & libvirt.VIR_STREAM_EVENT_ERROR or events & libvirt.VIR_STREAM_EVENT_HANGUP:
+            # Stream is shutting down. So, close it.
+            self._close_stream(True)
+
+    # Close the stream resource.
+    # Threading: Must only be called on libvirt events thread.
+    def _close_stream(self, abort: bool) -> None:
+        if self._stream_completed.is_set():
+            # Already closed. Nothing to do.
+            return
+
+        try:
+            # Close the log file
+            assert self._log_file
+            self._log_file.close()
+
+            # Close the stream
+            assert self._console_stream
+            if self._console_stream_callback_added:
+                self._console_stream.eventRemoveCallback()
+
+            if abort:
+                self._console_stream.abort()
+            else:
+                self._console_stream.finish()
+
+        finally:
+            # Signal that the stream has closed.
+            self._stream_completed.set()

--- a/test/vmtests/vmtests/utils/libvirt_events_thread.py
+++ b/test/vmtests/vmtests/utils/libvirt_events_thread.py
@@ -1,0 +1,68 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+# To use libvirt callbacks, one has to setup a single process-wide event loop for
+# libvirt. This module provisions the event loop in a python thread dedicated to
+# handling libvirt events.
+
+import asyncio
+from threading import Event, Lock, Thread
+from typing import Any, Callable, Optional
+
+import libvirtaio  # type: ignore
+
+_callbacks_thread_lock = Lock()
+_callbacks_thread: Optional[Thread] = None
+_callbacks_thread_running = Event()
+_callbacks_loop: Optional[asyncio.AbstractEventLoop] = None
+
+
+# Entry-point for the libvirt events thread.
+def _libvirt_events_thread() -> None:
+    global _callbacks_loop
+
+    # Provision this thread as an asyncio thread.
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    _callbacks_loop = loop
+
+    # Initialize this thread as the libvirt events thread.
+    libvirtaio.virEventRegisterAsyncIOImpl()
+
+    # Signal that thread is initialized.
+    _callbacks_thread_running.set()
+
+    # Run the asyncio loop.
+    loop.run_forever()
+
+
+def init() -> None:
+    global _callbacks_thread
+
+    # Check if the events thread is already running.
+    if _callbacks_thread_running.is_set():
+        return
+
+    _callbacks_thread_lock.acquire()
+    try:
+        # Check if the events thread already exists.
+        if not _callbacks_thread:
+            # Start the thread.
+            thread = Thread(target=_libvirt_events_thread)
+            thread.daemon = True
+            thread.start()
+
+            _callbacks_thread = thread
+    finally:
+        _callbacks_thread_lock.release()
+
+    # Wait for the events thread to initialize.
+    _callbacks_thread_running.wait()
+
+
+# Run a callback on the libvirt events thread.
+def run_callback(callback: Callable[..., Any], *args: Any) -> asyncio.Handle:
+    assert _callbacks_thread_running.is_set()
+
+    assert _callbacks_loop
+    return _callbacks_loop.call_soon_threadsafe(callback, *args)

--- a/test/vmtests/vmtests/utils/libvirt_utils.py
+++ b/test/vmtests/vmtests/utils/libvirt_utils.py
@@ -116,7 +116,7 @@ def _get_libvirt_firmware_config(
 
 
 # Create XML definition for a VM.
-def create_libvirt_domain_xml(libvirt_conn: libvirt.virConnect, vm_spec: VmSpec, log_file: str) -> str:
+def create_libvirt_domain_xml(libvirt_conn: libvirt.virConnect, vm_spec: VmSpec) -> str:
 
     host_arch = platform.machine()
 
@@ -212,9 +212,7 @@ def create_libvirt_domain_xml(libvirt_conn: libvirt.virConnect, vm_spec: VmSpec,
     controller_scsi.attrib["model"] = "virtio-scsi"
 
     serial = ET.SubElement(devices, "serial")
-    serial.attrib["type"] = "file"
-    serial_source = ET.SubElement(serial, "source")
-    serial_source.attrib["path"] = log_file
+    serial.attrib["type"] = "pty"
 
     serial_target = ET.SubElement(serial, "target")
     serial_target.attrib["type"] = serial_target_type
@@ -224,10 +222,7 @@ def create_libvirt_domain_xml(libvirt_conn: libvirt.virConnect, vm_spec: VmSpec,
     serial_target_model.attrib["name"] = serial_target_model_name
 
     console = ET.SubElement(devices, "console")
-    console.attrib["type"] = "file"
-
-    console_source = ET.SubElement(console, "source")
-    console_source.attrib["path"] = log_file
+    console.attrib["type"] = "pty"
 
     console_target = ET.SubElement(console, "target")
     console_target.attrib["type"] = "serial"


### PR DESCRIPTION
Currently, the console logs are written directly to file by QEMU. However, this can cause permission issues, particulartly on hosts with SELinux enabled (e.g. Fedora).

This change instead reads the console logs using the libvirt API and then uses Python I/O to write the logs to disk. This avoids the permission issues since the test process is the one writing the logs, instead of the more restricted QEMU process.

Similar to the other uses of the libvirt API in the VMTests suite, most of the code was copy/pasted from the
[LISA](https://github.com/microsoft/lisa/tree/main/lisa/sut_orchestrator/libvirt) project.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
