### PR TITLE
Enable run.sh help message on -h/--help

### DIFF
--- a/toolkit/tools/imagecustomizer/container/run.sh
+++ b/toolkit/tools/imagecustomizer/container/run.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 shopt -s nullglob
 
 exit_with_usage() {
-    local error_msg="$1"
+    local error_msg=""
+    if [[ $# -gt 0 ]]; then
+        error_msg="$1"
+    fi
 
     echo "Usage: run.sh <VERSION> [extra imagecustomizer args]"
     echo ""


### PR DESCRIPTION
Previously, passing -h/--help to run.sh would cause `/usr/local/bin/run.sh: line 7: $1: unbound variable`