### PR TITLE
Image Customizer: Iso: recreate image with a single ext4 partition

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoimages.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoimages.go
@@ -535,36 +535,20 @@ func createWriteableImageFromArtifacts(buildDir string, inputArtifactsStore *Iso
 
 	// define a disk layout with a boot partition and a rootfs partition
 	maxDiskSizeMB := imagecustomizerapi.DiskSize(safeDiskSizeMB * diskutils.MiB)
-	bootPartitionStart := imagecustomizerapi.DiskSize(1 * diskutils.MiB)
-	bootPartitionEnd := imagecustomizerapi.DiskSize(9 * diskutils.MiB)
+	partitionStart := imagecustomizerapi.DiskSize(1 * diskutils.MiB)
 
 	diskConfig := imagecustomizerapi.Disk{
 		PartitionTableType: imagecustomizerapi.PartitionTableTypeGpt,
 		MaxSize:            &maxDiskSizeMB,
 		Partitions: []imagecustomizerapi.Partition{
 			{
-				Id:    "esp",
-				Start: &bootPartitionStart,
-				End:   &bootPartitionEnd,
-				Type:  imagecustomizerapi.PartitionTypeESP,
-			},
-			{
 				Id:    "rootfs",
-				Start: &bootPartitionEnd,
+				Start: &partitionStart,
 			},
 		},
 	}
 
 	fileSystemConfigs := []imagecustomizerapi.FileSystem{
-		{
-			DeviceId:    "esp",
-			PartitionId: "esp",
-			Type:        imagecustomizerapi.FileSystemTypeFat32,
-			MountPoint: &imagecustomizerapi.MountPoint{
-				Path:    "/boot/efi",
-				Options: "umask=0077",
-			},
-		},
 		{
 			DeviceId:    "rootfs",
 			PartitionId: "rootfs",


### PR DESCRIPTION
Image Customizer: Iso: recreate image with a single ext4 partition

When we are starting from an input iso, we re-construct an image with a boot fat32 partition and a rootfs ext4 partition. Then, we copy everything unto that image.

The problem is that the boot fat32 partition cannot preserve all the file attributes coming from the source image. As a result, the copy command fails when it's set to preserve attributes. This problem shows only on Azure Linux 3. It does not repro on Ubuntu 22+.

There is no real need to create the boot partition at all in this flow. So, this fix drops the boot partition from the temporary image we create.

- [n/a] Tests added/updated
- [n/a] Documentation updated (if needed)
- [x] Code conforms to style guidelines
