### PR TITLE
add tmpfs to the default chroot mount options

### DIFF
--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -678,6 +678,11 @@ func defaultMountPoints() []*MountPoint {
 			fstype: "devpts",
 			data:   "gid=5,mode=620",
 		},
+		{
+			target: "/tmp",
+			fstype: "tmpfs",
+			data:   "mode=1777",
+		},
 	}
 }
 


### PR DESCRIPTION
<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

This pull request updates the default chroot mount options to include tmpfs. By adding tmpfs to the default mount configuration, temporary file storage within the chroot environment will use a memory-backed filesystem, which can improve performance and enhance security by ensuring that temporary files do not persist on disk.

**Key changes:**
- Adds tmpfs to the default set of mount options for chroot environments.
- Ensures that temporary files created within chroot are stored in memory, reducing disk usage and improving cleanup after chroot teardown.
- May help with environments that require ephemeral storage for build or testing workflows.

This change is intended to optimize the performance and security of the chroot environments managed by the tool.


### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] Code conforms to style guidelines
