### PR TITLE
Fix the UKI stub path on ARM64.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki.go
@@ -128,7 +128,7 @@ func prepareUki(ctx context.Context, buildDir string, uki *imagecustomizerapi.Uk
 	}
 
 	// Copy UKI-specific files such as kernel, initramfs, and UKI stub file.
-	err = copyUkiFiles(buildDir, kernelToInitramfs, imageChroot)
+	err = copyUkiFiles(buildDir, kernelToInitramfs, imageChroot, bootConfig)
 	if err != nil {
 		return fmt.Errorf("failed to copy UKI files:\n%w", err)
 	}
@@ -183,10 +183,12 @@ func createUkiDirectories(buildDir string, imageChroot *safechroot.Chroot) error
 	return nil
 }
 
-func copyUkiFiles(buildDir string, kernelToInitramfs map[string]string, imageChroot *safechroot.Chroot) error {
+func copyUkiFiles(buildDir string, kernelToInitramfs map[string]string, imageChroot *safechroot.Chroot,
+	bootConfig BootFilesArchConfig,
+) error {
 	filesToCopy := map[string]string{
-		filepath.Join(imageChroot.RootDir(), "/usr/lib/systemd/boot/efi/linuxx64.efi.stub"): filepath.Join(buildDir, UkiBuildDir, "linuxx64.efi.stub"),
-		filepath.Join(imageChroot.RootDir(), "/etc/os-release"):                             filepath.Join(buildDir, UkiBuildDir, "os-release"),
+		filepath.Join(imageChroot.RootDir(), bootConfig.ukiEfiStubBinaryPath): filepath.Join(buildDir, UkiBuildDir, bootConfig.ukiEfiStubBinary),
+		filepath.Join(imageChroot.RootDir(), "/etc/os-release"):               filepath.Join(buildDir, UkiBuildDir, "os-release"),
 	}
 
 	for kernel, initramfs := range kernelToInitramfs {

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki.go
@@ -307,6 +307,11 @@ func createUki(ctx context.Context, uki *imagecustomizerapi.Uki, buildDir string
 
 	var err error
 
+	_, bootConfig, err := getBootArchConfig()
+	if err != nil {
+		return err
+	}
+
 	loopback, err := safeloopback.NewLoopback(buildImageFile)
 	if err != nil {
 		return fmt.Errorf("failed to connect to image file to provision UKI:\n%w", err)
@@ -342,7 +347,7 @@ func createUki(ctx context.Context, uki *imagecustomizerapi.Uki, buildDir string
 	defer bootPartitionMount.Close()
 
 	osSubreleaseFullPath := filepath.Join(buildDir, UkiBuildDir, "os-release")
-	stubPath := filepath.Join(buildDir, UkiBuildDir, "linuxx64.efi.stub")
+	stubPath := filepath.Join(buildDir, UkiBuildDir, bootConfig.ukiEfiStubBinary)
 	cmdlineFilePath := filepath.Join(buildDir, UkiBuildDir, KernelCmdlineArgsJson)
 
 	// Get mapped kernels and initramfs.

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki.go
@@ -347,7 +347,6 @@ func createUki(ctx context.Context, uki *imagecustomizerapi.Uki, buildDir string
 	defer bootPartitionMount.Close()
 
 	osSubreleaseFullPath := filepath.Join(buildDir, UkiBuildDir, "os-release")
-	stubPath := filepath.Join(buildDir, UkiBuildDir, bootConfig.ukiEfiStubBinary)
 	cmdlineFilePath := filepath.Join(buildDir, UkiBuildDir, KernelCmdlineArgsJson)
 
 	// Get mapped kernels and initramfs.
@@ -357,7 +356,7 @@ func createUki(ctx context.Context, uki *imagecustomizerapi.Uki, buildDir string
 	}
 
 	for kernel, initramfs := range kernelToInitramfs {
-		err := buildUki(kernel, initramfs, cmdlineFilePath, osSubreleaseFullPath, stubPath, buildDir,
+		err := buildUki(kernel, initramfs, cmdlineFilePath, osSubreleaseFullPath, bootConfig.ukiEfiStubBinaryPath, buildDir,
 			systemBootPartitionTmpDir,
 		)
 		if err != nil {

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoutils.go
@@ -16,6 +16,7 @@ import (
 const (
 	osEspBootloaderDir = "/boot/efi/EFI/BOOT"
 	isoBootloaderDir   = "/efi/boot"
+	ukiEfiStubDir      = "/usr/lib/systemd/boot/efi/"
 
 	bootx64Binary  = "bootx64.efi"
 	bootAA64Binary = "bootaa64.efi"
@@ -28,6 +29,9 @@ const (
 
 	systemdBootx64Binary  = "systemd-bootx64.efi"
 	systemdBootAA64Binary = "systemd-bootaa64.efi"
+
+	ukiEfiStubx64Binary  = "linuxx64.efi.stub"
+	ukiEfiStubAA64Binary = "linuxaa64.efi.stub"
 
 	grubCfgDir     = "/boot/grub2"
 	isoGrubCfg     = "grub.cfg"
@@ -78,6 +82,8 @@ type BootFilesArchConfig struct {
 	osEspGrubNoPrefixBinaryPath string
 	isoBootBinaryPath           string
 	isoGrubBinaryPath           string
+	ukiEfiStubBinary            string
+	ukiEfiStubBinaryPath        string
 }
 
 var (
@@ -92,6 +98,8 @@ var (
 			osEspGrubNoPrefixBinaryPath: osEspBootloaderDir + "/" + grubx64NoPrefixBinary,
 			isoBootBinaryPath:           isoBootloaderDir + "/" + bootx64Binary,
 			isoGrubBinaryPath:           isoBootloaderDir + "/" + grubx64Binary,
+			ukiEfiStubBinary:            ukiEfiStubx64Binary,
+			ukiEfiStubBinaryPath:        ukiEfiStubDir + "/" + ukiEfiStubx64Binary,
 		},
 		"arm64": {
 			bootBinary:                  bootAA64Binary,
@@ -103,6 +111,8 @@ var (
 			osEspGrubNoPrefixBinaryPath: osEspBootloaderDir + "/" + grubAA64NoPrefixBinary,
 			isoBootBinaryPath:           isoBootloaderDir + "/" + bootAA64Binary,
 			isoGrubBinaryPath:           isoBootloaderDir + "/" + grubAA64Binary,
+			ukiEfiStubBinary:            ukiEfiStubAA64Binary,
+			ukiEfiStubBinaryPath:        ukiEfiStubDir + "/" + ukiEfiStubAA64Binary,
 		},
 	}
 )


### PR DESCRIPTION
<!-- Description: Please provide a summary of the changes and the motivation behind them. -->
Adding fix for arm64 UKI support. This adds dynamic setting of the stub filepaths based on architecture.

systemd-ukify and systemd-boot will be added to azurelinux arm64 with this PR: https://github.com/microsoft/azurelinux/pull/14449 


---

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] Code conforms to style guidelines
