### PR TITLE
Disable ARM64 tests that need systemd-boot.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput_test.go
@@ -3,6 +3,7 @@ package imagecustomizerlib
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -22,6 +23,10 @@ func TestOutputAndInjectArtifacts(t *testing.T) {
 	assert.NoError(t, err)
 	if !ukifyExists {
 		t.Skip("The 'ukify' command is not available")
+	}
+
+	if runtime.GOARCH == "arm64" {
+		t.Skip("systemd-boot not available on AZL3 ARM64 yet")
 	}
 
 	testTempDir := filepath.Join(tmpDir, "TestOutputAndInjectArtifacts")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
@@ -5,6 +5,7 @@ package imagecustomizerlib
 
 import (
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/microsoft/azurelinux/toolkit/tools/imagegen/diskutils"
@@ -22,6 +23,10 @@ func TestCustomizeImageVerityUsrUki(t *testing.T) {
 	assert.NoError(t, err)
 	if !ukifyExists {
 		t.Skip("The 'ukify' command is not available")
+	}
+
+	if runtime.GOARCH == "arm64" {
+		t.Skip("systemd-boot not available on AZL3 ARM64 yet")
 	}
 
 	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageUsrVerityUki")


### PR DESCRIPTION
The systemd-boot package is not available yet on Azure Linux 3.0 for ARM64. So, disable the tests that need systemd-boot.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
