### PR TITLE
Pin 3rd party GitHub actions.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,9 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10

--- a/.github/workflows/binary-build.yml
+++ b/.github/workflows/binary-build.yml
@@ -166,7 +166,7 @@ jobs:
         PUBLISH_TYPE: ${{ inputs.publishType }}
 
     - name: Setup Notation CLI
-      uses: notaryproject/notation-action/setup@v1
+      uses: notaryproject/notation-action/setup@b6fee73110795d6793253c673bd723f12bcf9bbb # v1.2.2
 
     - name: Build container
       run: |

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -18,7 +18,7 @@ jobs:
         persist-credentials: false
 
     - name: Setup ruby
-      uses: ruby/setup-ruby@4a9ddd6f338a97768b8006bf671dfbad383215f4 # v1.207.0
+      uses: ruby/setup-ruby@829114fc20da43a41d27359103ec7a63020954d4 # v1.255.0
       with:
         ruby-version: '3.3'
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -24,7 +24,7 @@ jobs:
       run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${GITHUB_ACTOR}" --password-stdin
 
     - name: Install cosign
-      uses: sigstore/cosign-installer@v3.8.2
+      uses: sigstore/cosign-installer@d58896d6a1865668819e1d91763c7751a165e159 # v3.9.2
       with:
         cosign-release: 'v2.5.0'
 

--- a/.github/workflows/tests-functional.yml
+++ b/.github/workflows/tests-functional.yml
@@ -72,7 +72,7 @@ jobs:
         curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 
     - name: Azure Login
-      uses: azure/login@v2
+      uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
       with:
         client-id: ${{ vars.AZURE_CLIENT_ID }}
         tenant-id: ${{ vars.AZURE_TENANT_ID }}

--- a/.github/workflows/tests-vmtests-imagecreator.yml
+++ b/.github/workflows/tests-vmtests-imagecreator.yml
@@ -89,6 +89,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: repo
+        persist-credentials: false
 
     - name: Build imagecreator and imagecustomizer
       run: |

--- a/.github/workflows/tests-vmtests-osmodifier.yml
+++ b/.github/workflows/tests-vmtests-osmodifier.yml
@@ -72,7 +72,7 @@ jobs:
           HOST_ARCH: ${{ inputs.hostArch }}
  
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
         with:
           client-id: ${{ vars.AZURE_CLIENT_ID }}
           tenant-id: ${{ vars.AZURE_TENANT_ID }}
@@ -82,6 +82,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: repo
+          persist-credentials: false
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4
@@ -93,7 +94,7 @@ jobs:
         run: |
           set -eux
 
-          CONTAINER_TAR_PATH="out/container-${{ inputs.hostArch }}/imagecustomizer.tar.gz"
+          CONTAINER_TAR_PATH="out/container-$HOST_ARCH/imagecustomizer.tar.gz"
           DOCKER_OUTPUT=$(sudo docker image load -i "$CONTAINER_TAR_PATH" 2>&1)
           CONTAINER_TAG=$(echo $DOCKER_OUTPUT | awk '{print $3}')
 
@@ -106,10 +107,12 @@ jobs:
         run: |
           set -eux
 
-          OSMODIFIER_BIN="$(realpath out/osmodifier-${{ inputs.hostArch }}/osmodifier)"
+          OSMODIFIER_BIN="$(realpath out/osmodifier-$HOST_ARCH/osmodifier)"
           [[ -f "$OSMODIFIER_BIN" ]] || { echo "osmodifier binary not found at $OSMODIFIER_BIN"; ls -la out/; exit 1; }
           chmod +x "$OSMODIFIER_BIN"
           echo "path=$OSMODIFIER_BIN" >> "$GITHUB_OUTPUT"
+        env:
+          HOST_ARCH: ${{ inputs.hostArch }}
 
       - name: Download base images
         run: |

--- a/.github/workflows/tests-vmtests.yml
+++ b/.github/workflows/tests-vmtests.yml
@@ -73,7 +73,7 @@ jobs:
         HOST_ARCH: ${{ inputs.hostArch }}
 
     - name: Azure Login
-      uses: azure/login@v2
+      uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
       with:
         client-id: ${{ vars.AZURE_CLIENT_ID }}
         tenant-id: ${{ vars.AZURE_TENANT_ID }}


### PR DESCRIPTION
Specify the commit ID of all the 3rd party GitHub actions. This prevents the commits changing from underneath the version tag.

Also, setup dependabot to automatically updated 3rd party GitHub actions' versions.

Also, fix up some other workflow security issues.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
