### PR TITLE
Optimize docker build cache when setting up telemetry venv

### DIFF
--- a/toolkit/tools/imagecustomizer/container/build-container.sh
+++ b/toolkit/tools/imagecustomizer/container/build-container.sh
@@ -90,10 +90,10 @@ cp "$exeFile" "${stagingBinDir}"
 cp "$runScriptPath" "${stagingBinDir}"
 cp -R "$licensesDir" "${stagingLicensesDir}"
 cp "$telemetryScript" "${stagingBinDir}"
-cp "$telemetryRequirements" "${stagingBinDir}"
 cp "$entrypointScript" "${stagingBinDir}"
 
-touch ${containerStagingFolder}/.mariner-toolkit-ignore-dockerenv
+cp "$telemetryRequirements" "${containerStagingFolder}"/telemetry-requirements.txt
+touch "${containerStagingFolder}"/.mariner-toolkit-ignore-dockerenv
 
 # azl doesn't support grub2-pc for arm64, hence remove it from dockerfile
 if [ "$ARCH" == "arm64" ]; then
@@ -101,8 +101,19 @@ if [ "$ARCH" == "arm64" ]; then
     sed -i 's/\<grub2-pc systemd-ukify\>//g' "$dockerFile"
 fi
 
+# list all staged files
+(
+    cd "$containerStagingFolder"
+    find . -type f | sort
+)
+
 # build the container
-docker build --build-arg "BASE_IMAGE=$baseImage" --build-arg "AZ_MON_CONN_STR=$azMonitorString" -f "$dockerFile" "$containerStagingFolder" -t "$containerTag"
+docker build \
+    --build-arg "BASE_IMAGE=$baseImage" \
+    --build-arg "AZ_MON_CONN_STR=$azMonitorString" \
+    --file "$dockerFile" \
+    --tag "$containerTag" \
+    "$containerStagingFolder"
 
 # clean-up
 cleanUp

--- a/toolkit/tools/imagecustomizer/container/imagecustomizer.Dockerfile
+++ b/toolkit/tools/imagecustomizer/container/imagecustomizer.Dockerfile
@@ -19,11 +19,13 @@ RUN tdnf update -y && \
    tdnf clean all
 
 # Create virtual environment and install Python dependencies for telemetry
-COPY ./usr/local/bin/requirements.txt /usr/local/bin/requirements.txt
-RUN python3 -m venv /opt/telemetry-venv && \
-   /opt/telemetry-venv/bin/pip install --no-cache-dir -r /usr/local/bin/requirements.txt
+RUN python3 -m venv /opt/telemetry-venv
+COPY telemetry-requirements.txt /telemetry-requirements.txt
+RUN /opt/telemetry-venv/bin/pip install --no-cache-dir -r /telemetry-requirements.txt
+RUN rm -rf /telemetry-requirements.txt
 
-# Copy binaries.
-COPY . /
+# Copy all necessary files
+COPY .mariner-toolkit-ignore-dockerenv /
+COPY usr /usr
 
 ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
Bootstrapping the Python virtual environment for telemetry is time-consuming. Previously, modifying any file copied into the container would bust the cache before the virtual environment was set up, triggering a full rebuild even when requirements.txt hadn't changed.

This PR refactors the Dockerfile to avoid that. Now, the base virtual environment is never rebuilt on any file change, and python packages are only installed when requirements.txt is modified.

This PR also removes the requirements.txt file from the docker container since it is not needed at runtime.