### PR TITLE
Improve error messages.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
@@ -228,7 +228,7 @@ func TestCustomizeImagePackagesDiskSpace(t *testing.T) {
 	// Customize image.
 	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
 		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
-	assert.ErrorContains(t, err, "failed to customize raw image")
+	assert.ErrorContains(t, err, "failed to customize OS")
 	assert.ErrorContains(t, err, "failed to install packages (packages=[gcc])")
 }
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitions.go
@@ -5,12 +5,18 @@ package imagecustomizerlib
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/logger"
 	"go.opentelemetry.io/otel"
+)
+
+var (
+	ErrPartitionsCustomize  = NewImageCustomizerError("Partitions:Customize", "failed to customize partitions")
+	ErrPartitionsResetUuids = NewImageCustomizerError("Partitions:ResetUuids", "failed to reset partition UUIDs")
 )
 
 func customizePartitions(ctx context.Context, buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
@@ -31,7 +37,7 @@ func customizePartitions(ctx context.Context, buildDir string, baseConfigPath st
 			buildImageFile, newBuildImageFile)
 		if err != nil {
 			os.Remove(newBuildImageFile)
-			return false, "", nil, err
+			return false, "", nil, fmt.Errorf("%w:\n%w", ErrPartitionsCustomize, err)
 		}
 
 		return true, newBuildImageFile, partIdToPartUuid, nil
@@ -39,7 +45,7 @@ func customizePartitions(ctx context.Context, buildDir string, baseConfigPath st
 	case config.Storage.ResetPartitionsUuidsType != imagecustomizerapi.ResetPartitionsUuidsTypeDefault:
 		err := resetPartitionsUuids(ctx, buildImageFile, buildDir)
 		if err != nil {
-			return false, "", nil, err
+			return false, "", nil, fmt.Errorf("%w:\n%w", ErrPartitionsResetUuids, err)
 		}
 
 		return true, buildImageFile, nil, nil

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -1052,13 +1052,19 @@ func testConvertImageToRawSuccess(t *testing.T, testName string, qemuImgArgs []s
 func TestCustomizeImageBaseImageMissing(t *testing.T) {
 	testutils.CheckSkipForCustomizeImageRequirements(t)
 
+	qemuimgExists, err := file.CommandExists("qemu-img")
+	assert.NoError(t, err)
+	if !qemuimgExists {
+		t.Skip("The 'qemu-img' command is not available")
+	}
+
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageBaseImageMissing")
 	buildDir := filepath.Join(testTmpDir, "build")
 	configFile := filepath.Join(testDir, "partitions-config.yaml")
 	baseImage := filepath.Join(testTmpDir, "missing.qcow2")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath,
+	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath,
 		"raw", false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	assert.ErrorContains(t, err, "no such file or directory")
 }
@@ -1066,13 +1072,19 @@ func TestCustomizeImageBaseImageMissing(t *testing.T) {
 func TestCustomizeImageBaseImageInvalid(t *testing.T) {
 	testutils.CheckSkipForCustomizeImageRequirements(t)
 
+	qemuimgExists, err := file.CommandExists("qemu-img")
+	assert.NoError(t, err)
+	if !qemuimgExists {
+		t.Skip("The 'qemu-img' command is not available")
+	}
+
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageBaseImageInvalid")
 	buildDir := filepath.Join(testTmpDir, "build")
 	configFile := filepath.Join(testDir, "partitions-config.yaml")
 	baseImage := configFile
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath,
+	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath,
 		"raw", false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	assert.ErrorContains(t, err, "failed to open image file:")
 	assert.ErrorContains(t, err, "image does not contain a partition table")

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -1049,6 +1049,35 @@ func testConvertImageToRawSuccess(t *testing.T, testName string, qemuImgArgs []s
 	assert.Equal(t, int64(diskSize), testRawFileStat.Size())
 }
 
+func TestCustomizeImageBaseImageMissing(t *testing.T) {
+	testutils.CheckSkipForCustomizeImageRequirements(t)
+
+	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageBaseImageMissing")
+	buildDir := filepath.Join(testTmpDir, "build")
+	configFile := filepath.Join(testDir, "partitions-config.yaml")
+	baseImage := filepath.Join(testTmpDir, "missing.qcow2")
+	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
+
+	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath,
+		"raw", false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	assert.ErrorContains(t, err, "no such file or directory")
+}
+
+func TestCustomizeImageBaseImageInvalid(t *testing.T) {
+	testutils.CheckSkipForCustomizeImageRequirements(t)
+
+	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageBaseImageInvalid")
+	buildDir := filepath.Join(testTmpDir, "build")
+	configFile := filepath.Join(testDir, "partitions-config.yaml")
+	baseImage := configFile
+	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
+
+	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath,
+		"raw", false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	assert.ErrorContains(t, err, "failed to open image file:")
+	assert.ErrorContains(t, err, "image does not contain a partition table")
+}
+
 func checkFileType(t *testing.T, filePath string, expectedFileType string) {
 	fileType, err := testutils.GetImageFileType(filePath)
 	assert.NoError(t, err)

--- a/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
@@ -34,7 +34,7 @@ func connectToExistingImage(ctx context.Context, imageFilePath string, buildDir 
 		imageFilePath, buildDir, chrootDirName, includeDefaultMounts, readonly, readOnlyVerity, ignoreOverlays)
 	if err != nil {
 		imageConnection.Close()
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, nil, fmt.Errorf("failed to open image file:\n%w", err)
 	}
 
 	return imageConnection, partUuidToMountPath, verityMetadata, readonlyPartUuids, nil
@@ -48,6 +48,15 @@ func connectToExistingImageHelper(imageConnection *imageconnection.ImageConnecti
 	err := imageConnection.ConnectLoopback(imageFilePath)
 	if err != nil {
 		return nil, nil, nil, err
+	}
+
+	partitionTable, err := diskutils.ReadDiskPartitionTable(imageConnection.Loopback().DevicePath())
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("failed to read image's partition table:\n%w", err)
+	}
+
+	if partitionTable == nil {
+		return nil, nil, nil, fmt.Errorf("image does not contain a partition table")
 	}
 
 	partitions, err := diskutils.GetDiskPartitions(imageConnection.Loopback().DevicePath())


### PR DESCRIPTION
Improve the error message when user passes a nonsense file as the base image. Previously, the error was "failed to find rootfs partition". Now, it is "image does not contain a partition table".

Also, add some high-level errors for these operations:

- Partition customization
- Reset partition UUIDs
- OS customization
- Verity provisioning
- Creating UKIs
- Outputting artifacts

These extra errors will make it clearer where in the customization process the error occurred.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines