### PR TITLE
Workflow file cleanup.

### DIFF
--- a/.github/workflows/binary-build.yml
+++ b/.github/workflows/binary-build.yml
@@ -37,6 +37,7 @@ jobs:
         path: repo
         # Patch releases need the full history to find the latest tag.
         fetch-depth: ${{ inputs.publishType == 'patch' && '0' || '1' }}
+        persist-credentials: false
 
     - name: setup go 1.x
       uses: actions/setup-go@v5
@@ -125,7 +126,7 @@ jobs:
         IS_LATEST_RELEASE=false
 
         # Create version suffix.
-        case "${{ inputs.publishType }}" in
+        case "$PUBLISH_TYPE" in
           "official")
             PRERELEASE_PARAM="IMAGE_CUSTOMIZER_VERSION_PREVIEW="
             IS_LATEST_RELEASE="true"
@@ -162,6 +163,8 @@ jobs:
 
         # Print version.
         echo "Version: $PACKAGE_VERSION"
+      env:
+        PUBLISH_TYPE: ${{ inputs.publishType }}
 
     - name: Setup Notation CLI
       uses: notaryproject/notation-action/setup@v1
@@ -173,9 +176,11 @@ jobs:
         ./repo/toolkit/tools/imagecustomizer/container/notation/notation-setup.sh
 
         CONTAINER_TAG="imagecustomizer:build"
-        ./repo/toolkit/tools/imagecustomizer/container/build-container.sh -t "$CONTAINER_TAG" -a "${{ inputs.arch }}" -b
+        ./repo/toolkit/tools/imagecustomizer/container/build-container.sh -t "$CONTAINER_TAG" -a "$ARCH" -b
 
         docker image save "$CONTAINER_TAG" | gzip > "imagecustomizer.tar.gz"
+      env:
+        ARCH: ${{ inputs.arch }}
 
     - name: Upload version artifact
       if: inputs.arch == 'amd64'

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Setup ruby
       uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # v1.207.0
@@ -29,17 +31,21 @@ jobs:
       uses: actions/configure-pages@v5
 
     - name: Build with Jekyll
-      run: bundle exec jekyll build --baseurl "${{ steps.pages.outputs.base_path }}"
+      run: bundle exec jekyll build --baseurl "$PAGES_PATH"
       working-directory: ./docs
+      env:
+        PAGES_PATH: ${{ steps.pages.outputs.base_path }}
 
     - name: Check links
       run: |
         bundle exec htmlproofer \
           --disable-external \
           --assume_extension '.html' \
-          --swap-urls '^${{ steps.pages.outputs.base_path }}/:/' \
+          --swap-urls "^${PAGES_PATH}/:/" \
           ./_site
       working-directory: ./docs
+      env:
+        PAGES_PATH: ${{ steps.pages.outputs.base_path }}
 
     - name: Upload site assets as artifact
       id: deployment

--- a/.github/workflows/fork-release-branch.yml
+++ b/.github/workflows/fork-release-branch.yml
@@ -22,6 +22,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: repo
+        persist-credentials: true
 
     - name: Download build artifacts
       uses: actions/download-artifact@v4

--- a/.github/workflows/imagecreator-tests-functional.yml
+++ b/.github/workflows/imagecreator-tests-functional.yml
@@ -45,11 +45,13 @@ jobs:
           git
 
         # grub2-pc is only available on x86.
-        if [[ "${{ inputs.hostArch }}" == "amd64" ]]; then
+        if [[ "$HOST_ARCH" == "amd64" ]]; then
           sudo tdnf install -y grub2-pc
         fi
 
         sudo tdnf list installed
+      env:
+        HOST_ARCH: ${{ inputs.hostArch }}
 
     - name: Install prerequisites (Ubuntu 24.04)
       if: inputs.hostDistro == 'ubuntu2404'
@@ -68,6 +70,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: repo
+        persist-credentials: false
 
     - name: Test setup
       run: |

--- a/.github/workflows/open-bump-version-pr.yml
+++ b/.github/workflows/open-bump-version-pr.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-name: Fork release branch
+name: Open bump version PR
 
 permissions:
   # Create release branch and publish release.
@@ -26,6 +26,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: repo
+        persist-credentials: true
 
     - name: Open bump version PR
       env:

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -25,7 +25,7 @@ jobs:
         path: out
 
     - name: Login to GHCR
-      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
 
     - name: Install cosign
       uses: sigstore/cosign-installer@v3.8.2

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -26,6 +26,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: repo
+        persist-credentials: true
 
     - name: Download build artifacts
       uses: actions/download-artifact@v4
@@ -35,6 +36,7 @@ jobs:
     - name: Publish release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        IS_LATEST_RELEASE: ${{ inputs.isLatestRelease }}
       run: |
         set -x
 
@@ -52,9 +54,9 @@ jobs:
         mv ../out/binary-amd64/imagecustomizer.tar.gz ../release/imagecustomizer-amd64.tar.gz
         mv ../out/binary-arm64/imagecustomizer.tar.gz ../release/imagecustomizer-arm64.tar.gz
 
-        gh release create --latest="${{ inputs.isLatestRelease }}" --title "${TAG}" --notes "" "${TAG}" ../release/*
+        gh release create --latest="$IS_LATEST_RELEASE" --title "${TAG}" --notes "" "${TAG}" ../release/*
 
         # Push to stable branch.
-        if [ "${{ inputs.isLatestRelease }}" == "true" ]; then
+        if [ "$IS_LATEST_RELEASE" == "true" ]; then
           git push --force origin HEAD:stable
         fi

--- a/.github/workflows/tests-functional.yml
+++ b/.github/workflows/tests-functional.yml
@@ -51,11 +51,13 @@ jobs:
           git azure-cli
 
         # grub2-pc is only available on x86.
-        if [[ "${{ inputs.hostArch }}" == "amd64" ]]; then
+        if [[ "$HOST_ARCH" == "amd64" ]]; then
           sudo tdnf install -y grub2-pc
         fi
 
         sudo tdnf list installed
+      env:
+        HOST_ARCH: ${{ inputs.hostArch }}
 
     - name: Install prerequisites (Ubuntu 24.04)
       if: inputs.hostDistro == 'ubuntu2404'
@@ -83,6 +85,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: repo
+        persist-credentials: false
 
     - name: Download base images
       run: |

--- a/.github/workflows/tests-vmtests.yml
+++ b/.github/workflows/tests-vmtests.yml
@@ -86,6 +86,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: repo
+        persist-credentials: false
 
     - name: Download base images
       run: |


### PR DESCRIPTION
1. In `actions/checkout` steps, explictly set `persist-credentials`.

2. Don't use workflow expressions inline in Bash scripts to avoid string escaping problems.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
