### PR TITLE
Fix workflow permissions.

### DIFF
--- a/.github/workflows/binary-build.yml
+++ b/.github/workflows/binary-build.yml
@@ -3,8 +3,7 @@
 
 name: Build binary and container for single arch
 
-permissions:
-  contents: read
+permissions: {}
 
 on:
   workflow_call:

--- a/.github/workflows/build-dev.yml
+++ b/.github/workflows/build-dev.yml
@@ -3,10 +3,7 @@
 
 name: Build (dev)
 
-permissions:
-  contents: read
-  # Azure login.
-  id-token: write
+permissions: {}
 
 on:
   pull_request:
@@ -34,3 +31,7 @@ jobs:
       publishType: dev
       runFunctionalTests: ${{ inputs.runFunctionalTests || false }}
       runVMTests: ${{ inputs.runVMTests || false }}
+    permissions:
+      contents: read
+      # Azure login.
+      id-token: write

--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -3,10 +3,7 @@
 
 name: Build (main)
 
-permissions:
-  contents: read
-  # Azure login.
-  id-token: write
+permissions: {}
 
 on:
   push:
@@ -16,6 +13,10 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/build.yml
+    permissions:
+      contents: read
+      # Azure login.
+      id-token: write
     with:
       publishType: main
       runFunctionalTests: true

--- a/.github/workflows/build-preview.yml
+++ b/.github/workflows/build-preview.yml
@@ -3,10 +3,7 @@
 
 name: Build (preview)
 
-permissions:
-  contents: read
-  # Azure login.
-  id-token: write
+permissions: {}
 
 on:
   push:
@@ -16,6 +13,10 @@ on:
 jobs:
   build:
     uses: ./.github/workflows/build.yml
+    permissions:
+      contents: read
+      # Azure login.
+      id-token: write
     with:
       publishType: preview
       runFunctionalTests: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -193,6 +193,10 @@ jobs:
     with:
       hostArch: amd64
       hostDistro: azl3
+    permissions:
+      contents: read
+      # Azure login.
+      id-token: write
 
   tests-vmtests-osmodifier-ubuntu2404-amd64:
     name: VMTests suite osmodifier Ubuntu24.04 AMD64
@@ -202,6 +206,10 @@ jobs:
     with:
       hostArch: amd64
       hostDistro: ubuntu2404
+    permissions:
+      contents: read
+      # Azure login.
+      id-token: write
 
   tests-vmtests-osmodifier-ubuntu2404-arm64:
     name: VMTests suite osmodifier Ubuntu24.04 ARM64
@@ -211,3 +219,7 @@ jobs:
     with:
       hostArch: arm64
       hostDistro: ubuntu2404
+    permissions:
+      contents: read
+      # Azure login.
+      id-token: write

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,7 @@
 
 name: Build binary, container, and docs
 
-permissions:
-  contents: read
-  # Azure login.
-  id-token: write
+permissions: {}
 
 on:
   workflow_call:
@@ -31,6 +28,8 @@ jobs:
     with:
       publishType: ${{ inputs.publishType }}
       arch: amd64
+    permissions:
+      contents: read
 
   binary-build-arm64:
     name: Build ARM64
@@ -38,9 +37,13 @@ jobs:
     with:
       publishType: ${{ inputs.publishType }}
       arch: arm64
+    permissions:
+      contents: read
 
   build-docs:
     uses: ./.github/workflows/docs-build.yml
+    permissions:
+      contents: read
 
   tests-functional-azl3-amd64:
     name: Functional tests AZL3 AMD64
@@ -49,14 +52,22 @@ jobs:
     with:
       hostArch: amd64
       hostDistro: azl3
+    permissions:
+      contents: read
+      # Azure login.
+      id-token: write
 
   tests-functional-azl3-arm64:
-   name: Functional tests AZL3 ARM64
-   if: ${{ inputs.runFunctionalTests }}
-   uses: ./.github/workflows/tests-functional.yml
-   with:
-     hostArch: arm64
-     hostDistro: azl3
+    name: Functional tests AZL3 ARM64
+    if: ${{ inputs.runFunctionalTests }}
+    uses: ./.github/workflows/tests-functional.yml
+    with:
+      hostArch: arm64
+      hostDistro: azl3
+    permissions:
+      contents: read
+      # Azure login.
+      id-token: write
 
   tests-functional-ubuntu2404-amd64:
     name: Functional tests Ubuntu24.04 AMD64
@@ -65,6 +76,10 @@ jobs:
     with:
       hostArch: amd64
       hostDistro: ubuntu2404
+    permissions:
+      contents: read
+      # Azure login.
+      id-token: write
 
   tests-functional-ubuntu2404-arm64:
     name: Functional tests Ubuntu24.04 ARM64
@@ -73,6 +88,10 @@ jobs:
     with:
       hostArch: arm64
       hostDistro: ubuntu2404
+    permissions:
+      contents: read
+      # Azure login.
+      id-token: write
 
   imagecreator-tests-functional-azl3-amd64:
     name: Functional tests AZL3 AMD64
@@ -81,6 +100,8 @@ jobs:
     with:
       hostArch: amd64
       hostDistro: azl3
