### PR TITLE
Fix UKI root verity functional test failure

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
@@ -85,7 +85,7 @@ func TestCustomizeImageVerityRootUki(t *testing.T) {
 		return
 	}
 
-	ukiFilesChecksums, ok := verifyRootVerityUki(t, buildDir, outImageFilePath, nil)
+	_, ok := verifyRootVerityUki(t, buildDir, outImageFilePath, nil)
 	if !ok {
 		return
 	}
@@ -100,7 +100,7 @@ func TestCustomizeImageVerityRootUki(t *testing.T) {
 		return
 	}
 
-	verifyRootVerityUki(t, buildDir, outImageFilePath2, ukiFilesChecksums)
+	verifyRootVerityUki(t, buildDir, outImageFilePath2, nil)
 }
 
 func verifyUsrVerity(t *testing.T, buildDir string, imagePath string, expectedUkiFilesChecksums map[string]string,

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
@@ -267,7 +267,7 @@ func verifyRootVerityUki(t *testing.T, buildDir string, imagePath string, expect
 	rootDevice := testutils.PartitionDevPath(imageConnection, 3)
 	rootHashDevice := testutils.PartitionDevPath(imageConnection, 4)
 	verifyVerityUki(t, espPath, rootDevice, rootHashDevice, "PARTUUID="+partitions[3].PartUuid,
-		"PARTUUID="+partitions[4].PartUuid, "root", buildDir, "rd.info", "panic-on-corruption")
+		"PARTUUID="+partitions[4].PartUuid, "root", buildDir, "", "panic-on-corruption")
 
 	expectedFstabEntries := []diskutils.FstabEntry{
 		{

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-reinit-root-nop.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-reinit-root-nop.yaml
@@ -1,10 +1,15 @@
 previewFeatures:
 - reinitialize-verity
+- uki
 
 storage:
-  reinitializeVerity: none
+  reinitializeVerity: all
 
 os:
+  bootloader:
+    resetType: hard-reset
+  uki:
+    kernels: auto
   additionalFiles:
   - content: |
       cat, dog, elephant, squirrel


### PR DESCRIPTION
<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

For root verity, we cannot make the partition read-only during customization because the resolve config requires write access. Additionally, for the second customization in this functional test case, the UKI won't be carried over, so we need to add extra fields to the MIC config.

---

### **Checklist**
- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines

Test: https://github.com/microsoft/azure-linux-image-tools/actions/runs/17870292411/job/50822285967
See `--- PASS: TestCustomizeImageVerityRootUki (54.22s)`