### PR TITLE
VMTests: Fix when run as 'root' user.

### DIFF
--- a/test/vmtests/vmtests/test_min_change.py
+++ b/test/vmtests/vmtests/test_min_change.py
@@ -4,7 +4,6 @@
 import logging
 import os
 import platform
-from getpass import getuser
 from pathlib import Path
 from typing import List, Tuple
 
@@ -20,6 +19,7 @@ from .utils.imagecustomizer import run_image_customizer
 from .utils.libvirt_utils import VmSpec, create_libvirt_domain_xml
 from .utils.libvirt_vm import LibvirtVm
 from .utils.ssh_client import SshClient
+from .utils.user_utils import get_username
 
 
 def run_min_change_test(
@@ -60,7 +60,7 @@ def run_min_change_test(
     logging.debug(f"- target_boot_type        = {target_boot_type}")
     logging.debug(f"- logs_dir                = {logs_dir}")
 
-    username = getuser()
+    username = get_username()
 
     run_image_customizer(
         docker_client,
@@ -122,7 +122,7 @@ def run_min_change_test(
     vm.start()
 
     # Connect to the VM.
-    with vm.create_ssh_client(ssh_private_key_path, test_temp_dir) as ssh_client:
+    with vm.create_ssh_client(ssh_private_key_path, test_temp_dir, username) as ssh_client:
         # Run the test
         run_basic_checks(ssh_client, input_image_azl_release, test_temp_dir)
 

--- a/test/vmtests/vmtests/utils/libvirt_vm.py
+++ b/test/vmtests/vmtests/utils/libvirt_vm.py
@@ -107,6 +107,7 @@ class LibvirtVm:
         self,
         ssh_private_key_path: Path,
         test_temp_dir: Path,
+        username: str,
     ) -> SshClient:
 
         ssh_known_hosts_path = test_temp_dir.joinpath("known_hosts")
@@ -133,7 +134,12 @@ class LibvirtVm:
 
             # Connect to VM using SSH.
             try:
-                vm_ssh = SshClient(vm_ip_address, key_path=ssh_private_key_path, known_hosts_path=ssh_known_hosts_path)
+                vm_ssh = SshClient(
+                    vm_ip_address,
+                    key_path=ssh_private_key_path,
+                    known_hosts_path=ssh_known_hosts_path,
+                    username=username,
+                )
                 return vm_ssh
             except SshClientException as e:
                 delta_time = time.monotonic() - stable_ip_start_time

--- a/test/vmtests/vmtests/utils/user_utils.py
+++ b/test/vmtests/vmtests/utils/user_utils.py
@@ -1,0 +1,23 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+import os
+from getpass import getuser
+
+
+# Get the name of the current user.
+# This makes it easier for the user to manually SSH into the VM when debugging.
+def get_username() -> str:
+    sudo_user = os.environ.get("SUDO_USER")
+    if sudo_user is not None:
+        # User is using sudo.
+        # So, use their actual user name instead of "root".
+        return sudo_user
+
+    user = getuser()
+    if user == "root":
+        # The root user is typically disabled for SSH.
+        # So, use a different name.
+        return "test"
+
+    return user


### PR DESCRIPTION
The VMTests suite uses the name of the current user as the name of the test user it deploys to the OS image. This makes it easier for the user to manually SSH into the VM when debugging. However, this doesn't work when the test is being run as "root" (e.g. sudo) since the SSH login is typically disabled for the "root" user. This change adds code to detect this and use a different username.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
