### PR TITLE
Revert: Image Customizer: assign a randomly generated label to the ISO media

### DIFF
--- a/toolkit/tools/internal/isogenerator/isogenerator.go
+++ b/toolkit/tools/internal/isogenerator/isogenerator.go
@@ -71,7 +71,7 @@ func GenerateIso(config IsoGenConfig) error {
 	}
 
 	err = BuildIsoImage(config.StagingDirPath, config.EnableBiosBoot, config.IsoOsFilesDirPath,
-		DefaultVolumeId, config.OutputFilePath)
+		config.OutputFilePath)
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func GenerateIso(config IsoGenConfig) error {
 	return nil
 }
 
-func BuildIsoImage(stagingPath string, enableBiosBoot bool, isoOsFilesDirPath string, volumeId string, outputImagePath string) error {
+func BuildIsoImage(stagingPath string, enableBiosBoot bool, isoOsFilesDirPath string, outputImagePath string) error {
 	logger.Log.Infof("Creating ISO image: %s", outputImagePath)
 
 	// For detailed parameter explanation see: https://linux.die.net/man/8/mkisofs.
@@ -88,7 +88,7 @@ func BuildIsoImage(stagingPath string, enableBiosBoot bool, isoOsFilesDirPath st
 
 	mkisofsArgs = append(mkisofsArgs,
 		// General mkisofs parameters.
-		"-R", "-l", "-D", "-J", "-joliet-long", "-o", outputImagePath, "-V", volumeId)
+		"-R", "-l", "-D", "-J", "-joliet-long", "-o", outputImagePath, "-V", DefaultVolumeId)
 
 	if enableBiosBoot {
 		mkisofsArgs = append(mkisofsArgs,

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -718,11 +718,6 @@ func convertWriteableFormatToOutputImage(ctx context.Context, ic *ImageCustomize
 
 		rebuildFullOsImage := ic.customizeOSPartitions || inputIsoArtifacts == nil || convertInitramfsType || kdumpBootFileChanging
 
-		isoVolumeId, err := generateIsoLabel()
-		if err != nil {
-			return fmt.Errorf("failed to generate ISO label.\n%w", err)
-		}
-
 		// Either re-build the full OS image, or just re-package the existing one
 		if rebuildFullOsImage {
 			requestedSELinuxMode := imagecustomizerapi.SELinuxModeDefault
@@ -730,13 +725,13 @@ func convertWriteableFormatToOutputImage(ctx context.Context, ic *ImageCustomize
 				requestedSELinuxMode = ic.config.OS.SELinux.Mode
 			}
 			err := createLiveOSFromRaw(ctx, ic.buildDirAbs, ic.configPath, inputIsoArtifacts, requestedSELinuxMode,
-				ic.config.Iso, ic.config.Pxe, ic.rawImageFile, ic.outputImageFormat, isoVolumeId, ic.outputImageFile)
+				ic.config.Iso, ic.config.Pxe, ic.rawImageFile, ic.outputImageFormat, ic.outputImageFile)
 			if err != nil {
 				return fmt.Errorf("%w:\n%w", ErrCreateLiveOSArtifacts, err)
 			}
 		} else {
 			err := repackageLiveOS(ic.buildDirAbs, ic.configPath, ic.config.Iso, ic.config.Pxe,
-				inputIsoArtifacts, ic.outputImageFormat, isoVolumeId, ic.outputImageFile)
+				inputIsoArtifacts, ic.outputImageFormat, ic.outputImageFile)
 			if err != nil {
 				return fmt.Errorf("%w:\n%w", ErrCreateLiveOSArtifacts, err)
 			}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -129,7 +129,7 @@ func populateWriteableRootfsDir(sourceDir, writeableRootfsDir string) error {
 }
 
 func createLiveOSFromRaw(ctx context.Context, buildDir, baseConfigPath string, inputArtifactsStore *IsoArtifactsStore, requestedSelinuxMode imagecustomizerapi.SELinuxMode,
-	isoConfig *imagecustomizerapi.Iso, pxeConfig *imagecustomizerapi.Pxe, rawImageFile string, outputFormat imagecustomizerapi.ImageFormatType, volumeId string,
+	isoConfig *imagecustomizerapi.Iso, pxeConfig *imagecustomizerapi.Pxe, rawImageFile string, outputFormat imagecustomizerapi.ImageFormatType,
 	outputPath string,
 ) (err error) {
 	logger.Log.Infof("Creating Live OS artifacts using customized full OS image")
@@ -139,7 +139,7 @@ func createLiveOSFromRaw(ctx context.Context, buildDir, baseConfigPath string, i
 		return fmt.Errorf("failed to build live OS configuration from input configuration:\n%w", err)
 	}
 
-	err = createLiveOSFromRawHelper(ctx, buildDir, baseConfigPath, inputArtifactsStore, requestedSelinuxMode, liveosConfig, rawImageFile, outputFormat, volumeId, outputPath)
+	err = createLiveOSFromRawHelper(ctx, buildDir, baseConfigPath, inputArtifactsStore, requestedSelinuxMode, liveosConfig, rawImageFile, outputFormat, outputPath)
 	if err != nil {
 		return fmt.Errorf("failed to create live OS artifacts:\n%w", err)
 	}
@@ -148,7 +148,7 @@ func createLiveOSFromRaw(ctx context.Context, buildDir, baseConfigPath string, i
 }
 
 func repackageLiveOS(isoBuildDir string, baseConfigPath string, isoConfig *imagecustomizerapi.Iso, pxeConfig *imagecustomizerapi.Pxe,
-	inputArtifactsStore *IsoArtifactsStore, outputFormat imagecustomizerapi.ImageFormatType, volumeId string, outputPath string,
+	inputArtifactsStore *IsoArtifactsStore, outputFormat imagecustomizerapi.ImageFormatType, outputPath string,
 ) error {
 	logger.Log.Infof("Creating Live OS artifacts using input ISO image")
 
@@ -157,7 +157,7 @@ func repackageLiveOS(isoBuildDir string, baseConfigPath string, isoConfig *image
 		return fmt.Errorf("failed to build live OS configuration from input configuration:\n%w", err)
 	}
 
-	err = repackageLiveOSHelper(isoBuildDir, baseConfigPath, liveosConfig, inputArtifactsStore, outputFormat, volumeId, outputPath)
+	err = repackageLiveOSHelper(isoBuildDir, baseConfigPath, liveosConfig, inputArtifactsStore, outputFormat, outputPath)
 	if err != nil {
 		return fmt.Errorf("failed to create live OS artifacts:\n%w", err)
 	}
@@ -181,7 +181,7 @@ func isIsoBootImageNeeded(outputFormat imagecustomizerapi.ImageFormatType, initr
 }
 
 func createLiveOSFromRawHelper(ctx context.Context, buildDir, baseConfigPath string, inputArtifactsStore *IsoArtifactsStore, requestedSelinuxMode imagecustomizerapi.SELinuxMode,
-	liveosConfig LiveOSConfig, rawImageFile string, outputFormat imagecustomizerapi.ImageFormatType, volumeId string,
+	liveosConfig LiveOSConfig, rawImageFile string, outputFormat imagecustomizerapi.ImageFormatType,
 	outputPath string,
 ) (err error) {
 	isoBuildDir := filepath.Join(buildDir, "liveosbuild")
@@ -265,7 +265,7 @@ func createLiveOSFromRawHelper(ctx context.Context, buildDir, baseConfigPath str
 	}
 
 	// Update grub.cfg
-	err = updateGrubCfg(artifactsStore.files.isoGrubCfgPath, outputFormat, volumeId, liveosConfig.initramfsType, disableSELinux,
+	err = updateGrubCfg(artifactsStore.files.isoGrubCfgPath, outputFormat, liveosConfig.initramfsType, disableSELinux,
 		updatedSavedConfigs, getKernelVersions(artifactsStore.files), artifactsStore.files.isoGrubCfgPath,
 		artifactsStore.files.pxeGrubCfgPath)
 	if err != nil {
@@ -318,7 +318,7 @@ func createLiveOSFromRawHelper(ctx context.Context, buildDir, baseConfigPath str
 	switch outputFormat {
 	case imagecustomizerapi.ImageFormatTypeIso:
 		err := createIsoImage(isoBuildDir, baseConfigPath, liveosConfig.initramfsType, artifactsStore.files,
-			liveosConfig.kdumpBootFiles, liveosConfig.additionalFiles, volumeId, outputPath)
+			liveosConfig.kdumpBootFiles, liveosConfig.additionalFiles, outputPath)
 		if err != nil {
 			return fmt.Errorf("failed to create the Iso image\n%w", err)
 		}
@@ -335,7 +335,7 @@ func createLiveOSFromRawHelper(ctx context.Context, buildDir, baseConfigPath str
 }
 
 func repackageLiveOSHelper(isoBuildDir string, baseConfigPath string, liveosConfig LiveOSConfig, inputArtifactsStore *IsoArtifactsStore,
-	outputFormat imagecustomizerapi.ImageFormatType, volumeId string, outputPath string,
+	outputFormat imagecustomizerapi.ImageFormatType, outputPath string,
 ) error {
 	// Note that in this ISO build flow, there is no os configuration, and hence
 	// no selinux configuration. So, we will set it to default (i.e. unspecified)
@@ -358,7 +358,7 @@ func repackageLiveOSHelper(isoBuildDir string, baseConfigPath string, liveosConf
 	disableSELinux := false
 
 	// Update grub.cfg
-	err = updateGrubCfg(inputArtifactsStore.files.isoGrubCfgPath, outputFormat, volumeId, liveosConfig.initramfsType, disableSELinux,
+	err = updateGrubCfg(inputArtifactsStore.files.isoGrubCfgPath, outputFormat, liveosConfig.initramfsType, disableSELinux,
 		updatedSavedConfigs, getKernelVersions(inputArtifactsStore.files), inputArtifactsStore.files.isoGrubCfgPath,
 		inputArtifactsStore.files.pxeGrubCfgPath)
 	if err != nil {
@@ -369,7 +369,7 @@ func repackageLiveOSHelper(isoBuildDir string, baseConfigPath string, liveosConf
 	switch outputFormat {
 	case imagecustomizerapi.ImageFormatTypeIso:
 		err := createIsoImage(isoBuildDir, baseConfigPath, liveosConfig.initramfsType, inputArtifactsStore.files,
-			liveosConfig.kdumpBootFiles, liveosConfig.additionalFiles, volumeId, outputPath)
+			liveosConfig.kdumpBootFiles, liveosConfig.additionalFiles, outputPath)
 		if err != nil {
 			return fmt.Errorf("failed to create the Iso image\n%w", err)
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoimages.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoimages.go
@@ -416,7 +416,7 @@ func stageLiveOSFiles(initramfsType imagecustomizerapi.InitramfsImageType, outpu
 
 func createIsoImage(buildDir string, baseConfigPath string, initramfsType imagecustomizerapi.InitramfsImageType, filesStore *IsoFilesStore,
 	kdumpBootFiles *imagecustomizerapi.KdumpBootFilesType, additionalIsoFiles imagecustomizerapi.AdditionalFileList,
-	volumeId string, outputImagePath string) error {
+	outputImagePath string) error {
 	stagingDir := filepath.Join(buildDir, "iso-staging")
 
 	err := stageLiveOSFiles(initramfsType, imagecustomizerapi.ImageFormatTypeIso, filesStore,
@@ -427,7 +427,7 @@ func createIsoImage(buildDir string, baseConfigPath string, initramfsType imagec
 
 	biosBootEnabled := false
 	biosFilesDirPath := ""
-	err = isogenerator.BuildIsoImage(stagingDir, biosBootEnabled, biosFilesDirPath, volumeId, outputImagePath)
+	err = isogenerator.BuildIsoImage(stagingDir, biosBootEnabled, biosFilesDirPath, outputImagePath)
 	if err != nil {
 		return fmt.Errorf("failed to create (%s) using the (%s) folder:\n%w", outputImagePath, stagingDir, err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoutils.go
@@ -7,9 +7,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
-	"strings"
 
-	"github.com/microsoft/azurelinux/toolkit/tools/internal/randomization"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/safeloopback"
 	"github.com/microsoft/azurelinux/toolkit/tools/internal/safemount"
 	"golang.org/x/sys/unix"
@@ -241,12 +239,4 @@ func extractIsoImageContents(buildDir string, isoImageFile string, isoExpansionF
 	}
 
 	return nil
-}
-
-func generateIsoLabel() (string, error) {
-	_, isoVolumeId, err := randomization.CreateUuid()
-	if err != nil {
-		return "", err
-	}
-	return strings.ReplaceAll(isoVolumeId, "-", ""), nil
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/liveospxe.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveospxe.go
@@ -88,16 +88,11 @@ func createPXEArtifacts(buildDir string, outputFormat imagecustomizerapi.ImageFo
 			return err
 		}
 
-		isoVolumeId, err := generateIsoLabel()
-		if err != nil {
-			return fmt.Errorf("failed to generate ISO label.\n%w", err)
-		}
-
 		// The iso image file itself must be placed in the PXE folder because
 		// dracut livenet module will download it.
 		artifactsIsoImagePath := filepath.Join(outputPXEArtifactsDir, isoImageName)
 		err = createIsoImage(buildDir, baseConfigPath, imagecustomizerapi.InitramfsImageTypeBootstrap,
-			artifactsStore.files, kdumpBootFiles, additionalIsoFiles, isoVolumeId, artifactsIsoImagePath)
+			artifactsStore.files, kdumpBootFiles, additionalIsoFiles, artifactsIsoImagePath)
 		if err != nil {
 			return fmt.Errorf("failed to create the Iso image.\n%w", err)
 		}


### PR DESCRIPTION
This change (cd6e5cf6a551ad5c3e2dcb4ffd87f6785618464b) seems to have caused failures in our internal pipelines.

We are reverting until we root cause the issue.