### PR TITLE
Fix UKI build.

### DIFF
--- a/.github/workflows/tests-functional.yml
+++ b/.github/workflows/tests-functional.yml
@@ -52,7 +52,7 @@ jobs:
 
         # grub2-pc is only available on x86.
         if [[ "$HOST_ARCH" == "amd64" ]]; then
-          sudo tdnf install -y grub2-pc
+          sudo tdnf install -y grub2-pc systemd-ukify
         fi
 
         sudo tdnf list installed
@@ -70,7 +70,7 @@ jobs:
 
         sudo apt -y install qemu-utils rpm coreutils util-linux mount fdisk udev openssl \
           sed createrepo-c squashfs-tools genisoimage e2fsprogs dosfstools \
-          xfsprogs zstd cryptsetup-bin grub2-common binutils lsof
+          xfsprogs zstd cryptsetup-bin grub2-common binutils lsof systemd-ukify
 
         curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki.go
@@ -300,7 +300,7 @@ func findSpecificKernelsAndInitramfs(bootDir string, versions []string) (map[str
 }
 
 func createUki(ctx context.Context, uki *imagecustomizerapi.Uki, buildDir string, buildImageFile string) error {
-	logger.Log.Debugf("Customizing UKI")
+	logger.Log.Infof("Creating UKIs")
 
 	_, span := otel.GetTracerProvider().Tracer(OtelTracerName).Start(ctx, "customize_uki")
 	defer span.End()
@@ -340,6 +340,7 @@ func createUki(ctx context.Context, uki *imagecustomizerapi.Uki, buildDir string
 	defer systemBootPartitionMount.Close()
 
 	bootPartitionTmpDir := filepath.Join(buildDir, tmpBootPartitionDirName)
+	stubPath := filepath.Join(buildDir, UkiBuildDir, bootConfig.ukiEfiStubBinary)
 	bootPartitionMount, err := safemount.NewMount(bootPartition.Path, bootPartitionTmpDir, bootPartition.FileSystemType, 0, "", true)
 	if err != nil {
 		return fmt.Errorf("failed to mount partition (%s):\n%w", bootPartition.Path, err)
@@ -356,7 +357,7 @@ func createUki(ctx context.Context, uki *imagecustomizerapi.Uki, buildDir string
 	}
 
 	for kernel, initramfs := range kernelToInitramfs {
-		err := buildUki(kernel, initramfs, cmdlineFilePath, osSubreleaseFullPath, bootConfig.ukiEfiStubBinaryPath, buildDir,
+		err := buildUki(kernel, initramfs, cmdlineFilePath, osSubreleaseFullPath, stubPath, buildDir,
 			systemBootPartitionTmpDir,
 		)
 		if err != nil {

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoutils.go
@@ -16,7 +16,7 @@ import (
 const (
 	osEspBootloaderDir = "/boot/efi/EFI/BOOT"
 	isoBootloaderDir   = "/efi/boot"
-	ukiEfiStubDir      = "/usr/lib/systemd/boot/efi/"
+	ukiEfiStubDir      = "/usr/lib/systemd/boot/efi"
 
 	bootx64Binary  = "bootx64.efi"
 	bootAA64Binary = "bootaa64.efi"


### PR DESCRIPTION
PR #360 accidentally broke the UKI build. Instead of pointing ukify at the image's EFI stub, it pointed it at the host's EFI stub instead. This change fixes this.

This change also fixes the GitHub workflows so that the UKI functional tests are run instead of being skipped.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
