### PR TITLE
Disable Overlay + SELinux test for AZL 3.0.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeoverlays_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeoverlays_test.go
@@ -80,9 +80,21 @@ func TestCustomizeImageOverlays(t *testing.T) {
 }
 
 func TestCustomizeImageOverlaysSELinux(t *testing.T) {
-	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
+	for _, baseImageInfo := range baseImageAll {
+		t.Run(baseImageInfo.Name, func(t *testing.T) {
+			testCustomizeImageOverlaysSELinuxHelper(t, "TestCustomizeImageOverlaysSELinux"+baseImageInfo.Name, baseImageInfo)
+		})
+	}
+}
 
-	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageOverlaysSELinux")
+func testCustomizeImageOverlaysSELinuxHelper(t *testing.T, testName string, baseImageInfo testBaseImageInfo) {
+	if baseImageInfo.Version == baseImageVersionAzl3 {
+		t.Skip("Azure Linux 3.0 is missing policy.kern file")
+	}
+
+	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
+
+	testTempDir := filepath.Join(tmpDir, testName)
 	buildDir := filepath.Join(testTempDir, "build")
 	outImageFilePath := filepath.Join(testTempDir, "image.raw")
 	configFile := filepath.Join(testDir, "overlays-selinux.yaml")


### PR DESCRIPTION
Azure Linux 3.0 has a bug where the `policy.kern` file is missing. And this results in calls to `semanage fcontext` failing, since that command expects the `policy.kern` to exist. This bug should be fixed in https://github.com/microsoft/azurelinux/pull/14549. But in the meantime, disable the test.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
