### PR TITLE
Boost functional test timeout

### DIFF
--- a/.github/workflows/tests-functional.yml
+++ b/.github/workflows/tests-functional.yml
@@ -127,7 +127,7 @@ jobs:
 
         sudo env "PATH=$PATH" go test -v \
           -coverprofile=out/testResults/lib.cov -covermode count \
-          -timeout 60m \
+          -timeout 90m \
           ./pkg/imagecustomizerlib \
           -args \
           --base-image-core-efi-azl2 "../../$AZL2_VHDX" \


### PR DESCRIPTION
Boost the test suite timeout to avoid the tests failing while they are still running.

---

### **Checklist**
- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
