### PR TITLE
Add `reinitializeVerity` API.

### DIFF
--- a/docs/imagecustomizer/api/configuration.md
+++ b/docs/imagecustomizer/api/configuration.md
@@ -155,6 +155,7 @@ os:
         - [options](./configuration/mountpoint.md#options-string)
         - [path](./configuration/mountpoint.md#path-string)
     - [resetPartitionsUuidsType](./configuration/storage.md#resetpartitionsuuidstype-string)
+    - [reinitializeVerity](./configuration/storage.md#reinitializeverity-string)
   - [iso](./configuration/config.md#iso-iso) ([iso type](./configuration/iso.md))
     - [additionalFiles](./configuration/iso.md#additionalfiles-additionalfile)
       - [additionalFile type](./configuration/additionalfile.md)

--- a/docs/imagecustomizer/api/configuration/storage.md
+++ b/docs/imagecustomizer/api/configuration/storage.md
@@ -136,3 +136,21 @@ os:
 ```
 
 Added in v0.7.
+
+## reinitializeVerity [string]
+
+This is a preview feature.
+Its API and behavior is subject to change.
+You must enable this feature by specifying `reinitialize-verity` in the
+[previewFeatures](./config.md#previewfeatures-string) API.
+
+When the base image contains verity partitions, controls whether or not the verity
+partitions can be modified.
+
+Supported options:
+
+- `none`: During OS customization, all verity data partitions are mounted as read-only.
+  The verity hash partitions are left unchanged.
+
+- `all`: During OS customization, all verity data partitions are mounted as read-write.
+  The verity hash partitions will be regenerated.

--- a/toolkit/tools/imagecustomizerapi/config.go
+++ b/toolkit/tools/imagecustomizerapi/config.go
@@ -118,6 +118,11 @@ func (c *Config) IsValid() (err error) {
 		}
 	}
 
+	if c.Storage.ReinitializeVerity != ReinitializeVerityTypeDefault &&
+		!sliceutils.ContainsValue(c.PreviewFeatures, PreviewFeatureReinitializeVerity) {
+		return fmt.Errorf("the 'reinitialize-verity' preview feature must be enabled to use 'storage.reinitializeVerity'")
+	}
+
 	return nil
 }
 

--- a/toolkit/tools/imagecustomizerapi/reinitializeveritytype.go
+++ b/toolkit/tools/imagecustomizerapi/reinitializeveritytype.go
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerapi
+
+import (
+	"fmt"
+)
+
+type ReinitializeVerityType string
+
+const (
+	ReinitializeVerityTypeDefault ReinitializeVerityType = ""
+	ReinitializeVerityTypeNone    ReinitializeVerityType = "none"
+	ReinitializeVerityTypeAll     ReinitializeVerityType = "all"
+)
+
+func (t ReinitializeVerityType) IsValid() error {
+	switch t {
+	case ReinitializeVerityTypeDefault, ReinitializeVerityTypeNone, ReinitializeVerityTypeAll:
+		// All good.
+		return nil
+
+	default:
+		return fmt.Errorf("invalid value (%s)", t)
+	}
+}

--- a/toolkit/tools/imagecustomizerapi/schema.json
+++ b/toolkit/tools/imagecustomizerapi/schema.json
@@ -592,6 +592,9 @@
             "$ref": "#/$defs/Verity"
           },
           "type": "array"
+        },
+        "reinitializeVerity": {
+          "type": "string"
         }
       },
       "additionalProperties": false,

--- a/toolkit/tools/imagecustomizerapi/storage.go
+++ b/toolkit/tools/imagecustomizerapi/storage.go
@@ -26,6 +26,7 @@ type Storage struct {
 	Disks                    []Disk                   `yaml:"disks" json:"disks,omitempty"`
 	FileSystems              []FileSystem             `yaml:"filesystems" json:"filesystems,omitempty"`
 	Verity                   []Verity                 `yaml:"verity" json:"verity,omitempty"`
+	ReinitializeVerity       ReinitializeVerityType   `yaml:"reinitializeVerity" json:"reinitializeVerity,omitempty"`
 
 	// Filled in by Storage.IsValid().
 	VerityPartitionsType VerityPartitionsType `json:"-"`
@@ -94,6 +95,11 @@ func (s *Storage) IsValid() error {
 		if err != nil {
 			return fmt.Errorf("invalid filesystems item at index %d:\n%w", i, err)
 		}
+	}
+
+	err = s.ReinitializeVerity.IsValid()
+	if err != nil {
+		return fmt.Errorf("invalid 'reinitializeVerity' value:\n%w", err)
 	}
 
 	hasResetUuids := s.ResetPartitionsUuidsType != ResetPartitionsUuidsTypeDefault

--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -176,6 +176,11 @@ func (m *MountPoint) GetTarget() string {
 	return m.target
 }
 
+// GetFlags gets the flags of the mount.
+func (m *MountPoint) GetFlags() uintptr {
+	return m.flags
+}
+
 // NewChroot creates a new Chroot struct
 func NewChroot(rootDir string, isExistingDir bool) *Chroot {
 	// get chroot folder

--- a/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput.go
@@ -364,8 +364,8 @@ func prepareImageConversionData(ctx context.Context, rawImageFile string, buildD
 ) (map[string]diskutils.FstabEntry, []verityDeviceMetadata, string,
 	[]OsPackage, [randomization.UuidSize]byte, string, *CosiBootloader, error,
 ) {
-	imageConnection, partUuidToFstabEntry, baseImageVerityMetadata, err := connectToExistingImage(ctx,
-		rawImageFile, buildDir, chrootDir, true, true)
+	imageConnection, partUuidToFstabEntry, baseImageVerityMetadata, _, err := connectToExistingImage(ctx,
+		rawImageFile, buildDir, chrootDir, true, true, false)
 	if err != nil {
 		return nil, nil, "", nil, [randomization.UuidSize]byte{}, "", nil, fmt.Errorf("failed to connect to image:\n%w", err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
@@ -78,7 +78,7 @@ func doOsCustomizations(ctx context.Context, buildDir string, baseConfigPath str
 	}
 
 	if config.OS.ImageHistory != imagecustomizerapi.ImageHistoryNone {
-		err = addImageHistory(ctx, imageChroot.RootDir(), imageUuid, baseConfigPath, ToolVersion, buildTime, config)
+		err = addImageHistory(ctx, imageChroot, imageUuid, baseConfigPath, ToolVersion, buildTime, config)
 		if err != nil {
 			return err
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
@@ -17,7 +17,8 @@ import (
 func customizePartitionsUsingFileCopy(ctx context.Context, buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
 	buildImageFile string, newBuildImageFile string,
 ) (map[string]string, error) {
-	existingImageConnection, _, _, err := connectToExistingImage(ctx, buildImageFile, buildDir, "imageroot", false, false)
+	existingImageConnection, _, _, _, err := connectToExistingImage(ctx, buildImageFile, buildDir, "imageroot", false,
+		true, false)
 	if err != nil {
 		return nil, err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeselinux.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeselinux.go
@@ -16,6 +16,7 @@ import (
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/safechroot"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"golang.org/x/sys/unix"
 )
 
 func handleSELinux(ctx context.Context, selinuxMode imagecustomizerapi.SELinuxMode, resetBootLoaderType imagecustomizerapi.ResetBootLoaderType,
@@ -119,6 +120,11 @@ func selinuxSetFiles(ctx context.Context, selinuxMode imagecustomizerapi.SELinux
 	// Get the list of mount points.
 	mountPointToFsTypeMap := make(map[string]string, 0)
 	for _, mountPoint := range getNonSpecialChrootMountPoints(imageChroot) {
+		if (mountPoint.GetFlags() & unix.MS_RDONLY) != 0 {
+			// Skip read-only filesystems.
+			continue
+		}
+
 		mountPointToFsTypeMap[mountPoint.GetTarget()] = mountPoint.GetFSType()
 	}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
@@ -173,7 +173,7 @@ func verifyUsrVerity(t *testing.T, buildDir string, imagePath string, expectedUk
 	}
 
 	if expectedUkiFilesChecksums != nil {
-		// Veirfy that the UKI files haven't changed.
+		// Verify that the UKI files haven't changed.
 		// Note: This indirectly also checks that the verity partitions haven't changed since the UKIs contain the
 		// verity root hash in the kernel command-line args.
 		assert.Equal(t, expectedUkiFilesChecksums, ukiFilesChecksums)

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
@@ -36,6 +36,26 @@ func TestCustomizeImageVerityUsrUki(t *testing.T) {
 		return
 	}
 
+	ukiFilesChecksums, ok := verifyUsrVerity(t, buildDir, outImageFilePath, nil)
+	if !ok {
+		return
+	}
+
+	// Customize again without changing /usr verity or the UKI.
+	outImageFilePath2 := filepath.Join(testTempDir, "image2.raw")
+	configFile2 := filepath.Join(testDir, "verity-reinit-usr-nop.yaml")
+
+	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile2, outImageFilePath, nil, outImageFilePath2, "raw",
+		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	verifyUsrVerity(t, buildDir, outImageFilePath2, ukiFilesChecksums)
+}
+
+func verifyUsrVerity(t *testing.T, buildDir string, imagePath string, expectedUkiFilesChecksums map[string]string,
+) (map[string]string, bool) {
 	// Connect to customized image.
 	mountPoints := []testutils.MountPoint{
 		{
@@ -66,9 +86,9 @@ func TestCustomizeImageVerityUsrUki(t *testing.T) {
 		},
 	}
 
-	imageConnection, err := testutils.ConnectToImage(buildDir, outImageFilePath, false /*includeDefaultMounts*/, mountPoints)
+	imageConnection, err := testutils.ConnectToImage(buildDir, imagePath, false /*includeDefaultMounts*/, mountPoints)
 	if !assert.NoError(t, err) {
-		return
+		return nil, false
 	}
 	defer imageConnection.Close()
 
@@ -136,4 +156,28 @@ func TestCustomizeImageVerityUsrUki(t *testing.T) {
 	}
 	filteredFstabEntries := getFilteredFstabEntries(t, imageConnection)
 	assert.Equal(t, expectedFstabEntries, filteredFstabEntries)
+
+	ukiFiles, err := getUkiFiles(espPath)
+	if !assert.NoError(t, err) {
+		return nil, false
+	}
+
+	ukiFilesChecksums := make(map[string]string)
+	for _, ukiFile := range ukiFiles {
+		checksum, err := file.GenerateSHA256(ukiFile)
+		if !assert.NoError(t, err) {
+			return nil, false
+		}
+
+		ukiFilesChecksums[ukiFile] = checksum
+	}
+
+	if expectedUkiFilesChecksums != nil {
+		// Veirfy that the UKI files haven't changed.
+		// Note: This indirectly also checks that the verity partitions haven't changed since the UKIs contain the
+		// verity root hash in the kernel command-line args.
+		assert.Equal(t, expectedUkiFilesChecksums, ukiFilesChecksums)
+	}
+
+	return ukiFilesChecksums, true
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecreator.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecreator.go
@@ -30,7 +30,8 @@ func CustomizeImageHelperImageCreator(ctx context.Context, buildDir string, base
 	}
 	defer toolsChroot.Close(false)
 
-	imageConnection, partUuidToFstabEntry, _, err := connectToExistingImage(ctx, rawImageFile, toolsChrootDir, toolsRootImageDir, true, false)
+	imageConnection, partUuidToFstabEntry, _, _, err := connectToExistingImage(ctx, rawImageFile, toolsChrootDir,
+		toolsRootImageDir, true, false, false)
 	if err != nil {
 		return nil, "", err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagehistory_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagehistory_test.go
@@ -39,7 +39,7 @@ func TestAddImageHistory(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Test adding the first entry
-	err = addImageHistory(t.Context(), tempDir, expectedUuid, testDir, expectedVersion, expectedDate, &config)
+	err = addImageHistoryHelper(t.Context(), tempDir, expectedUuid, testDir, expectedVersion, expectedDate, &config)
 	assert.NoError(t, err, "addImageHistory should not return an error")
 
 	verifyHistoryFile(t, 1, expectedUuid, expectedVersion, expectedDate, config, historyFilePath)
@@ -52,7 +52,7 @@ func TestAddImageHistory(t *testing.T) {
 	// Test adding another entry with a different uuid
 	_, expectedUuid, err = randomization.CreateUuid()
 	assert.NoError(t, err)
-	err = addImageHistory(t.Context(), tempDir, expectedUuid, testDir, expectedVersion, expectedDate, &config)
+	err = addImageHistoryHelper(t.Context(), tempDir, expectedUuid, testDir, expectedVersion, expectedDate, &config)
 	assert.NoError(t, err, "addImageHistory should not return an error")
 
 	allHistory := verifyHistoryFile(t, 2, expectedUuid, expectedVersion, expectedDate, config, historyFilePath)

--- a/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
@@ -24,50 +24,50 @@ import (
 type installOSFunc func(imageChroot *safechroot.Chroot) error
 
 func connectToExistingImage(ctx context.Context, imageFilePath string, buildDir string, chrootDirName string,
-	includeDefaultMounts bool, readonly bool,
-) (*imageconnection.ImageConnection, map[string]diskutils.FstabEntry, []verityDeviceMetadata, error) {
+	includeDefaultMounts bool, readonly bool, readOnlyVerity bool,
+) (*imageconnection.ImageConnection, map[string]diskutils.FstabEntry, []verityDeviceMetadata, []string, error) {
 	_, span := otel.GetTracerProvider().Tracer(OtelTracerName).Start(ctx, "connect_to_existing_image")
 	defer span.End()
 	imageConnection := imageconnection.NewImageConnection()
 
-	partUuidToMountPath, verityMetadata, err := connectToExistingImageHelper(imageConnection, imageFilePath, buildDir,
-		chrootDirName, includeDefaultMounts, readonly)
+	partUuidToMountPath, verityMetadata, readonlyPartUuids, err := connectToExistingImageHelper(imageConnection,
+		imageFilePath, buildDir, chrootDirName, includeDefaultMounts, readonly, readOnlyVerity)
 	if err != nil {
 		imageConnection.Close()
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
-	return imageConnection, partUuidToMountPath, verityMetadata, nil
+	return imageConnection, partUuidToMountPath, verityMetadata, readonlyPartUuids, nil
 }
 
 func connectToExistingImageHelper(imageConnection *imageconnection.ImageConnection, imageFilePath string,
-	buildDir string, chrootDirName string, includeDefaultMounts bool, readonly bool,
-) (map[string]diskutils.FstabEntry, []verityDeviceMetadata, error) {
+	buildDir string, chrootDirName string, includeDefaultMounts bool, readonly bool, readOnlyVerity bool,
+) (map[string]diskutils.FstabEntry, []verityDeviceMetadata, []string, error) {
 	// Connect to image file using loopback device.
 	err := imageConnection.ConnectLoopback(imageFilePath)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	partitions, err := diskutils.GetDiskPartitions(imageConnection.Loopback().DevicePath())
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	rootfsPartition, err := findRootfsPartition(partitions, buildDir)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to find rootfs partition:\n%w", err)
+		return nil, nil, nil, fmt.Errorf("failed to find rootfs partition:\n%w", err)
 	}
 
 	fstabEntries, err := readFstabEntriesFromRootfs(rootfsPartition, partitions, buildDir)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to read fstab entries from rootfs partition:\n%w", err)
+		return nil, nil, nil, fmt.Errorf("failed to read fstab entries from rootfs partition:\n%w", err)
 	}
 
-	mountPoints, partUuidToFstabEntry, verityMetadata, err := fstabEntriesToMountPoints(fstabEntries, partitions,
-		buildDir, readonly)
+	mountPoints, partUuidToFstabEntry, verityMetadata, readonlyPartUuids, err := fstabEntriesToMountPoints(fstabEntries,
+		partitions, buildDir, readonly, readOnlyVerity)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to find mount info for fstab file entries:\n%w", err)
+		return nil, nil, nil, fmt.Errorf("failed to find mount info for fstab file entries:\n%w", err)
 	}
 
 	// Create chroot environment.
@@ -75,10 +75,10 @@ func connectToExistingImageHelper(imageConnection *imageconnection.ImageConnecti
 
 	err = imageConnection.ConnectChroot(imageChrootDir, false, []string(nil), mountPoints, includeDefaultMounts)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	return partUuidToFstabEntry, verityMetadata, nil
+	return partUuidToFstabEntry, verityMetadata, readonlyPartUuids, nil
 }
 
 func CreateNewImage(targetOs targetos.TargetOs, filename string, diskConfig imagecustomizerapi.Disk,
@@ -259,7 +259,7 @@ func createImageBoilerplate(targetOs targetos.TargetOs, imageConnection *imageco
 		return nil, "", err
 	}
 
-	mountPoints, _, _, err := fstabEntriesToMountPoints(fstabEntries, diskPartitions, buildDir, false)
+	mountPoints, _, _, _, err := fstabEntriesToMountPoints(fstabEntries, diskPartitions, buildDir, false, false)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to find mount info for fstab file entries:\n%w", err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -197,7 +197,8 @@ func createLiveOSFromRawHelper(ctx context.Context, buildDir, baseConfigPath str
 	}()
 
 	logger.Log.Debugf("Connecting to raw image (%s)", rawImageFile)
-	rawImageConnection, _, _, err := connectToExistingImage(ctx, rawImageFile, isoBuildDir, "readonly-rootfs-mount", false /*includeDefaultMounts*/, false)
+	rawImageConnection, _, _, _, err := connectToExistingImage(ctx, rawImageFile, isoBuildDir, "readonly-rootfs-mount",
+		false /*includeDefaultMounts*/, false /*readonly*/, false /*readonlyVerity*/)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/readonlymounts.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/readonlymounts.go
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerlib
+
+import (
+	"path/filepath"
+
+	"github.com/microsoft/azurelinux/toolkit/tools/internal/safechroot"
+	"golang.org/x/sys/unix"
+)
+
+func isPathOnReadOnlyMount(chrootPath string, imageChroot *safechroot.Chroot) bool {
+	mostSpecificMount := (*safechroot.MountPoint)(nil)
+
+	mounts := imageChroot.GetMountPoints()
+	for _, mount := range mounts {
+		_, err := filepath.Rel(mount.GetTarget(), chrootPath)
+		if err != nil {
+			// Path is not relative to the mount.
+			continue
+		}
+
+		if mostSpecificMount == nil || len(mount.GetTarget()) > len(mostSpecificMount.GetTarget()) {
+			mostSpecificMount = mount
+		}
+	}
+
+	if mostSpecificMount == nil {
+		return false
+	}
+
+	mountIsReadOnly := (mostSpecificMount.GetFlags() & unix.MS_RDONLY) != 0
+	return mountIsReadOnly
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
@@ -3,6 +3,7 @@ package imagecustomizerlib
 import (
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -12,7 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func shrinkFilesystems(imageLoopDevice string) error {
+func shrinkFilesystems(imageLoopDevice string, readonlyPartUuids []string) error {
 	logger.Log.Infof("Shrinking filesystems")
 
 	// Get partition info
@@ -37,6 +38,12 @@ func shrinkFilesystems(imageLoopDevice string) error {
 		fstype := diskPartition.FileSystemType
 		if !supportedShrinkFsType(fstype) {
 			logger.Log.Infof("Shrinking partition (%s): unsupported filesystem type (%s)", partitionLoopDevice, fstype)
+			continue
+		}
+
+		readonly := slices.Contains(readonlyPartUuids, diskPartition.PartUuid)
+		if readonly {
+			logger.Log.Infof("Shrinking partition (%s): skipping read-only partition (%s)", partitionLoopDevice, fstype)
 			continue
 		}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-reinit-bootloader-reset.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-reinit-bootloader-reset.yaml
@@ -1,6 +1,9 @@
 previewFeatures:
 - reinitialize-verity
 
+storage:
+  reinitializeVerity: all
+
 os:
   bootloader:
     resetType: hard-reset

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-reinit-usr-nop.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-reinit-usr-nop.yaml
@@ -2,10 +2,10 @@ previewFeatures:
 - reinitialize-verity
 
 storage:
-  reinitializeVerity: all
+  reinitializeVerity: none
 
 os:
   additionalFiles:
   - content: |
       cat, dog, elephant, squirrel
-    destination: /usr/local/share/animals.txt
+    destination: /etc/animals.txt


### PR DESCRIPTION
Add API that controls how verity partitions in the base image are handled. Specifically, whether or not the verity data partitions are set to read-only or read-write during OS customization.

The primary scenario being targeted is recustomizing an image with a usr verity partition + UKIs without changing/invalidating the /usr partition or the UKIs. A functional test has been added for this scenario.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
