### PR TITLE
Set container ENTRYPOINT.

### DIFF
--- a/docs/imagecustomizer/how-to/azure-vm.md
+++ b/docs/imagecustomizer/how-to/azure-vm.md
@@ -152,14 +152,13 @@ in front of any HTTP endpoints.
 5. Run Image Customizer to create the new image:
 
    ```bash
-   IMG_CUSTOMIZER_TAG="mcr.microsoft.com/azurelinux/imagecustomizer:0.17.0"
+   IMG_CUSTOMIZER_TAG="mcr.microsoft.com/azurelinux/imagecustomizer:0.18.0"
    docker run \
      --rm \
      --privileged=true \
      -v /dev:/dev \
      -v "$STAGE_DIR:/mnt/staging:z" \
      "$IMG_CUSTOMIZER_TAG" \
-     imagecustomizer \
        --image-file "/mnt/staging/image.vhd" \
        --config-file "/mnt/staging/image-config.yaml" \
        --build-dir "/mnt/staging/build" \

--- a/docs/imagecustomizer/quick-start/quick-start.md
+++ b/docs/imagecustomizer/quick-start/quick-start.md
@@ -20,7 +20,7 @@ The container is published to both:
   For example:
 
   ```text
-  mcr.microsoft.com/azurelinux/imagecustomizer:0.17.0
+  mcr.microsoft.com/azurelinux/imagecustomizer:0.18.0
   ```
 
   You can use the MCR REST API to query available and latest tags:
@@ -38,7 +38,7 @@ The container is published to both:
   For example:
 
   ```text
-  ghcr.io/microsoft/imagecustomizer:0.17.0
+  ghcr.io/microsoft/imagecustomizer:0.18.0
   ```
 
 ## Prerequisites
@@ -74,8 +74,7 @@ The container is published to both:
       --privileged=true \
       -v /dev:/dev \
       -v "$HOME/staging:/mnt/staging:z" \
-      mcr.microsoft.com/azurelinux/imagecustomizer:0.17.0 \
-      imagecustomizer \
+      mcr.microsoft.com/azurelinux/imagecustomizer:0.18.0 \
         --image-file "/mnt/staging/image.vhdx" \
         --config-file "/mnt/staging/image-config.yaml" \
         --build-dir "/build" \
@@ -101,7 +100,7 @@ The container is published to both:
     - `-v $HOME/staging:/mnt/staging:z`: Mounts a host directory (`$HOME/staging`) into the
       container. This can be used to easily pass files in and out of the container.
 
-    - `mcr.microsoft.com/azurelinux/imagecustomizer:0.17.0`: The container to run.
+    - `mcr.microsoft.com/azurelinux/imagecustomizer:0.18.0`: The container to run.
 
     - `imagecustomizer`: Specifies the executable to run within the container.
 
@@ -118,7 +117,7 @@ The container is published to both:
     - `--output-image-file "/mnt/staging/out/image.vhdx"`: Output the customized image to
       the host's `$HOME/staging/out/image.vhdx` file path.
 
-5. Use the customized image.
+4. Use the customized image.
 
    The customized image is placed in the file that you specified with the
    `--output-image-file` parameter. You can now use this image as you see fit.
@@ -126,7 +125,7 @@ The container is published to both:
 
 ## Helper script
 
-`run-container.sh`
+Link: [run-container.sh](https://github.com/microsoft/azure-linux-image-tools/blob/main/toolkit/tools/imagecustomizer/container/run-container.sh)
 
 This script wraps the Docker call. It is intended to make using the Image Customizer
 container a little easier.
@@ -135,7 +134,7 @@ For example, this is the equivalent call to the above example:
 
 ```bash
 run-container.sh \
-    -t mcr.microsoft.com/azurelinux/imagecustomizer:0.17.0 \
+    -t mcr.microsoft.com/azurelinux/imagecustomizer:0.18.0 \
     -i "$HOME/staging/image.vhdx" \
     -c "$HOME/staging/image-config.yaml" \
     -f vhdx \

--- a/docs/imagecustomizer/telemetry.md
+++ b/docs/imagecustomizer/telemetry.md
@@ -31,8 +31,7 @@ docker run \
    --privileged=true \
    -v /dev:/dev \
    -v "$HOME/staging:/mnt/staging:z" \
