### PR TITLE
Upgrade minimal-os image used to test the Image Customizer container to 3.0

### DIFF
--- a/toolkit/tools/imagecustomizer/container/test-container.sh
+++ b/toolkit/tools/imagecustomizer/container/test-container.sh
@@ -30,7 +30,7 @@ docker run --rm \
     -v /dev:/dev \
     "$containerTag" \
     /usr/local/bin/run.sh \
-        "2.0.latest" \
+        "3.0.latest" \
         --config-file "$containerInputConfig" \
         --build-dir "$containerBuildDir" \
         --output-image-format "vhdx" \


### PR DESCRIPTION
This change enables onboarding of ARM64 container tests, which require a minimal-os image for ARM64, now available in the latest 3.0 release.

Version 2.0 of minimal-os is being deprecated, so we're also upgrading to 3.0 to ensure continued support.