+    permissions:
+      contents: read
 
   imagecreator-tests-functional-ubuntu2404-amd64:
     name: Functional tests Ubuntu24.04 AMD64
@@ -89,6 +110,8 @@ jobs:
     with:
       hostArch: amd64
       hostDistro: ubuntu2404
+    permissions:
+      contents: read
 
   tests-vmtests-azl3-amd64:
     name: VMTests suite AZL3 AMD64
@@ -98,6 +121,10 @@ jobs:
     with:
       hostArch: amd64
       hostDistro: azl3
+    permissions:
+      contents: read
+      # Azure login.
+      id-token: write
 
   tests-vmtests-ubuntu2404-amd64:
     name: VMTests suite Ubuntu24.04 AMD64
@@ -107,6 +134,10 @@ jobs:
     with:
       hostArch: amd64
       hostDistro: ubuntu2404
+    permissions:
+      contents: read
+      # Azure login.
+      id-token: write
 
   tests-vmtests-ubuntu2404-arm64:
     name: VMTests suite Ubuntu24.04 ARM64
@@ -116,6 +147,10 @@ jobs:
     with:
       hostArch: arm64
       hostDistro: ubuntu2404
+    permissions:
+      contents: read
+      # Azure login.
+      id-token: write
 
   tests-vmtests-imagecreator-azl3-amd64:
     name: VMTests suite image creator AZL3 AMD64
@@ -125,6 +160,8 @@ jobs:
     with:
       hostArch: amd64
       hostDistro: azl3
+    permissions:
+      contents: read
 
   tests-vmtests-imagecreator-ubuntu2404-amd64:
     name: VMTests suite image creator Ubuntu24.04 AMD64
@@ -133,7 +170,9 @@ jobs:
     uses: ./.github/workflows/tests-vmtests-imagecreator.yml
     with:
       hostArch: amd64
-      hostDistro: ubuntu2404    
+      hostDistro: ubuntu2404
+    permissions:
+      contents: read
 
   tests-vmtests-imagecreator-ubuntu2404-arm64:
     name: VMTests suite image creator Ubuntu24.04 ARM64
@@ -143,6 +182,8 @@ jobs:
     with:
       hostArch: arm64
       hostDistro: ubuntu2404
+    permissions:
+      contents: read
 
   tests-vmtests-osmodifier-azl3-amd64:
     name: VMTests suite osmodifier AZL3 AMD64

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,7 +1,6 @@
 name: Build docs
 
-permissions:
-  contents: read
+permissions: {}
 
 on:
   workflow_call: {}

--- a/.github/workflows/fork-release-branch.yml
+++ b/.github/workflows/fork-release-branch.yml
@@ -3,9 +3,7 @@
 
 name: Fork release branch
 
-permissions:
-  # Create release branch.
-  contents: write
+permissions: {}
 
 on:
   workflow_call: {}

--- a/.github/workflows/imagecreator-tests-functional.yml
+++ b/.github/workflows/imagecreator-tests-functional.yml
@@ -3,8 +3,7 @@
 
 name: Tests Image Creator functional
 
-permissions:
-  contents: read
+permissions: {}
 
 on:
   workflow_call:

--- a/.github/workflows/open-bump-version-pr.yml
+++ b/.github/workflows/open-bump-version-pr.yml
@@ -3,11 +3,7 @@
 
 name: Open bump version PR
 
-permissions:
-  # Create release branch and publish release.
-  contents: write
-  # Publish PR.
-  #pull-requests: write
+permissions: {}
 
 on:
   workflow_call: {}

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -1,10 +1,6 @@
 name: Publish container to GHCR
 
-permissions:
-  # "Keyless" container signing
-  id-token: write
-  # Publish to GHCR.
-  packages: write
+permissions: {}
 
 on:
   workflow_call: {}

--- a/.github/workflows/publish-github-pages.yml
+++ b/.github/workflows/publish-github-pages.yml
@@ -9,6 +9,7 @@ jobs:
   deploy:
     name: Publish GitHub pages
     permissions:
+      # GitHub pages publish.
       pages: write
       id-token: write
     environment:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -3,9 +3,7 @@
 
 name: Publish release
 
-permissions:
-  # Create release tag and publish release.
-  contents: write
+permissions: {}
 
 on:
   workflow_call:

--- a/.github/workflows/release-minor-version.yml
+++ b/.github/workflows/release-minor-version.yml
@@ -3,17 +3,7 @@
 
 name: Release (major/minor)
 
-permissions:
-  # Push release branch and publish release.
-  contents: write
-  # Publish to GHCR.
-  packages: write
-  # "Keyless" container signing, Azure login, GitHub pages publish.
-  id-token: write
-  # Publish PR.
-  #pull-requests: write
-  # GitHub pages publish.
-  pages: write
+permissions: {}
 
 on:
   # Allow pipeline to be run manually.
@@ -26,11 +16,20 @@ jobs:
       publishType: official
       runFunctionalTests: true
       runVMTests: true
+    permissions:
+      contents: read
+      # Azure login
+      id-token: write
 
   publish-container:
     uses: ./.github/workflows/publish-container.yml
     needs:
     - build