-   mcr.microsoft.com/azurelinux/imagecustomizer:0.17.0 \
-   imagecustomizer \
+   mcr.microsoft.com/azurelinux/imagecustomizer:0.18.0 \
      --image-file "/mnt/staging/image.vhdx" \
      --config-file "/mnt/staging/image-config.yaml" \
      --build-dir "/build" \

--- a/test/vmtests/vmtests/utils/imagecustomizer.py
+++ b/test/vmtests/vmtests/utils/imagecustomizer.py
@@ -49,7 +49,6 @@ def run_image_customizer(
     container_output_image_path = container_output_image_dir.joinpath(output_image_path.name)
 
     args = [
-        "imagecustomizer",
         "--image-file",
         str(container_base_image_path),
         "--config-file",

--- a/toolkit/tools/imagecustomizer/container/entrypoint.sh
+++ b/toolkit/tools/imagecustomizer/container/entrypoint.sh
@@ -26,4 +26,4 @@ if [[ "$ENABLE_TELEMETRY" == "true" ]] && [[ -n "$AZURE_MONITOR_CONNECTION_STRIN
     sleep 1
 fi
 
-exec "$@"
+imagecustomizer "$@"

--- a/toolkit/tools/imagecustomizer/container/run-container.sh
+++ b/toolkit/tools/imagecustomizer/container/run-container.sh
@@ -92,7 +92,6 @@ docker run --rm \
    -v $outputImageDir:$containerOutputDir:z \
    -v /dev:/dev \
    "$containerTag" \
-   imagecustomizer \
       --image-file $containerInputImage \
       --config-file $containerInputConfig \
       --build-dir $containerBuildDir \

--- a/toolkit/tools/imagecustomizer/container/run.sh
+++ b/toolkit/tools/imagecustomizer/container/run.sh
@@ -63,6 +63,16 @@ if [[ -z "$ARG_VERSION" ]]; then
     exit_with_usage "missing required argument: 'VERSION'"
 fi
 
+ENABLE_TELEMETRY="${ENABLE_TELEMETRY:-true}"
+
+# Check if --disable-telemetry flag is present in arguments
+for arg in "$@"; do
+    if [[ "$arg" == "--disable-telemetry" ]]; then
+        ENABLE_TELEMETRY=false
+        break
+    fi
+done
+
 PLATFORM="linux/amd64"
 case "$(uname -m)" in
     aarch64|arm64)
@@ -134,6 +144,17 @@ else
         echo "Error: no image file found in the OCI artifact '$OCI_ARTIFACT_PATH'" >&2
         exit 1
     fi
+fi
+
+# Start telemetry service if enabled and connection string is set
+if [[ "$ENABLE_TELEMETRY" == "true" ]] && [[ -n "$AZURE_MONITOR_CONNECTION_STRING" ]]; then
+
+    export OTEL_PORT=4317
+    export OTEL_EXPORTER_OTLP_PROTOCOL="grpc"
+    export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:${OTEL_PORT}"
+    
+    /opt/telemetry-venv/bin/python /usr/local/bin/telemetry_hopper.py --port $OTEL_PORT > /var/log/image_customizer_telemetry.log 2>&1 || true &
+    sleep 1
 fi
 
 imagecustomizer --image-file "$ARTIFACT_DIR/$IMAGE_FILE_NAME" "$@"

--- a/toolkit/tools/imagecustomizer/container/test-container.sh
+++ b/toolkit/tools/imagecustomizer/container/test-container.sh
@@ -28,8 +28,8 @@ docker run --rm \
     -v "$inputConfigDir":"$containerInputConfigDir":z \
     -v "$outputImageDir":"$containerOutputDir":z \
     -v /dev:/dev \
+    --entrypoint /usr/local/bin/run.sh \
     "$containerTag" \
-    /usr/local/bin/run.sh \
         "3.0.latest" \
         --config-file "$containerInputConfig" \
         --build-dir "$containerBuildDir" \


### PR DESCRIPTION
Set the `imagecustomizer` executable as the default ENTRYPOINT for the container.

Technically, the telemetry hopper is already the entrypoint. So, this change is actually just having the telemetry hopper call `imagecustomizer`, instead of requiring the user to pass in the command name. But when the telemetry hopper is removed, `imagecustomizer` will become the entrypoint.

Also, update the `run.sh` script to include a copy of the telemetry hopper logic. Now, to use the `run.sh` script, the user must pass `--entrypoint /usr/local/bin/run.sh` to docker to override the default command.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
