### PR TITLE
Enable VMTests against legacy images in workflows.

### DIFF
--- a/.github/workflows/scripts/download-image.sh
+++ b/.github/workflows/scripts/download-image.sh
@@ -31,20 +31,22 @@ CONTAINERS_JSON=$(
         --prefix "$IMAGE_NAME/"
 )
 
-LATEST_DIR=$(
+LATEST_IMAGE=$(
     jq \
     -r \
     --arg image "$IMAGE_NAME" \
-    '[.[].name | select(endswith("/image.vhdx")) | rtrimstr("/image.vhdx")] | sort | last' \
+    '[.[].name | select(endswith("/image.vhdx") or endswith("/image.vhd"))] | sort | last' \
     <<< "$CONTAINERS_JSON" \
 )
 
-echo "Latest: $LATEST_DIR"
+echo "Latest: $LATEST_IMAGE"
+
+FILENAME="$(basename "$LATEST_IMAGE")"
 
 az storage blob download \
     --auth-mode login \
     --account-name "$ACCOUNT" \
     --container-name "$CONTAINER" \
-    --name "$LATEST_DIR/image.vhdx" \
-    --file "$OUTPUT_DIR/image.vhdx" \
+    --name "$LATEST_IMAGE" \
+    --file "$OUTPUT_DIR/$FILENAME" \
     --output none

--- a/.github/workflows/tests-vmtests.yml
+++ b/.github/workflows/tests-vmtests.yml
@@ -93,6 +93,11 @@ jobs:
 
         ./repo/.github/workflows/scripts/download-image.sh "$AZURE_STORAGE" "$AZURE_CONTAINER" "azure-linux/core-efi-vhdx-2.0-$HOST_ARCH" azl-core-efi-2.0
         ./repo/.github/workflows/scripts/download-image.sh "$AZURE_STORAGE" "$AZURE_CONTAINER" "azure-linux/core-efi-vhdx-3.0-$HOST_ARCH" azl-core-efi-3.0
+
+        if [ "$HOST_ARCH" == "amd64" ]; then
+          ./repo/.github/workflows/scripts/download-image.sh "$AZURE_STORAGE" "$AZURE_CONTAINER" "azure-linux/core-legacy-vhd-2.0-$HOST_ARCH" azl-core-legacy-2.0
+          ./repo/.github/workflows/scripts/download-image.sh "$AZURE_STORAGE" "$AZURE_CONTAINER" "azure-linux/core-legacy-vhd-3.0-$HOST_ARCH" azl-core-legacy-3.0
+        fi
       env:
         HOST_ARCH: ${{ inputs.hostArch }}
         AZURE_STORAGE: ${{ vars.AZURE_STORAGE }}
@@ -133,12 +138,22 @@ jobs:
 
         pushd ./repo/test/vmtests
 
+        CORE_LEGACY_AZL2=""
+        CORE_LEGACY_AZL3=""
+        if [ "$HOST_ARCH" == "amd64" ]; then
+          CORE_LEGACY_AZL2="../../../azl-core-legacy-2.0/image.vhd"
+          CORE_LEGACY_AZL3="../../../azl-core-legacy-3.0/image.vhd"
+        fi
+
         sudo make test \
           IMAGE_CUSTOMIZER_CONTAINER_TAG="$CONTAINER_TAG" \
           CORE_EFI_AZL2="../../../azl-core-efi-2.0/image.vhdx" \
           CORE_EFI_AZL3="../../../azl-core-efi-3.0/image.vhdx" \
+          CORE_LEGACY_AZL2="$CORE_LEGACY_AZL2" \
+          CORE_LEGACY_AZL3="$CORE_LEGACY_AZL3" \
           SSH_PRIVATE_KEY_FILE=~/.ssh/id_ed25519
       env:
+        HOST_ARCH: ${{ inputs.hostArch }}
         CONTAINER_TAG: ${{ steps.importContainer.outputs.containerTag }}
 
     - uses: actions/upload-artifact@v4


### PR DESCRIPTION
Pass the Azure Linux core-efi legacy boot images to the VMTests suite to enable the legacy boot tests.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines

Workflow run: https://github.com/microsoft/azure-linux-image-tools/actions/runs/16682814384