### PR TITLE
Add ignoreOverlays param to skip overlay for COSI

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput.go
@@ -387,7 +387,7 @@ func prepareImageConversionData(ctx context.Context, rawImageFile string, buildD
 	[]OsPackage, [randomization.UuidSize]byte, string, *CosiBootloader, error,
 ) {
 	imageConnection, partUuidToFstabEntry, baseImageVerityMetadata, _, err := connectToExistingImage(ctx,
-		rawImageFile, buildDir, chrootDir, true, true, false)
+		rawImageFile, buildDir, chrootDir, true, true, false, false)
 	if err != nil {
 		return nil, nil, "", nil, [randomization.UuidSize]byte{}, "", nil, fmt.Errorf("%w:\n%w", ErrArtifactImageConnectionForExtraction, err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
@@ -25,7 +25,7 @@ func customizePartitionsUsingFileCopy(ctx context.Context, buildDir string, base
 	buildImageFile string, newBuildImageFile string,
 ) (map[string]string, error) {
 	existingImageConnection, _, _, _, err := connectToExistingImage(ctx, buildImageFile, buildDir, "imageroot", false,
-		true, false)
+		true, false, false)
 	if err != nil {
 		return nil, err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecreator.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecreator.go
@@ -31,7 +31,7 @@ func CustomizeImageHelperImageCreator(ctx context.Context, buildDir string, base
 	defer toolsChroot.Close(false)
 
 	imageConnection, partUuidToFstabEntry, _, _, err := connectToExistingImage(ctx, rawImageFile, toolsChrootDir,
-		toolsRootImageDir, true, false, false)
+		toolsRootImageDir, true, false, false, false)
 	if err != nil {
 		return nil, "", err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -1059,7 +1059,7 @@ func customizeImageHelper(ctx context.Context, buildDir string, baseConfigPath s
 	readOnlyVerity := config.Storage.ReinitializeVerity != imagecustomizerapi.ReinitializeVerityTypeAll
 
 	imageConnection, partUuidToFstabEntry, baseImageVerityMetadata, readonlyPartUuids, err := connectToExistingImage(
-		ctx, rawImageFile, buildDir, "imageroot", true, false, readOnlyVerity)
+		ctx, rawImageFile, buildDir, "imageroot", true, false, readOnlyVerity, false)
 	if err != nil {
 		return nil, nil, nil, "", err
 	}
@@ -1105,7 +1105,7 @@ func customizeImageHelper(ctx context.Context, buildDir string, baseConfigPath s
 func collectOSInfo(ctx context.Context, buildDir string, rawImageFile string,
 ) ([]OsPackage, *CosiBootloader, error) {
 	var err error
-	imageConnection, _, _, _, err := connectToExistingImage(ctx, rawImageFile, buildDir, "imageroot", true, true, false)
+	imageConnection, _, _, _, err := connectToExistingImage(ctx, rawImageFile, buildDir, "imageroot", true, true, false, true)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -198,7 +198,7 @@ func createLiveOSFromRawHelper(ctx context.Context, buildDir, baseConfigPath str
 
 	logger.Log.Debugf("Connecting to raw image (%s)", rawImageFile)
 	rawImageConnection, _, _, _, err := connectToExistingImage(ctx, rawImageFile, isoBuildDir, "readonly-rootfs-mount",
-		false /*includeDefaultMounts*/, false /*readonly*/, false /*readonlyVerity*/)
+		false /*includeDefaultMounts*/, false /*readonly*/, false /*readonlyVerity*/, false /*ignoreOverlays*/)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
@@ -199,7 +199,7 @@ func readFstabEntriesFromRootfs(rootfsPartition *diskutils.PartitionInfo, diskPa
 }
 
 func fstabEntriesToMountPoints(fstabEntries []diskutils.FstabEntry, diskPartitions []diskutils.PartitionInfo,
-	buildDir string, readonly bool, readOnlyVerity bool,
+	buildDir string, readonly bool, readOnlyVerity bool, ignoreOverlays bool,
 ) ([]*safechroot.MountPoint, map[string]diskutils.FstabEntry, []verityDeviceMetadata, []string, error) {
 	filteredFstabEntries := filterOutSpecialPartitions(fstabEntries)
 
@@ -210,6 +210,9 @@ func fstabEntriesToMountPoints(fstabEntries []diskutils.FstabEntry, diskPartitio
 	verityMetadataList := []verityDeviceMetadata(nil)
 	readonlyPartUuids := []string(nil)
 	for _, fstabEntry := range filteredFstabEntries {
+		if ignoreOverlays && strings.ToLower(fstabEntry.FsType) == "overlay" {
+			continue // Skip overlay entries when requested
+		}
 		_, partition, _, verityMetadata, err := findSourcePartition(fstabEntry.Source, diskPartitions, buildDir)
 		if err != nil {
 			return nil, nil, nil, nil, err


### PR DESCRIPTION
<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

For COSI generation, connectToExistingImage is called after customization is done, so when there is overlay in the config, fstabEntriesToMountPoints() encounters an overlay entry with source "overlay", isn't in the fstab source types. And overlay should be excluded from partition metadata so this PR addresses this bug by adding ignoreOverlays param

---

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] Code conforms to style guidelines
