### PR TITLE
Workaround 'sudo' problem in GitHub workflows.

### DIFF
--- a/.github/workflows/tests-vmtests-osmodifier.yml
+++ b/.github/workflows/tests-vmtests-osmodifier.yml
@@ -96,7 +96,7 @@ jobs:
 
           CONTAINER_TAR_PATH="out/container-$HOST_ARCH/imagecustomizer.tar.gz"
           DOCKER_OUTPUT=$(sudo docker image load -i "$CONTAINER_TAR_PATH" 2>&1)
-          CONTAINER_TAG=$(echo $DOCKER_OUTPUT | awk '{print $3}')
+          CONTAINER_TAG=$(echo "$DOCKER_OUTPUT" | grep "Loaded image: " | awk '{print $3}')
 
           echo "containerTag=$CONTAINER_TAG" >> "$GITHUB_OUTPUT"
         env:

--- a/.github/workflows/tests-vmtests.yml
+++ b/.github/workflows/tests-vmtests.yml
@@ -113,7 +113,7 @@ jobs:
 
         CONTAINER_TAR_PATH="out/container-$HOST_ARCH/imagecustomizer.tar.gz"
         DOCKER_OUTPUT=$(sudo docker image load -i "$CONTAINER_TAR_PATH" 2>&1)
-        CONTAINER_TAG=$(echo $DOCKER_OUTPUT | awk '{print $3}')
+        CONTAINER_TAG=$(echo "$DOCKER_OUTPUT" | grep "Loaded image: " | awk '{print $3}')
 
         echo "containerTag=$CONTAINER_TAG" >> "$GITHUB_OUTPUT"
       env:


### PR DESCRIPTION
The GitHub workflows are experiencing the error: "sudo: unable to resolve host 8e70e4e9c000000: Name or service not known" when the `sudo` command is used. This is polluting the stderr, which can cause problems when parsing output of `docker image load` command. Workaround this problem by making the output parsing more robust.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines

Workflow run: https://github.com/microsoft/azure-linux-image-tools/actions/runs/17248144085