+    permissions:
+      # "Keyless" container signing
+      id-token: write
+      # Publish to GHCR.
+      packages: write
 
   publish-release:
     uses: ./.github/workflows/publish-release.yml
@@ -38,18 +37,33 @@ jobs:
       isLatestRelease: true
     needs:
     - build
+    permissions:
+      # Create release tag and publish release.
+      contents: write
 
   fork-release-branch:
     uses: ./.github/workflows/fork-release-branch.yml
     needs:
     - build
+    permissions:
+      # Create release branch.
+      contents: write
 
   open-bump-version-pr:
     uses: ./.github/workflows/open-bump-version-pr.yml
     needs:
     - build
+    permissions:
+      # Create release branch and publish release.
+      contents: write
+      # Publish PR.
+      #pull-requests: write
 
   publish-github-pages:
     uses: ./.github/workflows/publish-github-pages.yml
     needs:
     - build
+    permissions:
+      # GitHub pages publish.
+      pages: write
+      id-token: write

--- a/.github/workflows/release-patch-version.yml
+++ b/.github/workflows/release-patch-version.yml
@@ -3,15 +3,7 @@
 
 name: Release (patch)
 
-permissions:
-  # Push release branch and publish release.
-  contents: write
-  # Publish to GHCR.
-  packages: write
-  # "Keyless" container signing and Azure login.
-  id-token: write
-  # GitHub pages publish.
-  pages: write
+permissions: {}
 
 on:
   # Allow pipeline to be run manually.

--- a/.github/workflows/release-patch-version.yml
+++ b/.github/workflows/release-patch-version.yml
@@ -24,11 +24,20 @@ jobs:
       publishType: patch
       runFunctionalTests: true
       runVMTests: true
+    permissions:
+      contents: read
+      # Azure login
+      id-token: write
 
   publish-container:
     uses: ./.github/workflows/publish-container.yml
     needs:
     - build
+    permissions:
+      # "Keyless" container signing
+      id-token: write
+      # Publish to GHCR.
+      packages: write
 
   publish-release:
     uses: ./.github/workflows/publish-release.yml
@@ -36,9 +45,16 @@ jobs:
       isLatestRelease: ${{ needs.build.outputs.isLatestRelease }}
     needs:
     - build
+    permissions:
+      # Create release tag and publish release.
+      contents: write
 
   publish-github-pages:
     uses: ./.github/workflows/publish-github-pages.yml
     if: ${{ needs.build.outputs.isLatestRelease == 'true' }}
     needs:
     - build
+    permissions:
+      # GitHub pages publish.
+      pages: write
+      id-token: write

--- a/.github/workflows/release-preview-version.yml
+++ b/.github/workflows/release-preview-version.yml
@@ -3,12 +3,7 @@
 
 name: Release (preview)
 
-permissions:
-  contents: read
-  # "Keyless" container signing and Azure login.
-  id-token: write
-  # Publish to GHCR.
-  packages: write
+permissions: {}
 
 on:
   # Allow pipeline to be run manually.

--- a/.github/workflows/release-preview-version.yml
+++ b/.github/workflows/release-preview-version.yml
@@ -21,8 +21,17 @@ jobs:
       publishType: preview
       runFunctionalTests: true
       runVMTests: true
+    permissions:
+      contents: read
+      # Azure login
+      id-token: write
 
   publish-container:
     uses: ./.github/workflows/publish-container.yml
     needs:
     - build
+    permissions:
+      # "Keyless" container signing
+      id-token: write
+      # Publish to GHCR.
+      packages: write

--- a/.github/workflows/tests-functional.yml
+++ b/.github/workflows/tests-functional.yml
@@ -3,10 +3,7 @@
 
 name: Tests functional
 
-permissions:
-  contents: read
-  # Azure login.
-  id-token: write
+permissions: {}
 
 on:
   workflow_call:

--- a/.github/workflows/tests-vmtests-imagecreator.yml
+++ b/.github/workflows/tests-vmtests-imagecreator.yml
@@ -3,8 +3,7 @@
 
 name: Tests VMTests suite for Image Creator
 
-permissions:
-  contents: read
+permissions: {}
 
 on:
   workflow_call:

--- a/.github/workflows/tests-vmtests-osmodifier.yml
+++ b/.github/workflows/tests-vmtests-osmodifier.yml
@@ -3,10 +3,7 @@
 
 name: Tests VMTests suite for OSModifier
 
-permissions:
-  contents: read
-  # Azure login.
-  id-token: write
+permissions: {}
 
 on:
   workflow_call:

--- a/.github/workflows/tests-vmtests.yml
+++ b/.github/workflows/tests-vmtests.yml
@@ -3,10 +3,7 @@
 
 name: Tests VMTests suite
 
-permissions:
-  contents: read
-  # Azure login.
-  id-token: write
+permissions: {}
 
 on:
   workflow_call:


### PR DESCRIPTION
The permissions at the top of the workflow file apply to all jobs within the file. So, explicitly set this to nothing to ensure there are no default permissions. Then, set explict permissions on each job, to only what each job needs.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
