### PR TITLE
Fix functional tests.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeservices_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeservices_test.go
@@ -90,5 +90,4 @@ func TestCustomizeImageServicesDisableUnknown(t *testing.T) {
 	err := CustomizeImage(t.Context(), buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw",
 		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	assert.ErrorContains(t, err, "failed to disable service (service='chocolate-chip-muffin')")
-	assert.ErrorContains(t, err, "No such file or directory")
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeusers_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeusers_test.go
@@ -248,8 +248,8 @@ func TestCustomizeImageUsersAddFiles(t *testing.T) {
 	userHomeDirStat, err := os.Stat(userHomeDir)
 	if assert.NoError(t, err) {
 		userHomeDirStatSys := userHomeDirStat.Sys().(*syscall.Stat_t)
-		assert.Equal(t, uint32(1000), userHomeDirStatSys.Uid)
-		assert.Equal(t, uint32(1000), userHomeDirStatSys.Gid)
+		assert.Equal(t, uint32(2000), userHomeDirStatSys.Uid)
+		assert.Equal(t, uint32(2000), userHomeDirStatSys.Gid)
 	}
 
 	// Verity file was copied to image.

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"testing"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/imagecustomizerapi"
@@ -603,11 +602,19 @@ func TestCustomizeImage_InputImageFileAsRelativePath(t *testing.T) {
 }
 
 func TestCustomizeImageKernelCommandLineAdd(t *testing.T) {
+	for _, baseImageInfo := range baseImageAll {
+		t.Run(baseImageInfo.Name, func(t *testing.T) {
+			testCustomizeImageKernelCommandLineAddHelper(t, "TestCustomizeImageKernelCommandLineAdd"+baseImageInfo.Name, baseImageInfo)
+		})
+	}
+}
+
+func testCustomizeImageKernelCommandLineAddHelper(t *testing.T, testName string, baseImageInfo testBaseImageInfo) {
 	var err error
 
-	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
+	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
-	buildDir := filepath.Join(tmpDir, "TestCustomizeImageKernelCommandLine")
+	buildDir := filepath.Join(tmpDir, testName)
 	outImageFilePath := filepath.Join(buildDir, "image.vhd")
 
 	// Customize image.
@@ -640,14 +647,7 @@ func TestCustomizeImageKernelCommandLineAdd(t *testing.T) {
 		return
 	}
 
-	t.Logf("%s", grub2ConfigFile)
-
-	linuxCommandLineRegex, err := regexp.Compile(`linux .* console=tty0 console=ttyS0 `)
-	if !assert.NoError(t, err) {
-		return
-	}
-
-	assert.True(t, linuxCommandLineRegex.Match(grub2ConfigFile))
+	assert.Regexp(t, `linux\s+.*\s+console=tty0 console=ttyS0\s+`, grub2ConfigFile)
 }
 
 func TestCustomizeImage_OutputImageFileSelection(t *testing.T) {

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/add-user-files.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/add-user-files.yaml
@@ -1,7 +1,7 @@
 os:
   users:
   - name: test
-    uid: 1000
+    uid: 2000
 
   additionalFiles:
   - destination: /home/test/platypus


### PR DESCRIPTION
PR #370 changed the default test image from Azure Linux 2.0 to 3.0. But this accidentally broke some tests due to subtle differences in behavior. This changes fixes the tests to handle Azure Linux 3.0.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
