### PR TITLE
Detect GRUB + xfs + sparse file problem.

### DIFF
--- a/toolkit/tools/internal/file/file.go
+++ b/toolkit/tools/internal/file/file.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/logger"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/shell"
+	"golang.org/x/sys/unix"
 )
 
 // IsDir check if a given file path is a directory.
@@ -446,4 +447,26 @@ func CommandExists(name string) (bool, error) {
 		return false, err
 	}
 	return true, nil
+}
+
+func IsFileSparse(name string) (bool, error) {
+	fd, err := os.Open(name)
+	if err != nil {
+		return false, err
+	}
+	defer fd.Close()
+
+	stat, err := fd.Stat()
+	if err != nil {
+		return false, err
+	}
+
+	holeOffset, err := fd.Seek(0, unix.SEEK_HOLE)
+	if err != nil {
+		return false, err
+	}
+
+	// If there are no holes, then 'holeOffset' will point to the end of the file.
+	isSparse := holeOffset < stat.Size()
+	return isSparse, nil
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
@@ -393,6 +393,29 @@ func testCustomizeImageNewUUIDsHelper(t *testing.T, testName string, baseImageIn
 		baseImageInfo)
 }
 
+func TestCustomizeImageGrubXfsSparse(t *testing.T) {
+	for _, baseImageInfo := range baseImageAll {
+		t.Run(baseImageInfo.Name, func(t *testing.T) {
+			testCustomizeImageGrubXfsSparseHelper(t, "TestCustomizeImageGrubXfsSparse"+baseImageInfo.Name, baseImageInfo)
+		})
+	}
+}
+
+func testCustomizeImageGrubXfsSparseHelper(t *testing.T, testName string, baseImageInfo testBaseImageInfo) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
+
+	testTmpDir := filepath.Join(tmpDir, testName)
+	buildDir := filepath.Join(testTmpDir, "build")
+	configFile := filepath.Join(testDir, "grub-xfs-sparse-kernel.yaml")
+	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
+
+	// Customize image.
+	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
+		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	assert.ErrorContains(t, err, "failed while checking for GRUB + xfs + sparse files problem")
+	assert.ErrorContains(t, err, "GRUB cannot read sparse files on xfs partitions")
+}
+
 func getFilteredFstabEntries(t *testing.T, imageConnection *imageconnection.ImageConnection) []diskutils.FstabEntry {
 	fstabPath := filepath.Join(imageConnection.Chroot().RootDir(), "/etc/fstab")
 	fstabEntries, err := diskutils.ReadFstabFile(fstabPath)

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/grub-xfs-sparse-kernel.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/grub-xfs-sparse-kernel.yaml
@@ -1,0 +1,40 @@
+storage:
+  disks:
+  - partitionTableType: gpt
+    partitions:
+    - id: esp
+      type: esp
+      size: 8M
+
+    - id: rootfs
+      type: root
+      size: 1G
+
+  bootType: efi
+
+  filesystems:
+  - deviceId: esp
+    type: fat32
+    mountPoint:
+      path: /boot/efi
+      options: umask=0077
+
+  - deviceId: rootfs
+    type: xfs
+    mountPoint:
+      path: /
+
+os:
+  bootloader:
+    resetType: hard-reset
+
+scripts:
+  postCustomization:
+  - content: |
+      set -eux
+
+      KERNEL_FILE=$(find /boot -name 'vmlinuz*' | grep -m 1 .)
+      KERNEL_FILE_SIZE=$(du --bytes "$KERNEL_FILE" | cut -d $'\t' -f 1)
+      NEW_FILE_SIZE=$(( $KERNEL_FILE_SIZE + 52428800 ))
+
+      truncate --size "$NEW_FILE_SIZE" "$KERNEL_FILE"


### PR DESCRIPTION
GRUB is unable to read sparse files on an xfs filesystem. So, add logic that fails the build if a file GRUB care about (e.g. kernel or initramfs) is on an XFS filesystem and is sparse.

While this doesn't prevent the underlying problem causing the files to be sparse in the first place, it ensures that the problem results in a build-time error instead of a runtime error.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
