### PR TITLE
Add SKIP_LICENSE_SCAN flag to support air-gapped builds.

### DIFF
--- a/toolkit/Makefile
+++ b/toolkit/Makefile
@@ -22,6 +22,8 @@ include $(SCRIPTS_DIR)/utils.mk
 ######## REMAINING BUILD FLAGS ########
 
 STOP_ON_WARNING    ?= n
+# Skip license scanning (useful for air-gapped builds).
+SKIP_LICENSE_SCAN  ?= n
 
 ######## HIGH LEVEL TARGETS ########
 

--- a/toolkit/scripts/check-and-collect-licenses.py
+++ b/toolkit/scripts/check-and-collect-licenses.py
@@ -16,7 +16,8 @@ import tempfile
 import urllib
 import urllib.request
 
-REPO_ROOT = subprocess.run(["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True, check=True).stdout.strip()
+SCRIPT_DIR = Path(os.path.realpath(__file__)).parent
+REPO_ROOT = (SCRIPT_DIR / ".." / "..").resolve()
 OUTPUT_DIR = Path(REPO_ROOT) / "toolkit" / "out"
 LICENSE_SCAN_OUTPUT = OUTPUT_DIR / "LICENSES-SCAN.json"
 LICENSES_DIR = OUTPUT_DIR / "LICENSES"

--- a/toolkit/scripts/tools.mk
+++ b/toolkit/scripts/tools.mk
@@ -76,9 +76,16 @@ go_ldflags := 	-X github.com/microsoft/azurelinux/toolkit/tools/internal/exe.Too
 				-X github.com/microsoft/azurelinux/toolkit/tools/internal/exe.DistroNameAbbreviation=$(DIST_NAME_ABRV) \
 				-X github.com/microsoft/azurelinux/toolkit/tools/internal/exe.DistroMajorVersion=$(dist_major_version_number)
 
+# Conditionally include license-scan dependency based on SKIP_LICENSE_SCAN flag
+ifeq ($(SKIP_LICENSE_SCAN),y)
+license_scan_dependency =
+else
+license_scan_dependency = license-scan
+endif
+
 # Matching rules for the above targets
 # Tool specific pre-requisites are tracked via $(go-util): $(shell find...) dynamic variable defined above
-$(TOOL_BINS_DIR)/%: $(go_common_files) license-scan
+$(TOOL_BINS_DIR)/%: $(go_common_files) $(license_scan_dependency)
 	cd $(TOOLS_DIR)/$* && \
 		go test -ldflags="$(go_ldflags)" -test.short -covermode=atomic -coverprofile=$(BUILD_DIR)/tools/$*.test_coverage ./... && \
 		CGO_ENABLED=0 go build \
@@ -92,19 +99,27 @@ $(BUILD_DIR)/tools/internal.test_coverage: $(go_internal_files) $(go_imagegen_fi
 		go test -ldflags="$(go_ldflags)" -test.short -covermode=atomic -coverprofile=$@ ./...
 
 .PHONY: imagecustomizer-targz
-imagecustomizer-targz: go-imagecustomizer license-scan
+imagecustomizer-targz: go-imagecustomizer $(license_scan_dependency)
 	rm -rf $(BUILD_DIR)/imagecustomizertar || true
 	mkdir -p $(BUILD_DIR)/imagecustomizertar
 	cp $(TOOL_BINS_DIR)/imagecustomizer $(BUILD_DIR)/imagecustomizertar
+ifeq ($(SKIP_LICENSE_SCAN),y)
+	@echo "Skipping license scan - LICENSES directory will not be included"
+else
 	cp -r $(toolkit_root)/out/LICENSES $(BUILD_DIR)/imagecustomizertar
+endif
 	tar -C $(BUILD_DIR)/imagecustomizertar -cz --file $(toolkit_root)/out/imagecustomizer.tar.gz .
 
 .PHONY: imagecreator-targz
-imagecreator-targz: go-imagecreator license-scan
+imagecreator-targz: go-imagecreator $(license_scan_dependency)
 	rm -rf $(BUILD_DIR)/imagecreatortargz || true
 	mkdir -p $(BUILD_DIR)/imagecreatortargz
 	cp $(TOOL_BINS_DIR)/imagecreator $(BUILD_DIR)/imagecreatortargz
+ifeq ($(SKIP_LICENSE_SCAN),y)
+	@echo "Skipping license scan - LICENSES directory will not be included"
+else
 	cp -r $(toolkit_root)/out/LICENSES $(BUILD_DIR)/imagecreatortargz
+endif
 	tar -C $(BUILD_DIR)/imagecreatortargz -cz --file $(toolkit_root)/out/imagecreator.tar.gz .
 
 # Downloads all the go dependencies without using sudo, so we don't break other go use cases for the user.


### PR DESCRIPTION
<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

## Summary
Adds a `SKIP_LICENSE_SCAN` build flag to allow building imagecustomizer in air-gapped environments where external downloads are not permitted.

## Problem
During RPM packaging builds in air-gapped environments, the license scanning process fails because it attempts to download Trivy from GitHub:
- `check-and-collect-licenses.py` downloads Trivy binary during build
- Air-gapped build systems cannot access external URLs
- This causes build failures in restricted network environments

## Solution
- Added `SKIP_LICENSE_SCAN` flag to Makefile (defaults to `n` for backward compatibility)
- Modified build dependencies to conditionally include license scanning
- Updated tar.gz targets to skip LICENSES directory when scanning is disabled
- Added help documentation for the new flag

## Changes
- **toolkit/Makefile**: Added `SKIP_LICENSE_SCAN` flag with help documentation
- **toolkit/scripts/tools.mk**: 
  - Conditional license scan dependency logic
  - Updated `imagecustomizer-targz` target to handle skipped scanning
- **SPECS/azure-linux-image-tools.spec**: Use `SKIP_LICENSE_SCAN=y` for RPM builds

## Usage
**Air-gapped builds:**
```bash
make -C toolkit go-imagecustomizer REBUILD_TOOLS=y SKIP_LICENSE_SCAN=y
```

---

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] Code conforms to style guidelines
