### PR TITLE
Support forking before publishing new release.

### DIFF
--- a/.github/workflows/release-minor-version.yml
+++ b/.github/workflows/release-minor-version.yml
@@ -7,7 +7,13 @@ permissions: {}
 
 on:
   # Allow pipeline to be run manually.
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      noPublishRelease:
+        description: Do not publish release (only fork the release branch)
+        required: true
+        type: boolean
+        default: false
 
 jobs:
   build:
@@ -23,6 +29,7 @@ jobs:
 
   publish-container:
     uses: ./.github/workflows/publish-container.yml
+    if: ${{ !(inputs.noPublishRelease || false) }}
     needs:
     - build
     permissions:
@@ -33,6 +40,7 @@ jobs:
 
   publish-release:
     uses: ./.github/workflows/publish-release.yml
+    if: ${{ !(inputs.noPublishRelease || false) }}
     with:
       isLatestRelease: true
     needs:
@@ -61,6 +69,7 @@ jobs:
 
   publish-github-pages:
     uses: ./.github/workflows/publish-github-pages.yml
+    if: ${{ !(inputs.noPublishRelease || false) }}
     needs:
     - build
     permissions:

--- a/.github/workflows/scripts/next_patch_version.py
+++ b/.github/workflows/scripts/next_patch_version.py
@@ -7,19 +7,32 @@ from version_utils import getMakefileVersion, getVersionTags
 
 def main():
     makefileVersion = getMakefileVersion()
+    makefileVersionMgrMin = makefileVersion[0:2]
 
     versions = getVersionTags(merged=True)
-    if len(versions) <= 0:
-        print(f"No previous tags found", file=sys.stderr)
-        exit(2)
 
-    mostRecentVersion = versions[0]
+    mostRecentVersion = None
+    mostRecentVersionMgrMin = None
+    if len(versions) > 0:
+        mostRecentVersion = versions[0]
+        mostRecentVersionMgrMin = mostRecentVersion[0:2]
 
-    if mostRecentVersion[0] != makefileVersion[0] or mostRecentVersion[1] != makefileVersion[1]:
-        print(f"Makefile and most recent major/minor versions don't match: {makefileVersion} vs. {mostRecentVersion}", file=sys.stderr)
+    if mostRecentVersion is not None and makefileVersionMgrMin < mostRecentVersionMgrMin:
+        print(f"Makefile major/minor version is less than most recent major/minor version: "+
+            f"{makefileVersion} vs. {mostRecentVersion}",
+            file=sys.stderr)
         exit(3)
 
-    newPatchVersion = (mostRecentVersion[0], mostRecentVersion[1], mostRecentVersion[2]+1)
+    elif mostRecentVersion is not None and makefileVersionMgrMin == mostRecentVersionMgrMin:
+        # A previous version tag for the current major/minor version exists.
+        # So, increment the patch version.
+        newPatchVersion = (mostRecentVersion[0], mostRecentVersion[1], mostRecentVersion[2]+1)
+
+    else:
+        # A version tag doesn't doesn't exist yet for the current major/minor version.
+        # So, start from patch 0.
+        newPatchVersion = makefileVersion
+
     print(f"{newPatchVersion[0]}.{newPatchVersion[1]}.{newPatchVersion[2]}")
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add support for forking a release branch before doing a release.

Firstly, update the `Release (major/minor)` workflow with an option to not publish the release and only fork the release branch.

Secondly, update the `Release (patch)` workflow's logic that increments the patch version so that it supports the case where no release has occured for the major/minor version yet.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
