### PR TITLE
Fix grub2-mkconfig log level.

### DIFF
--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -1457,7 +1457,7 @@ func installGrubTemplateFile(assetFile, targetFile, installRoot, rootDevice, boo
 }
 
 func CallGrubMkconfig(installChroot safechroot.ChrootInterface) (err error) {
-	squashErrors := false
+	squashErrors := true
 
 	ReportActionf("Running grub2-mkconfig...")
 	err = installChroot.UnsafeRun(func() error {


### PR DESCRIPTION
Put the grub2-mkconfig stderr logs in the DEBUG level instead of WARN since its stderr contains more than just errors.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
