### PR TITLE
Fix 'TestOutputAndInjectArtifacts' test.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput_test.go
@@ -13,7 +13,10 @@ import (
 )
 
 func TestOutputAndInjectArtifacts(t *testing.T) {
-	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
+	baseImage, baseImageInfo := checkSkipForCustomizeDefaultImage(t)
+	if baseImageInfo.Version == baseImageVersionAzl2 {
+		t.Skip("'systemd-boot' is not available on Azure Linux 2.0")
+	}
 
 	ukifyExists, err := file.CommandExists("ukify")
 	assert.NoError(t, err)
@@ -152,20 +155,20 @@ func TestOutputAndInjectArtifacts(t *testing.T) {
 
 	// Check the injected files
 	// shim
-	expectedInjectedShim := filepath.Join(imageConnection.Chroot().RootDir(), "EFI", "BOOT", filepath.Base(bootBinary))
+	expectedInjectedShim := filepath.Join(imageConnection.Chroot().RootDir(), "boot/efi/EFI/BOOT", filepath.Base(bootBinary))
 	contains, err := fileContainsMarker(expectedInjectedShim, marker)
 	assert.NoError(t, err)
 	assert.True(t, contains, "Expected injected shim to exist:\n%s", expectedInjectedShim)
 
 	// systemd-boot
-	expectedInjectedSystemdBoot := filepath.Join(imageConnection.Chroot().RootDir(), "EFI", "systemd", filepath.Base(systemdBootBinary))
+	expectedInjectedSystemdBoot := filepath.Join(imageConnection.Chroot().RootDir(), "boot/efi/EFI/systemd", filepath.Base(systemdBootBinary))
 	contains, err = fileContainsMarker(expectedInjectedSystemdBoot, marker)
 	assert.NoError(t, err)
 	assert.True(t, contains, "Expected injected systemd-boot to exist:\n%s", expectedInjectedSystemdBoot)
 
 	// UKI(s)
 	for _, src := range ukiFiles {
-		expectedInjectedUKI := filepath.Join(imageConnection.Chroot().RootDir(), "EFI", "Linux", filepath.Base(src))
+		expectedInjectedUKI := filepath.Join(imageConnection.Chroot().RootDir(), "boot/efi/EFI/Linux", filepath.Base(src))
 
 		exists, err = file.PathExists(expectedInjectedUKI)
 		assert.NoError(t, err)

--- a/toolkit/tools/pkg/imagecustomizerlib/main_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/main_test.go
@@ -79,10 +79,10 @@ var (
 	}
 
 	defaultBaseImagePriorityList = []testBaseImageInfo{
-		testBaseImageAzl2CoreEfi,
-		testBaseImageAzl2BareMetal,
 		testBaseImageAzl3CoreEfi,
 		testBaseImageAzl3BareMetal,
+		testBaseImageAzl2CoreEfi,
+		testBaseImageAzl2BareMetal,
 	}
 )
 

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/artifacts-output.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/artifacts-output.yaml
@@ -1,19 +1,16 @@
 storage:
   disks:
   - partitionTableType: gpt
-    maxSize: 2048M
     partitions:
     - id: esp
       type: esp
-      start: 1M
-      end: 9M
+      size: 100M
 
     - id: boot
-      start: 9M
-      end: 108M
+      size: 100M
 
     - id: rootfs
-      start: 108M
+      size: 2G
 
   bootType: efi
 


### PR DESCRIPTION
1. Skip this test on Azure Linux 2.0, since the systemd-boot package isn't available.

2. Increase the size of the ESP partition so that it can fit the UKIs.

3. Fix the expected paths of the injected file.

4. For the functional tests, set Azure Linux 3.0 as the default image instead of 2.0.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
