### PR TITLE
Fix overlay SELinux equivalency rules add.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeselinux.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeselinux.go
@@ -80,6 +80,11 @@ func handleSELinux(ctx context.Context, selinuxMode imagecustomizerapi.SELinuxMo
 		return imagecustomizerapi.SELinuxModeDefault, err
 	}
 
+	err = installutils.SELinuxBuildPolicyIfMissing(imageChroot)
+	if err != nil {
+		return imagecustomizerapi.SELinuxModeDefault, err
+	}
+
 	return selinuxMode, nil
 }
 


### PR DESCRIPTION
The Azure Linux 3.0's selinux-policy package has a bug where the SELinux policy is not being rebuilt after the RPM is installed. This causes problems for Image Customizer's overlays API, since the `semanage fcontext -a` call requires the policy file to be built.

This change adds a workaround to Image Customizer to detect this case and triggers an SELinux rebuild when needed.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
