### PR TITLE
unique vm test job names

### DIFF
--- a/.github/workflows/tests-functional.yml
+++ b/.github/workflows/tests-functional.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   tests-functional:
-    name: Functional test suite
+    name: Functional test suite - ${{ inputs.hostDistro }} ${{ inputs.hostArch }}
     runs-on:
     - self-hosted
     - 1ES.Pool=${{ inputs.hostDistro == 'azl3' && (inputs.hostArch == 'amd64' && 'maritimus-github-runner-azl3-amd64' || 'maritimus-github-runner-azl3-arm64') || (inputs.hostArch == 'amd64' && 'maritimus-github-runner-ubuntu2404-amd64' || 'maritimus-github-runner-ubuntu2404-arm64') }}

--- a/.github/workflows/tests-vmtests-imagecreator.yml
+++ b/.github/workflows/tests-vmtests-imagecreator.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   tests-vmtests:
-    name: Tests VMTests suite
+    name: Tests VMTests Image Creator suite - ${{ inputs.hostDistro }} ${{ inputs.hostArch }}
     runs-on:
     - self-hosted
     - 1ES.Pool=${{ inputs.hostDistro == 'azl3' && (inputs.hostArch == 'amd64' && 'maritimus-github-runner-azl3-amd64' || 'maritimus-github-runner-azl3-arm64') || (inputs.hostArch == 'amd64' && 'maritimus-github-runner-ubuntu2404-amd64' || 'maritimus-github-runner-ubuntu2404-arm64') }}

--- a/.github/workflows/tests-vmtests-osmodifier.yml
+++ b/.github/workflows/tests-vmtests-osmodifier.yml
@@ -20,7 +20,7 @@ env:
 
 jobs:
   tests-osmodifier:
-    name: Tests VMTests suite
+    name: Tests VMTests OSModifier suite - ${{ inputs.hostDistro }} ${{ inputs.hostArch }}
     runs-on:
       - self-hosted
       - 1ES.Pool=${{ inputs.hostDistro == 'azl3' && (inputs.hostArch == 'amd64' && 'maritimus-github-runner-azl3-amd64' || 'maritimus-github-runner-azl3-arm64') || (inputs.hostArch == 'amd64' && 'maritimus-github-runner-ubuntu2404-amd64' || 'maritimus-github-runner-ubuntu2404-arm64') }}

--- a/.github/workflows/tests-vmtests.yml
+++ b/.github/workflows/tests-vmtests.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   tests-vmtests:
-    name: Tests VMTests suite
+    name: Tests VMTests suite - ${{ inputs.hostDistro }} ${{ inputs.hostArch }}
     runs-on:
     - self-hosted
     - 1ES.Pool=${{ inputs.hostDistro == 'azl3' && (inputs.hostArch == 'amd64' && 'maritimus-github-runner-azl3-amd64' || 'maritimus-github-runner-azl3-arm64') || (inputs.hostArch == 'amd64' && 'maritimus-github-runner-ubuntu2404-amd64' || 'maritimus-github-runner-ubuntu2404-arm64') }}


### PR DESCRIPTION
<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

This PR updates the VM test jobs to use unique names for each job instance. By assigning distinct identifiers to each VM test job, we avoid conflicts and make it easier to track job executions and results, especially when running multiple tests in parallel or rerunning workflows.

#### Changes included:
- Generates unique names for VM test jobs in the workflow files/scripts.
- Improves traceability and clarity in logs and test results.
- Reduces job name collisions that could previously cause confusion or workflow failures.

---

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] Code conforms to style guidelines
