### PR TITLE
Add API for mounting partition as readonly during customization.

### DIFF
--- a/docs/imagecustomizer/api/configuration.md
+++ b/docs/imagecustomizer/api/configuration.md
@@ -155,6 +155,7 @@ os:
         - [options](./configuration/mountpoint.md#options-string)
         - [path](./configuration/mountpoint.md#path-string)
     - [resetPartitionsUuidsType](./configuration/storage.md#resetpartitionsuuidstype-string)
+    - [customizationReadOnlyMounts](./configuration/storage.md#customizationreadonlymounts-string)
   - [iso](./configuration/config.md#iso-iso) ([iso type](./configuration/iso.md))
     - [additionalFiles](./configuration/iso.md#additionalfiles-additionalfile)
       - [additionalFile type](./configuration/additionalfile.md)

--- a/docs/imagecustomizer/api/configuration/config.md
+++ b/docs/imagecustomizer/api/configuration/config.md
@@ -104,6 +104,12 @@ Supported options:
 
   Added in v0.15.
 
+- `read-only-mounts`: Enables the
+  [`storage.customizationReadOnlyMounts`](./storage.md#customizationreadonlymounts-string)
+  API.
+
+  Added in v0.17.
+
 ## output [[output](./output.md)]
 
 Specifies the configuration for the output image and artifacts.

--- a/docs/imagecustomizer/api/configuration/storage.md
+++ b/docs/imagecustomizer/api/configuration/storage.md
@@ -136,3 +136,32 @@ os:
 ```
 
 Added in v0.7.
+
+## customizationReadOnlyMounts [string[]]
+
+This is a preview feature.
+Its API and behavior is subject to change.
+You must enable this feature by specifying `read-only-mounts` in the
+[previewFeatures](./config.md#previewfeatures-string) API.
+
+Specifies a list of partitions that will be mounted as readonly during OS customization.
+Partitions are specified by mount target path.
+
+Example:
+
+```yaml
+previewFeatures:
+- read-only-mounts
+
+storage:
+  customizationReadOnlyMounts:
+  - /usr
+
+os:
+  additionalFiles:
+  - content: |
+      cat, dog, elephant, squirrel
+    destination: /etc/animals.txt
+```
+
+Added in v0.17.

--- a/toolkit/tools/imagecustomizerapi/config.go
+++ b/toolkit/tools/imagecustomizerapi/config.go
@@ -118,6 +118,11 @@ func (c *Config) IsValid() (err error) {
 		}
 	}
 
+	if len(c.Storage.CustomizationReadOnlyMounts) > 0 &&
+		!sliceutils.ContainsValue(c.PreviewFeatures, PreviewFeatureReadOnlyMounts) {
+		return fmt.Errorf("the 'read-only-mounts' preview feature must be enabled to use 'storage.customizationReadOnlyMounts'")
+	}
+
 	return nil
 }
 

--- a/toolkit/tools/imagecustomizerapi/previewfeaturetype.go
+++ b/toolkit/tools/imagecustomizerapi/previewfeaturetype.go
@@ -25,6 +25,9 @@ const (
 
 	// PreviewFeatureKdumpBootFiles enables support for crash dump configuration.
 	PreviewFeatureKdumpBootFiles PreviewFeature = "kdump-boot-files"
+
+	// PreviewFeatureReadOnlyMounts enables support for setting mounts as readonly during customization.
+	PreviewFeatureReadOnlyMounts PreviewFeature = "read-only-mounts"
 )
 
 func (pf PreviewFeature) IsValid() error {

--- a/toolkit/tools/imagecustomizerapi/schema.json
+++ b/toolkit/tools/imagecustomizerapi/schema.json
@@ -592,6 +592,12 @@
             "$ref": "#/$defs/Verity"
           },
           "type": "array"
+        },
+        "customizationReadOnlyMounts": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "additionalProperties": false,

--- a/toolkit/tools/imagecustomizerapi/storage.go
+++ b/toolkit/tools/imagecustomizerapi/storage.go
@@ -21,11 +21,12 @@ const (
 )
 
 type Storage struct {
-	ResetPartitionsUuidsType ResetPartitionsUuidsType `yaml:"resetPartitionsUuidsType" json:"resetPartitionsUuidsType,omitempty"`
-	BootType                 BootType                 `yaml:"bootType" json:"bootType,omitempty"`
-	Disks                    []Disk                   `yaml:"disks" json:"disks,omitempty"`
-	FileSystems              []FileSystem             `yaml:"filesystems" json:"filesystems,omitempty"`
-	Verity                   []Verity                 `yaml:"verity" json:"verity,omitempty"`
+	ResetPartitionsUuidsType    ResetPartitionsUuidsType `yaml:"resetPartitionsUuidsType" json:"resetPartitionsUuidsType,omitempty"`
+	BootType                    BootType                 `yaml:"bootType" json:"bootType,omitempty"`
+	Disks                       []Disk                   `yaml:"disks" json:"disks,omitempty"`
+	FileSystems                 []FileSystem             `yaml:"filesystems" json:"filesystems,omitempty"`
+	Verity                      []Verity                 `yaml:"verity" json:"verity,omitempty"`
+	CustomizationReadOnlyMounts []string                 `yaml:"customizationReadOnlyMounts" json:"customizationReadOnlyMounts,omitempty"`
 
 	// Filled in by Storage.IsValid().
 	VerityPartitionsType VerityPartitionsType `json:"-"`
@@ -93,6 +94,12 @@ func (s *Storage) IsValid() error {
 		err = fileSystem.IsValid()
 		if err != nil {
 			return fmt.Errorf("invalid filesystems item at index %d:\n%w", i, err)
+		}
+	}
+
+	for i, mountPath := range s.CustomizationReadOnlyMounts {
+		if err := validatePath(mountPath); err != nil {
+			return fmt.Errorf("invalid customizationMountOptions item at index %d:\n%w", i, err)
 		}
 	}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput.go
@@ -364,8 +364,8 @@ func prepareImageConversionData(ctx context.Context, rawImageFile string, buildD
 ) (map[string]diskutils.FstabEntry, []verityDeviceMetadata, string,
 	[]OsPackage, [randomization.UuidSize]byte, string, *CosiBootloader, error,
 ) {
-	imageConnection, partUuidToFstabEntry, baseImageVerityMetadata, err := connectToExistingImage(ctx,
-		rawImageFile, buildDir, chrootDir, true, true)
+	imageConnection, partUuidToFstabEntry, baseImageVerityMetadata, _, err := connectToExistingImage(ctx,
+		rawImageFile, buildDir, chrootDir, true, true, nil)
 	if err != nil {
 		return nil, nil, "", nil, [randomization.UuidSize]byte{}, "", nil, fmt.Errorf("failed to connect to image:\n%w", err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
@@ -78,7 +78,7 @@ func doOsCustomizations(ctx context.Context, buildDir string, baseConfigPath str
 	}
 
 	if config.OS.ImageHistory != imagecustomizerapi.ImageHistoryNone {
-		err = addImageHistory(ctx, imageChroot.RootDir(), imageUuid, baseConfigPath, ToolVersion, buildTime, config)
+		err = addImageHistory(ctx, imageChroot, imageUuid, baseConfigPath, ToolVersion, buildTime, config)
 		if err != nil {
 			return err
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
@@ -17,7 +17,8 @@ import (
 func customizePartitionsUsingFileCopy(ctx context.Context, buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
 	buildImageFile string, newBuildImageFile string,
 ) (map[string]string, error) {
-	existingImageConnection, _, _, err := connectToExistingImage(ctx, buildImageFile, buildDir, "imageroot", false, false)
+	existingImageConnection, _, _, _, err := connectToExistingImage(ctx, buildImageFile, buildDir, "imageroot", false,
+		true, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
@@ -36,6 +36,26 @@ func TestCustomizeImageVerityUsrUki(t *testing.T) {
 		return
 	}
 
+	ukiFilesChecksums, ok := verifyUsrVerity(t, buildDir, outImageFilePath, nil)
+	if !ok {
+		return
+	}
+
+	// Customize again without changing /usr verity or the UKI.
+	outImageFilePath2 := filepath.Join(testTempDir, "image2.raw")
+	configFile2 := filepath.Join(testDir, "verity-reinit-usr-nop.yaml")
+
+	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile2, outImageFilePath, nil, outImageFilePath2, "raw",
+		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	verifyUsrVerity(t, buildDir, outImageFilePath2, ukiFilesChecksums)
+}
+
+func verifyUsrVerity(t *testing.T, buildDir string, imagePath string, expectedUkiFilesChecksums map[string]string,
+) (map[string]string, bool) {
 	// Connect to customized image.
 	mountPoints := []testutils.MountPoint{
 		{
@@ -66,9 +86,9 @@ func TestCustomizeImageVerityUsrUki(t *testing.T) {
 		},
 	}
 
-	imageConnection, err := testutils.ConnectToImage(buildDir, outImageFilePath, false /*includeDefaultMounts*/, mountPoints)
+	imageConnection, err := testutils.ConnectToImage(buildDir, imagePath, false /*includeDefaultMounts*/, mountPoints)
 	if !assert.NoError(t, err) {
-		return
+		return nil, false
 	}
 	defer imageConnection.Close()
 
@@ -136,4 +156,28 @@ func TestCustomizeImageVerityUsrUki(t *testing.T) {
 	}
 	filteredFstabEntries := getFilteredFstabEntries(t, imageConnection)
 	assert.Equal(t, expectedFstabEntries, filteredFstabEntries)
+
+	ukiFiles, err := getUkiFiles(espPath)
+	if !assert.NoError(t, err) {
+		return nil, false
+	}
+
+	ukiFilesChecksums := make(map[string]string)
+	for _, ukiFile := range ukiFiles {
+		checksum, err := file.GenerateSHA256(ukiFile)
+		if !assert.NoError(t, err) {
+			return nil, false
+		}
+
+		ukiFilesChecksums[ukiFile] = checksum
+	}
+
+	if expectedUkiFilesChecksums != nil {
+		// Veirfy that the UKI files haven't changed.
+		// Note: This indirectly also checks that the verity partitions haven't changed since the UKIs contain the
+		// verity root hash in the kernel command-line args.
+		assert.Equal(t, expectedUkiFilesChecksums, ukiFilesChecksums)
+	}
+
+	return ukiFilesChecksums, true
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecreator.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecreator.go
@@ -30,7 +30,8 @@ func CustomizeImageHelperImageCreator(ctx context.Context, buildDir string, base
 	}
 	defer toolsChroot.Close(false)
 
-	imageConnection, partUuidToFstabEntry, _, err := connectToExistingImage(ctx, rawImageFile, toolsChrootDir, toolsRootImageDir, true, false)
+	imageConnection, partUuidToFstabEntry, _, _, err := connectToExistingImage(ctx, rawImageFile, toolsChrootDir,
+		toolsRootImageDir, true, false, nil)
 	if err != nil {
 		return nil, "", err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -515,9 +515,9 @@ func customizeOSContents(ctx context.Context, ic *ImageCustomizerParameters) err
 	}
 
 	// Customize the raw image file.
-	partUuidToFstabEntry, baseImageVerityMetadata, osRelease, err := customizeImageHelper(ctx, ic.buildDirAbs, ic.configPath,
-		ic.config, ic.rawImageFile, ic.rpmsSources, ic.useBaseImageRpmRepos, partitionsCustomized, ic.imageUuidStr, ic.packageSnapshotTime,
-		ic.outputImageFormat)
+	partUuidToFstabEntry, baseImageVerityMetadata, readonlyPartUuids, osRelease, err := customizeImageHelper(ctx,
+		ic.buildDirAbs, ic.configPath, ic.config, ic.rawImageFile, ic.rpmsSources, ic.useBaseImageRpmRepos,
+		partitionsCustomized, ic.imageUuidStr, ic.packageSnapshotTime, ic.outputImageFormat)
 	if err != nil {
 		return err
 	}
@@ -538,7 +538,7 @@ func customizeOSContents(ctx context.Context, ic *ImageCustomizerParameters) err
 	// For COSI, always shrink the filesystems.
 	shrinkPartitions := ic.outputImageFormat == imagecustomizerapi.ImageFormatTypeCosi
 	if shrinkPartitions {
-		err = shrinkFilesystemsHelper(ctx, ic.rawImageFile)
+		err = shrinkFilesystemsHelper(ctx, ic.rawImageFile, readonlyPartUuids)
 		if err != nil {
 			return fmt.Errorf("failed to shrink filesystems:\n%w", err)
 		}
@@ -547,7 +547,7 @@ func customizeOSContents(ctx context.Context, ic *ImageCustomizerParameters) err
 	if len(ic.config.Storage.Verity) > 0 || len(ic.baseImageVerityMetadata) > 0 {
 		// Customize image for dm-verity, setting up verity metadata and security features.
 		verityMetadata, err := customizeVerityImageHelper(ctx, ic.buildDirAbs, ic.config, ic.rawImageFile, partIdToPartUuid,
-			shrinkPartitions, ic.baseImageVerityMetadata)
+			shrinkPartitions, ic.baseImageVerityMetadata, readonlyPartUuids)
 		if err != nil {
 			return err
 		}
@@ -968,19 +968,19 @@ func validateUser(baseConfigPath string, user imagecustomizerapi.User) error {
 func customizeImageHelper(ctx context.Context, buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
 	rawImageFile string, rpmsSources []string, useBaseImageRpmRepos bool, partitionsCustomized bool,
 	imageUuidStr string, packageSnapshotTime string, outputImageFormatType imagecustomizerapi.ImageFormatType,
-) (map[string]diskutils.FstabEntry, []verityDeviceMetadata, string, error) {
+) (map[string]diskutils.FstabEntry, []verityDeviceMetadata, []string, string, error) {
 	logger.Log.Debugf("Customizing OS")
 
-	imageConnection, partUuidToFstabEntry, baseImageVerityMetadata, err := connectToExistingImage(ctx, rawImageFile,
-		buildDir, "imageroot", true, false)
+	imageConnection, partUuidToFstabEntry, baseImageVerityMetadata, readonlyPartUuids, err := connectToExistingImage(
+		ctx, rawImageFile, buildDir, "imageroot", true, false, config.Storage.CustomizationReadOnlyMounts)
 	if err != nil {
-		return nil, nil, "", err
+		return nil, nil, nil, "", err
 	}
 	defer imageConnection.Close()
 
 	osRelease, err := extractOSRelease(imageConnection)
 	if err != nil {
-		return nil, nil, "", err
+		return nil, nil, nil, "", err
 	}
 
 	imageConnection.Chroot().UnsafeRun(func() error {
@@ -992,7 +992,7 @@ func customizeImageHelper(ctx context.Context, buildDir string, baseConfigPath s
 
 	err = validateVerityMountPaths(imageConnection, config, partUuidToFstabEntry, baseImageVerityMetadata)
 	if err != nil {
-		return nil, nil, "", fmt.Errorf("verity validation failed:\n%w", err)
+		return nil, nil, nil, "", fmt.Errorf("verity validation failed:\n%w", err)
 	}
 
 	// Do the actual customizations.
@@ -1004,21 +1004,21 @@ func customizeImageHelper(ctx context.Context, buildDir string, baseConfigPath s
 	warnOnLowFreeSpace(buildDir, imageConnection)
 
 	if err != nil {
-		return nil, nil, "", err
+		return nil, nil, nil, "", err
 	}
 
 	err = imageConnection.CleanClose()
 	if err != nil {
-		return nil, nil, "", err
+		return nil, nil, nil, "", err
 	}
 
-	return partUuidToFstabEntry, baseImageVerityMetadata, osRelease, nil
+	return partUuidToFstabEntry, baseImageVerityMetadata, readonlyPartUuids, osRelease, nil
 }
 
 func collectOSInfo(ctx context.Context, buildDir string, rawImageFile string,
 ) ([]OsPackage, *CosiBootloader, error) {
 	var err error
-	imageConnection, _, _, err := connectToExistingImage(ctx, rawImageFile, buildDir, "imageroot", true, true)
+	imageConnection, _, _, _, err := connectToExistingImage(ctx, rawImageFile, buildDir, "imageroot", true, true, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -1053,7 +1053,7 @@ func collectOSInfoHelper(ctx context.Context, buildDir string, imageConnection *
 	return osPackages, cosiBootMetadata, nil
 }
 
-func shrinkFilesystemsHelper(ctx context.Context, buildImageFile string) error {
+func shrinkFilesystemsHelper(ctx context.Context, buildImageFile string, readonlyPartUuids []string) error {
 	_, span := otel.GetTracerProvider().Tracer(OtelTracerName).Start(ctx, "shrink_filesystems")
 	defer span.End()
 
@@ -1064,7 +1064,7 @@ func shrinkFilesystemsHelper(ctx context.Context, buildImageFile string) error {
 	defer imageLoopback.Close()
 
 	// Shrink the filesystems.
-	err = shrinkFilesystems(imageLoopback.DevicePath())
+	err = shrinkFilesystems(imageLoopback.DevicePath(), readonlyPartUuids)
 	if err != nil {
 		return err
 	}
@@ -1079,7 +1079,7 @@ func shrinkFilesystemsHelper(ctx context.Context, buildImageFile string) error {
 
 func customizeVerityImageHelper(ctx context.Context, buildDir string, config *imagecustomizerapi.Config,
 	buildImageFile string, partIdToPartUuid map[string]string, shrinkHashPartition bool,
-	baseImageVerity []verityDeviceMetadata,
+	baseImageVerity []verityDeviceMetadata, readonlyPartUuids []string,
 ) ([]verityDeviceMetadata, error) {
 	logger.Log.Infof("Provisioning verity")
 
@@ -1104,29 +1104,37 @@ func customizeVerityImageHelper(ctx context.Context, buildDir string, config *im
 		return nil, fmt.Errorf("failed to get disk's (%s) sector size:\n%w", loopback.DevicePath(), err)
 	}
 
+	verityUpdated := false
+
 	for _, metadata := range baseImageVerity {
-		// Find partitions.
-		dataPartition, _, err := findPartitionHelper(imagecustomizerapi.MountIdentifierTypePartUuid,
-			metadata.dataPartUuid, diskPartitions)
-		if err != nil {
-			return nil, fmt.Errorf("failed to find verity (%s) data partition:\n%w", metadata.name, err)
-		}
-
-		hashPartition, _, err := findPartitionHelper(imagecustomizerapi.MountIdentifierTypePartUuid,
-			metadata.hashPartUuid, diskPartitions)
-		if err != nil {
-			return nil, fmt.Errorf("failed to find verity (%s) data partition:\n%w", metadata.name, err)
-		}
-
-		// Format hash partition.
-		rootHash, err := verityFormat(loopback.DevicePath(), dataPartition.Path, hashPartition.Path,
-			shrinkHashPartition, sectorSize)
-		if err != nil {
-			return nil, err
-		}
-
 		newMetadata := metadata
-		newMetadata.rootHash = rootHash
+
+		readonly := slices.Contains(readonlyPartUuids, metadata.dataPartUuid)
+		if !readonly {
+			// Find partitions.
+			dataPartition, _, err := findPartitionHelper(imagecustomizerapi.MountIdentifierTypePartUuid,
+				metadata.dataPartUuid, diskPartitions)
+			if err != nil {
+				return nil, fmt.Errorf("failed to find verity (%s) data partition:\n%w", metadata.name, err)
+			}
+
+			hashPartition, _, err := findPartitionHelper(imagecustomizerapi.MountIdentifierTypePartUuid,
+				metadata.hashPartUuid, diskPartitions)
+			if err != nil {
+				return nil, fmt.Errorf("failed to find verity (%s) data partition:\n%w", metadata.name, err)
+			}
+
+			// Format hash partition.
+			rootHash, err := verityFormat(loopback.DevicePath(), dataPartition.Path, hashPartition.Path,
+				shrinkHashPartition, sectorSize)
+			if err != nil {
+				return nil, err
+			}
+
+			newMetadata.rootHash = rootHash
+			verityUpdated = true
+		}
+
 		verityMetadata = append(verityMetadata, newMetadata)
 	}
 
@@ -1161,6 +1169,7 @@ func customizeVerityImageHelper(ctx context.Context, buildDir string, config *im
 			hashSignaturePath:     verityConfig.HashSignaturePath,
 		}
 		verityMetadata = append(verityMetadata, metadata)
+		verityUpdated = true
 	}
 
 	// Refresh disk partitions after running veritysetup so that the hash partition's UUID is correct.
@@ -1169,16 +1178,18 @@ func customizeVerityImageHelper(ctx context.Context, buildDir string, config *im
 		return nil, err
 	}
 
-	diskPartitions, err = diskutils.GetDiskPartitions(loopback.DevicePath())
-	if err != nil {
-		return nil, err
-	}
+	if verityUpdated {
+		diskPartitions, err = diskutils.GetDiskPartitions(loopback.DevicePath())
+		if err != nil {
+			return nil, err
+		}
 
-	// Update kernel args.
-	isUki := config.OS.Uki != nil
-	err = updateKernelArgsForVerity(buildDir, diskPartitions, verityMetadata, isUki)
-	if err != nil {
-		return nil, err
+		// Update kernel args.
+		isUki := config.OS.Uki != nil
+		err = updateKernelArgsForVerity(buildDir, diskPartitions, verityMetadata, isUki)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	err = loopback.CleanClose()

--- a/toolkit/tools/pkg/imagecustomizerlib/imagehistory.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagehistory.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/file"
@@ -31,6 +32,12 @@ const (
 
 func addImageHistory(ctx context.Context, rootDir string, imageUuid string, baseConfigPath string, toolVersion string, buildTime string, config *imagecustomizerapi.Config) error {
 	var err error
+
+	// TODO: What if /usr subdirectory has its own mount?
+	if slices.Contains(config.Storage.CustomizationReadOnlyMounts, "/usr") {
+		return nil
+	}
+
 	logger.Log.Infof("Creating image customizer history file")
 
 	_, span := otel.GetTracerProvider().Tracer(OtelTracerName).Start(ctx, "add_image_history")

--- a/toolkit/tools/pkg/imagecustomizerlib/imagehistory_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagehistory_test.go
@@ -39,7 +39,7 @@ func TestAddImageHistory(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Test adding the first entry
-	err = addImageHistory(t.Context(), tempDir, expectedUuid, testDir, expectedVersion, expectedDate, &config)
+	err = addImageHistoryHelper(t.Context(), tempDir, expectedUuid, testDir, expectedVersion, expectedDate, &config)
 	assert.NoError(t, err, "addImageHistory should not return an error")
 
 	verifyHistoryFile(t, 1, expectedUuid, expectedVersion, expectedDate, config, historyFilePath)
@@ -52,7 +52,7 @@ func TestAddImageHistory(t *testing.T) {
 	// Test adding another entry with a different uuid
 	_, expectedUuid, err = randomization.CreateUuid()
 	assert.NoError(t, err)
-	err = addImageHistory(t.Context(), tempDir, expectedUuid, testDir, expectedVersion, expectedDate, &config)
+	err = addImageHistoryHelper(t.Context(), tempDir, expectedUuid, testDir, expectedVersion, expectedDate, &config)
 	assert.NoError(t, err, "addImageHistory should not return an error")
 
 	allHistory := verifyHistoryFile(t, 2, expectedUuid, expectedVersion, expectedDate, config, historyFilePath)

--- a/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
@@ -24,50 +24,50 @@ import (
 type installOSFunc func(imageChroot *safechroot.Chroot) error
 
 func connectToExistingImage(ctx context.Context, imageFilePath string, buildDir string, chrootDirName string,
-	includeDefaultMounts bool, readonly bool,
-) (*imageconnection.ImageConnection, map[string]diskutils.FstabEntry, []verityDeviceMetadata, error) {
+	includeDefaultMounts bool, readonly bool, readOnlyMounts []string,
+) (*imageconnection.ImageConnection, map[string]diskutils.FstabEntry, []verityDeviceMetadata, []string, error) {
 	_, span := otel.GetTracerProvider().Tracer(OtelTracerName).Start(ctx, "connect_to_existing_image")
 	defer span.End()
 	imageConnection := imageconnection.NewImageConnection()
 
-	partUuidToMountPath, verityMetadata, err := connectToExistingImageHelper(imageConnection, imageFilePath, buildDir,
-		chrootDirName, includeDefaultMounts, readonly)
+	partUuidToMountPath, verityMetadata, readonlyPartUuids, err := connectToExistingImageHelper(imageConnection,
+		imageFilePath, buildDir, chrootDirName, includeDefaultMounts, readonly, readOnlyMounts)
 	if err != nil {
 		imageConnection.Close()
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
-	return imageConnection, partUuidToMountPath, verityMetadata, nil
+	return imageConnection, partUuidToMountPath, verityMetadata, readonlyPartUuids, nil
 }
 
 func connectToExistingImageHelper(imageConnection *imageconnection.ImageConnection, imageFilePath string,
-	buildDir string, chrootDirName string, includeDefaultMounts bool, readonly bool,
-) (map[string]diskutils.FstabEntry, []verityDeviceMetadata, error) {
+	buildDir string, chrootDirName string, includeDefaultMounts bool, readonly bool, readOnlyMounts []string,
+) (map[string]diskutils.FstabEntry, []verityDeviceMetadata, []string, error) {
 	// Connect to image file using loopback device.
 	err := imageConnection.ConnectLoopback(imageFilePath)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	partitions, err := diskutils.GetDiskPartitions(imageConnection.Loopback().DevicePath())
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	rootfsPartition, err := findRootfsPartition(partitions, buildDir)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to find rootfs partition:\n%w", err)
+		return nil, nil, nil, fmt.Errorf("failed to find rootfs partition:\n%w", err)
 	}
 
 	fstabEntries, err := readFstabEntriesFromRootfs(rootfsPartition, partitions, buildDir)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to read fstab entries from rootfs partition:\n%w", err)
+		return nil, nil, nil, fmt.Errorf("failed to read fstab entries from rootfs partition:\n%w", err)
 	}
 
-	mountPoints, partUuidToFstabEntry, verityMetadata, err := fstabEntriesToMountPoints(fstabEntries, partitions,
-		buildDir, readonly)
+	mountPoints, partUuidToFstabEntry, verityMetadata, readonlyPartUuids, err := fstabEntriesToMountPoints(fstabEntries,
+		partitions, buildDir, readonly, readOnlyMounts)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to find mount info for fstab file entries:\n%w", err)
+		return nil, nil, nil, fmt.Errorf("failed to find mount info for fstab file entries:\n%w", err)
 	}
 
 	// Create chroot environment.
@@ -75,10 +75,10 @@ func connectToExistingImageHelper(imageConnection *imageconnection.ImageConnecti
 
 	err = imageConnection.ConnectChroot(imageChrootDir, false, []string(nil), mountPoints, includeDefaultMounts)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	return partUuidToFstabEntry, verityMetadata, nil
+	return partUuidToFstabEntry, verityMetadata, readonlyPartUuids, nil
 }
 
 func CreateNewImage(targetOs targetos.TargetOs, filename string, diskConfig imagecustomizerapi.Disk,
@@ -259,7 +259,7 @@ func createImageBoilerplate(targetOs targetos.TargetOs, imageConnection *imageco
 		return nil, "", err
 	}
 
-	mountPoints, _, _, err := fstabEntriesToMountPoints(fstabEntries, diskPartitions, buildDir, false)
+	mountPoints, _, _, _, err := fstabEntriesToMountPoints(fstabEntries, diskPartitions, buildDir, false, nil)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to find mount info for fstab file entries:\n%w", err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -197,7 +197,8 @@ func createLiveOSFromRawHelper(ctx context.Context, buildDir, baseConfigPath str
 	}()
 
 	logger.Log.Debugf("Connecting to raw image (%s)", rawImageFile)
-	rawImageConnection, _, _, err := connectToExistingImage(ctx, rawImageFile, isoBuildDir, "readonly-rootfs-mount", false /*includeDefaultMounts*/, false)
+	rawImageConnection, _, _, _, err := connectToExistingImage(ctx, rawImageFile, isoBuildDir, "readonly-rootfs-mount",
+		false /*includeDefaultMounts*/, false /*readonly*/, nil)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/readonlymounts.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/readonlymounts.go
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerlib
+
+import (
+	"path/filepath"
+	"slices"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/safechroot"
+)
+
+func isPathOnReadOnlyMount(chrootPath string, imageChroot *safechroot.Chroot, readOnlyMounts []string,
+) bool {
+	mostSpecificMountTarget := ""
+
+	mounts := imageChroot.GetMountPoints()
+	for _, mount := range mounts {
+		mountTarget := mount.GetTarget()
+
+		_, err := filepath.Rel(mountTarget, chrootPath)
+		if err != nil {
+			// Path is not relative to the mount.
+			continue
+		}
+
+		if len(mountTarget) > len(mostSpecificMountTarget) {
+			mostSpecificMountTarget = mountTarget
+		}
+	}
+
+	if mostSpecificMountTarget == "" {
+		return false
+	}
+
+	mountIsReadOnly := slices.Contains(readOnlyMounts, mostSpecificMountTarget)
+	return mountIsReadOnly
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
@@ -3,6 +3,7 @@ package imagecustomizerlib
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -12,7 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func shrinkFilesystems(imageLoopDevice string) error {
+func shrinkFilesystems(imageLoopDevice string, readonlyPartUuids []string) error {
 	logger.Log.Infof("Shrinking filesystems")
 
 	// Get partition info
@@ -37,6 +38,12 @@ func shrinkFilesystems(imageLoopDevice string) error {
 		fstype := diskPartition.FileSystemType
 		if !supportedShrinkFsType(fstype) {
 			logger.Log.Infof("Shrinking partition (%s): unsupported filesystem type (%s)", partitionLoopDevice, fstype)
+			continue
+		}
+
+		readonly := slices.Contains(readonlyPartUuids, diskPartition.PartUuid)
+		if readonly {
+			logger.Log.Infof("Shrinking partition (%s): skipping readonly partition (%s)", partitionLoopDevice, fstype)
 			continue
 		}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-reinit-usr-nop.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-reinit-usr-nop.yaml
@@ -1,0 +1,13 @@
+previewFeatures:
+- reinitialize-verity
+- read-only-mounts
+
+storage:
+  customizationReadOnlyMounts:
+  - /usr
+
+os:
+  additionalFiles:
+  - content: |
+      cat, dog, elephant, squirrel
+    destination: /etc/animals.txt


### PR DESCRIPTION
Add an API that allows the user to specify that a partition should be set as readonly during OS customization.

The primary scenario being targeted is recustomizing an image with a usr verity partition + UKIs without changing/invalidating the /usr partition or the UKIs. A functional test has been added for this scenario.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
