### PR TITLE
Improve container file paths.

### DIFF
--- a/test/vmtests/vmtests/utils/imagecustomizer.py
+++ b/test/vmtests/vmtests/utils/imagecustomizer.py
@@ -75,8 +75,6 @@ def run_image_customizer(
         "AZURE_MONITOR_CONNECTION_STRING": AZURE_CONN_STR,
     }
 
-    entrypoint = "/usr/local/bin/entrypoint.sh"
-
     container_run(
         docker_client,
         image_customizer_container_url,
@@ -85,7 +83,6 @@ def run_image_customizer(
         privileged=True,
         volumes=volumes,
         environment=environment,
-        entrypoint=entrypoint,
     )
 
 

--- a/toolkit/tools/imagecustomizer/container/build-container.sh
+++ b/toolkit/tools/imagecustomizer/container/build-container.sh
@@ -76,21 +76,23 @@ telemetryScript="$enlistmentRoot/toolkit/scripts/telemetry_hopper/telemetry_hopp
 telemetryRequirements="$enlistmentRoot/toolkit/scripts/telemetry_hopper/requirements.txt"
 entrypointScript="$scriptDir/entrypoint.sh"
 
-stagingBinDir="${containerStagingFolder}/usr/local/bin"
-stagingLicensesDir="${containerStagingFolder}/usr/local/share/licenses"
+stagingBinDir="${containerStagingFolder}/usr/bin"
+stagingLibDir="${containerStagingFolder}/usr/lib/imagecustomizer"
+stagingLicensesDir="${containerStagingFolder}/usr/share/licenses"
 
 dockerFile="$scriptDir/imagecustomizer.Dockerfile"
 runScriptPath="$scriptDir/run.sh"
 
 # stage those files that need to be in the container
 mkdir -p "${stagingBinDir}"
+mkdir -p "${stagingLibDir}"
 mkdir -p "${stagingLicensesDir}"
 
 cp "$exeFile" "${stagingBinDir}"
-cp "$runScriptPath" "${stagingBinDir}"
+cp "$runScriptPath" "${stagingLibDir}"
 cp -R "$licensesDir" "${stagingLicensesDir}"
-cp "$telemetryScript" "${stagingBinDir}"
-cp "$entrypointScript" "${stagingBinDir}"
+cp "$telemetryScript" "${stagingLibDir}"
+cp "$entrypointScript" "${stagingLibDir}"
 
 cp "$telemetryRequirements" "${containerStagingFolder}"/telemetry-requirements.txt
 

--- a/toolkit/tools/imagecustomizer/container/entrypoint.sh
+++ b/toolkit/tools/imagecustomizer/container/entrypoint.sh
@@ -21,8 +21,8 @@ if [[ "$ENABLE_TELEMETRY" == "true" ]] && [[ -n "$AZURE_MONITOR_CONNECTION_STRIN
     export OTEL_PORT=4317
     export OTEL_EXPORTER_OTLP_PROTOCOL="grpc"
     export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:${OTEL_PORT}"
-    
-    /opt/telemetry-venv/bin/python /usr/local/bin/telemetry_hopper.py --port $OTEL_PORT > /var/log/image_customizer_telemetry.log 2>&1 || true &
+
+    /usr/lib/imagecustomizer/telemetry-venv/bin/python /usr/lib/imagecustomizer/telemetry_hopper.py --port $OTEL_PORT > /var/log/image_customizer_telemetry.log 2>&1 || true &
     sleep 1
 fi
 

--- a/toolkit/tools/imagecustomizer/container/imagecustomizer.Dockerfile
+++ b/toolkit/tools/imagecustomizer/container/imagecustomizer.Dockerfile
@@ -19,12 +19,12 @@ RUN tdnf update -y && \
    tdnf clean all
 
 # Create virtual environment and install Python dependencies for telemetry
-RUN python3 -m venv /opt/telemetry-venv
-COPY telemetry-requirements.txt /telemetry-requirements.txt
-RUN /opt/telemetry-venv/bin/pip install --no-cache-dir -r /telemetry-requirements.txt
-RUN rm -rf /telemetry-requirements.txt
+RUN python3 -m venv /usr/lib/imagecustomizer/telemetry-venv
+COPY telemetry-requirements.txt /usr/lib/imagecustomizer/telemetry-requirements.txt
+RUN /usr/lib/imagecustomizer/telemetry-venv/bin/pip install --no-cache-dir -r /usr/lib/imagecustomizer/telemetry-requirements.txt
+RUN rm -rf /usr/lib/imagecustomizer/telemetry-requirements.txt
 
 # Copy all necessary files
 COPY usr /usr
 
-ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+ENTRYPOINT ["/usr/lib/imagecustomizer/entrypoint.sh"]

--- a/toolkit/tools/imagecustomizer/container/run.sh
+++ b/toolkit/tools/imagecustomizer/container/run.sh
@@ -152,8 +152,8 @@ if [[ "$ENABLE_TELEMETRY" == "true" ]] && [[ -n "$AZURE_MONITOR_CONNECTION_STRIN
     export OTEL_PORT=4317
     export OTEL_EXPORTER_OTLP_PROTOCOL="grpc"
     export OTEL_EXPORTER_OTLP_ENDPOINT="http://localhost:${OTEL_PORT}"
-    
-    /opt/telemetry-venv/bin/python /usr/local/bin/telemetry_hopper.py --port $OTEL_PORT > /var/log/image_customizer_telemetry.log 2>&1 || true &
+
+    /usr/lib/imagecustomizer/telemetry-venv/bin/python /usr/lib/imagecustomizer/telemetry_hopper.py --port $OTEL_PORT > /var/log/image_customizer_telemetry.log 2>&1 || true &
     sleep 1
 fi
 

--- a/toolkit/tools/imagecustomizer/container/test-container.sh
+++ b/toolkit/tools/imagecustomizer/container/test-container.sh
@@ -28,7 +28,7 @@ docker run --rm \
     -v "$inputConfigDir":"$containerInputConfigDir":z \
     -v "$outputImageDir":"$containerOutputDir":z \
     -v /dev:/dev \
-    --entrypoint /usr/local/bin/run.sh \
+    --entrypoint /usr/lib/imagecustomizer/run.sh \
     "$containerTag" \
         "3.0.latest" \
         --config-file "$containerInputConfig" \


### PR DESCRIPTION
Move the files within the container to more appropriate directories.

Specifically, place all miscellaneous files under `/usr/lib/imagecustomizer`. Also, don't use `local` directory to keep the paths consistent with the RPM in the [azurelinux](https://github.com/microsoft/azurelinux) repo.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
