### PR TITLE
VMTests: Fix legacy boot tests.

### DIFF
--- a/test/vmtests/vmtests/utils/libvirt_utils.py
+++ b/test/vmtests/vmtests/utils/libvirt_utils.py
@@ -160,7 +160,8 @@ def create_libvirt_domain_xml(libvirt_conn: libvirt.virConnect, vm_spec: VmSpec)
     os_type.attrib["arch"] = host_arch
     os_type.attrib["machine"] = machine_model
 
-    ET.SubElement(os_tag, "nvram")
+    if vm_spec.boot_type == "efi":
+        ET.SubElement(os_tag, "nvram")
 
     os_boot = ET.SubElement(os_tag, "boot")
 


### PR DESCRIPTION
In newer versions of libvirt, specifying the `nvram` element in the domain XML will result in the VM being interpreted as UEFI firmware based. Whereas in older versions of libvirt, the `nvram` element is ignored if the other UEFI elements (e.g. `loader`) are not specified.

This change drops the `nvram` element when legacy boot is specified. This fixes the `libvirt: Domain Config error : no loader path specified and firmware auto selection disabled` error.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
