### PR TITLE
Fix unintended password reset for existing users

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeusers.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeusers.go
@@ -120,7 +120,6 @@ func addOrUpdateUser(user imagecustomizerapi.User, baseConfigPath string, imageC
 		}
 	}
 
-
 	// Set user's password expiry.
 	if user.PasswordExpiresDays != nil {
 		err = installutils.Chage(imageChroot, *user.PasswordExpiresDays, user.Name)

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeusers.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeusers.go
@@ -52,7 +52,6 @@ func addOrUpdateUser(user imagecustomizerapi.User, baseConfigPath string, imageC
 		logger.Log.Infof("Adding user (%s)", user.Name)
 	}
 
-
 	hashedPassword := ""
 	shouldUpdatePassword := false
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeusers.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeusers.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"strconv"
-	"strings"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/installutils"
@@ -56,6 +55,8 @@ func addOrUpdateUser(user imagecustomizerapi.User, baseConfigPath string, imageC
 	shouldUpdatePassword := false
 
 	if user.Password != nil {
+		shouldUpdatePassword = true
+
 		passwordIsFile := user.Password.Type == imagecustomizerapi.PasswordTypePlainTextFile ||
 			user.Password.Type == imagecustomizerapi.PasswordTypeHashedFile
 
@@ -75,16 +76,12 @@ func addOrUpdateUser(user imagecustomizerapi.User, baseConfigPath string, imageC
 			password = string(passwordFileContents)
 		}
 
-		// Only proceed if password is not empty
-		if strings.TrimSpace(password) != "" {
-			shouldUpdatePassword = true
-			hashedPassword = password
-			if !passwordIsHashed {
-				// Hash the password.
-				hashedPassword, err = userutils.HashPassword(password)
-				if err != nil {
-					return err
-				}
+		hashedPassword = password
+		if !passwordIsHashed {
+			// Hash the password.
+			hashedPassword, err = userutils.HashPassword(password)
+			if err != nil {
+				return err
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

updates the addOrUpdateUser logic to avoid unintentionally clearing a pre-existing user's password when no new password is explicitly provided in the config.

---

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] Code conforms to style guidelines
