### PR TITLE
Remove temp resources between tests.

### DIFF
--- a/toolkit/tools/pkg/imagecreatorlib/imagecreator_test.go
+++ b/toolkit/tools/pkg/imagecreatorlib/imagecreator_test.go
@@ -16,6 +16,8 @@ func TestCreateImageRaw(t *testing.T) {
 	checkSkipForCreateImage(t, runCreateImageTests)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCreateImageRaw")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	partitionsConfigFile := filepath.Join(testDir, "minimal-os.yaml")
 	outputImageFilePath := filepath.Join(testTmpDir, "image1.raw")
@@ -65,6 +67,8 @@ func TestCreateImageRawNoTar(t *testing.T) {
 	checkSkipForCreateImage(t, runCreateImageTests)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCreateImageRaw")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	partitionsConfigFile := filepath.Join(testDir, "minimal-os.yaml")
 	outputImageFilePath := filepath.Join(testTmpDir, "image1.raw")
@@ -81,6 +85,8 @@ func TestCreateImageRawNoTar(t *testing.T) {
 
 func TestCreateImageEmptyConfig(t *testing.T) {
 	testTmpDir := filepath.Join(tmpDir, "TestCreateImageRaw")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	outputImageFilePath := filepath.Join(testTmpDir, "image1.raw")
 
@@ -99,8 +105,11 @@ func TestCreateImageEmptyConfig(t *testing.T) {
 func TestCreateImage_OutputImageFileAsRelativePath(t *testing.T) {
 	checkSkipForCreateImage(t, runCreateImageTests)
 
-	buildDir := filepath.Join(tmpDir, "TestCreateImage_OutputImageFileAsRelativePathOnCommandLine")
-	baseConfigPath := buildDir
+	testTmpDir := filepath.Join(tmpDir, "TestCreateImage_OutputImageFileAsRelativePathOnCommandLine")
+	defer os.RemoveAll(testTmpDir)
+
+	buildDir := filepath.Join(testTmpDir, "build")
+	baseConfigPath := testTmpDir
 	ConfigPath := filepath.Join(testDir, "minimal-os.yaml")
 	var config imagecustomizerapi.Config
 	err := imagecustomizerapi.UnmarshalYamlFile(ConfigPath, &config)
@@ -146,10 +155,13 @@ func TestCreateImage_OutputImageFileAsRelativePath(t *testing.T) {
 func TestCreateImageCreatorParameters_OutputImageFileSelection(t *testing.T) {
 	checkSkipForCreateImage(t, runCreateImageTests)
 
-	buildDir := filepath.Join(tmpDir, "TestCreateImageCreatorParameters_OutputImageFileSelection")
-	outputImageFilePathAsArg := filepath.Join(buildDir, "image-as-arg.raw")
-	outputImageFilePathAsConfig := filepath.Join(buildDir, "image-as-config.raw")
-	toolsfile := filepath.Join(buildDir, "tools.tar.gz")
+	testTmpDir := filepath.Join(tmpDir, "TestCreateImageCreatorParameters_OutputImageFileSelection")
+	defer os.RemoveAll(testTmpDir)
+
+	buildDir := filepath.Join(testTmpDir, "build")
+	outputImageFilePathAsArg := filepath.Join(testTmpDir, "image-as-arg.raw")
+	outputImageFilePathAsConfig := filepath.Join(testTmpDir, "image-as-config.raw")
+	toolsfile := filepath.Join(testTmpDir, "tools.tar.gz")
 
 	err := os.MkdirAll(buildDir, os.ModePerm)
 	assert.NoError(t, err)
@@ -177,7 +189,7 @@ func TestCreateImageCreatorParameters_OutputImageFileSelection(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, ic.outputImageFile, outputImageFilePathAsConfig)
 	assert.Equal(t, ic.outputImageBase, "image-as-config")
-	assert.Equal(t, ic.outputImageDir, buildDir)
+	assert.Equal(t, ic.outputImageDir, testTmpDir)
 	assert.Equal(t, ic.toolsTar, toolsfile)
 
 	// Pass the output image file only as an argument.
@@ -190,7 +202,7 @@ func TestCreateImageCreatorParameters_OutputImageFileSelection(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, ic.outputImageFile, outputImageFilePathAsArg)
 	assert.Equal(t, ic.outputImageBase, "image-as-arg")
-	assert.Equal(t, ic.outputImageDir, buildDir)
+	assert.Equal(t, ic.outputImageDir, testTmpDir)
 
 	// Pass the output image file in both the config and as an argument.
 	config.Output.Image.Path = outputImageFilePathAsConfig
@@ -201,5 +213,5 @@ func TestCreateImageCreatorParameters_OutputImageFileSelection(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, ic.outputImageFile, outputImageFilePathAsArg)
 	assert.Equal(t, ic.outputImageBase, "image-as-arg")
-	assert.Equal(t, ic.outputImageDir, buildDir)
+	assert.Equal(t, ic.outputImageDir, testTmpDir)
 }

--- a/toolkit/tools/pkg/imagecreatorlib/validation_test.go
+++ b/toolkit/tools/pkg/imagecreatorlib/validation_test.go
@@ -49,7 +49,11 @@ func TestValidateOutput_AcceptsValidPaths(t *testing.T) {
 	cwd, err := os.Getwd()
 	assert.NoError(t, err)
 
-	buildDir := filepath.Join(tmpDir, "TestValidateOutput_AcceptsValidPaths")
+	testTmpDir := filepath.Join(tmpDir, "TestValidateOutput_AcceptsValidPaths")
+	defer os.RemoveAll(testTmpDir)
+
+	buildDir := testTmpDir
+
 	err = os.MkdirAll(buildDir, os.ModePerm)
 	assert.NoError(t, err)
 

--- a/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput_test.go
@@ -38,6 +38,8 @@ func TestOutputAndInjectArtifacts(t *testing.T) {
 	}
 
 	testTempDir := filepath.Join(tmpDir, "TestOutputAndInjectArtifacts")
+	defer os.RemoveAll(testTempDir)
+
 	buildDir := filepath.Join(testTempDir, "build")
 	outImageFilePath := filepath.Join(testTempDir, "image.raw")
 	originalConfigFile := filepath.Join(testDir, "artifacts-output.yaml")
@@ -111,6 +113,8 @@ func TestOutputAndInjectArtifactsCosi(t *testing.T) {
 	}
 
 	testTempDir := filepath.Join(tmpDir, "TestOutputAndInjectArtifacts")
+	defer os.RemoveAll(testTempDir)
+
 	buildDir := filepath.Join(testTempDir, "build")
 	outImageFilePath := filepath.Join(testTempDir, "image.raw")
 	cosiFilePath := filepath.Join(testTempDir, "image.cosi")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizebootloader_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizebootloader_test.go
@@ -4,6 +4,7 @@
 package imagecustomizerlib
 
 import (
+	"os"
 	"path/filepath"
 	"regexp"
 	"testing"
@@ -24,6 +25,8 @@ func testCustomizeImageMultiKernel(t *testing.T, testName string, baseImageInfo 
 	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	testTmpDir := filepath.Join(tmpDir, testName)
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizefiles_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizefiles_test.go
@@ -20,7 +20,10 @@ func TestCopyAdditionalFiles(t *testing.T) {
 		t.Skip("Test must be run as root because it uses a chroot")
 	}
 
-	proposedDir := filepath.Join(tmpDir, "TestCopyAdditionalFiles")
+	testTempDir := filepath.Join(tmpDir, "TestCopyAdditionalFiles")
+	defer os.RemoveAll(testTempDir)
+
+	proposedDir := testTempDir
 	chroot := safechroot.NewChroot(proposedDir, false)
 	baseConfigPath := testDir
 
@@ -75,6 +78,8 @@ func TestCustomizeImageAdditionalFiles(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageAdditionalFiles")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	configFile := filepath.Join(testDir, "addfiles-config.yaml")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
@@ -121,6 +126,8 @@ func TestCustomizeImageAdditionalFilesInfiniteFile(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageAdditionalFilesInfiniteFile")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	configFile := filepath.Join(testDir, "infinite-file-config.yaml")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
@@ -137,7 +144,10 @@ func TestCopyAdditionalDirs(t *testing.T) {
 		t.Skip("Test must be run as root because it uses a chroot")
 	}
 
-	proposedDir := filepath.Join(tmpDir, "TestCopyAdditionalDirs")
+	testTmpDir := filepath.Join(tmpDir, "TestCopyAdditionalDirs")
+	defer os.RemoveAll(testTmpDir)
+
+	proposedDir := testTmpDir
 	chroot := safechroot.NewChroot(proposedDir, false)
 	baseConfigPath := testDir
 
@@ -197,6 +207,8 @@ func TestCustomizeImageAdditionalDirs(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageAdditionalDirs")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	configFile := filepath.Join(testDir, "adddirs-config.yaml")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
@@ -226,6 +238,8 @@ func TestCustomizeImageAdditionalDirsInfiniteFile(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageAdditionalDirsInfiniteFile")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizegroups_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizegroups_test.go
@@ -4,6 +4,7 @@
 package imagecustomizerlib
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -15,6 +16,8 @@ func TestCustomizeImageGroupsExistingGid(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageGroupExistingGid")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 	configFile := filepath.Join(testDir, "user-group-root-gid.yaml")
@@ -29,6 +32,8 @@ func TestCustomizeImageGroupsNewGid(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageGroupNewGid")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 	configFile := filepath.Join(testDir, "user-group-new-gid.yaml")
@@ -62,6 +67,8 @@ func TestCustomizeImageGroupsNew(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageGroupNew")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 	configFile := filepath.Join(testDir, "user-group-new.yaml")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizehostname_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizehostname_test.go
@@ -18,7 +18,10 @@ func TestUpdateHostname(t *testing.T) {
 	}
 
 	// Setup environment.
-	proposedDir := filepath.Join(tmpDir, "TestUpdateHostname")
+	testTmpDir := filepath.Join(tmpDir, "TestUpdateHostname")
+	defer os.RemoveAll(testTmpDir)
+
+	proposedDir := testTmpDir
 	chroot := safechroot.NewChroot(proposedDir, false)
 	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{}, false)
 	assert.NoError(t, err)
@@ -42,6 +45,8 @@ func TestCustomizeImageHostname(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageHostname")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	configFile := filepath.Join(testDir, "hostname-config.yaml")
 	outImageFilePath := filepath.Join(buildDir, "image.qcow2")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeoverlays_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeoverlays_test.go
@@ -5,6 +5,7 @@ package imagecustomizerlib
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -19,6 +20,8 @@ func TestCustomizeImageOverlays(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageOverlays")
+	defer os.RemoveAll(testTempDir)
+
 	buildDir := filepath.Join(testTempDir, "build")
 	outImageFilePath := filepath.Join(testTempDir, "image.raw")
 	configFile := filepath.Join(testDir, "overlays-config.yaml")
@@ -95,6 +98,8 @@ func testCustomizeImageOverlaysSELinuxHelper(t *testing.T, testName string, base
 	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	testTempDir := filepath.Join(tmpDir, testName)
+	defer os.RemoveAll(testTempDir)
+
 	buildDir := filepath.Join(testTempDir, "build")
 	outImageFilePath := filepath.Join(testTempDir, "image.raw")
 	configFile := filepath.Join(testDir, "overlays-selinux.yaml")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
@@ -22,6 +22,7 @@ import (
 
 func TestCustomizeImagePackagesAddOfflineDir(t *testing.T) {
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImagePackagesAddOfflineDir")
+	defer os.RemoveAll(testTmpDir)
 
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 	downloadedRpmsDir := testutils.GetDownloadedRpmsDir(t, testutilsDir, "azurelinux", "2.0", false)
@@ -150,6 +151,7 @@ func TestCustomizeImagePackagesAddOfflineLocalRepoNoGpgKey(t *testing.T) {
 
 func testCustomizeImagePackagesAddOfflineLocalRepoHelper(t *testing.T, testName string, withGpgKey bool) {
 	testTmpDir := filepath.Join(tmpDir, testName)
+	defer os.RemoveAll(testTmpDir)
 
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
@@ -184,6 +186,8 @@ func TestCustomizeImagePackagesUpdate(t *testing.T) {
 	baseImage, baseImageInfo := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImagePackagesUpdate")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
@@ -220,6 +224,8 @@ func TestCustomizeImagePackagesDiskSpace(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImagePackagesDiskSpace")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
@@ -237,6 +243,8 @@ func TestCustomizeImagePackagesUrlSource(t *testing.T) {
 	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImagePackagesUrlSource")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
@@ -268,6 +276,8 @@ func TestCustomizeImagePackagesBadRepo(t *testing.T) {
 	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImagePackagesBadRepo")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
@@ -315,6 +325,7 @@ func ensureTdnfCacheCleanup(t *testing.T, imageConnection *imageconnection.Image
 
 func TestCustomizeImagePackagesSnapshotTime(t *testing.T) {
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImagePackagesSnapshotTime")
+	defer os.RemoveAll(testTmpDir)
 
 	baseImageInfo := testBaseImageAzl3CoreEfi
 	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
@@ -366,6 +377,7 @@ func TestCustomizeImagePackagesSnapshotTime(t *testing.T) {
 
 func TestCustomizeImagePackagesCliSnapshotTimeOverridesConfigFile(t *testing.T) {
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImagePackagesSnapshotTime")
+	defer os.RemoveAll(testTmpDir)
 
 	baseImageInfo := testBaseImageAzl3CoreEfi
 	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
@@ -417,6 +429,7 @@ func TestCustomizeImagePackagesCliSnapshotTimeOverridesConfigFile(t *testing.T) 
 
 func TestCustomizeImagePackagesSnapshotTimeWithoutPreviewFlagFails(t *testing.T) {
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImagePackagesSnapshotTimeWithoutPreviewFlagFails")
+	defer os.RemoveAll(testTmpDir)
 
 	baseImageInfo := testBaseImageAzl3CoreEfi
 	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
@@ -32,6 +32,8 @@ func testCustomizeImagePartitionsToEfi(t *testing.T, testName string, baseImageI
 	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	testTmpDir := filepath.Join(tmpDir, testName)
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	configFile := filepath.Join(testDir, "partitions-config.yaml")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
@@ -124,6 +126,8 @@ func TestCustomizeImagePartitionsSizeOnly(t *testing.T) {
 	baseImage, baseImageInfo := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImagePartitionsSizeOnly")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	configFile := filepath.Join(testDir, "partitions-size-only-config.yaml")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
@@ -207,6 +211,8 @@ func testCustomizeImagePartitionsLegacy(t *testing.T, testName string, baseImage
 	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	testTmpDir := filepath.Join(tmpDir, testName)
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	legacybootConfigFile := filepath.Join(testDir, "legacyboot-config.yaml")
 	efiConfigFile := filepath.Join(testDir, "partitions-config.yaml")
@@ -281,7 +287,10 @@ func TestCustomizeImageKernelCommandLine(t *testing.T) {
 func testCustomizeImageKernelCommandLineHelper(t *testing.T, testName string, baseImageInfo testBaseImageInfo) {
 	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
-	buildDir := filepath.Join(tmpDir, testName)
+	testTmpDir := filepath.Join(tmpDir, testName)
+	defer os.RemoveAll(testTmpDir)
+
+	buildDir := filepath.Join(testTmpDir, "build")
 	configFile := filepath.Join(testDir, "extracommandline-config.yaml")
 	outImageFilePath := filepath.Join(buildDir, "image.qcow2")
 
@@ -317,6 +326,8 @@ func testCustomizeImageNewUUIDsHelper(t *testing.T, testName string, baseImageIn
 	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	testTmpDir := filepath.Join(tmpDir, testName)
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	configFile := filepath.Join(testDir, "newpartitionsuuids-config.yaml")
 	tempRawBaseImage := filepath.Join(testTmpDir, "baseImage.raw")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeselinux_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeselinux_test.go
@@ -5,6 +5,7 @@ package imagecustomizerlib
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"testing"
@@ -27,6 +28,8 @@ func testCustomizeImageSELinuxHelper(t *testing.T, testName string, baseImageInf
 	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	testTmpDir := filepath.Join(tmpDir, testName)
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
@@ -121,6 +124,8 @@ func testCustomizeImageSELinuxAndPartitionsHelper(t *testing.T, testName string,
 	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	testTmpDir := filepath.Join(tmpDir, testName)
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
@@ -171,6 +176,8 @@ func TestCustomizeImageSELinuxNoPolicy(t *testing.T) {
 	baseImage, baseImageInfo := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageSELinuxNoPolicy")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	outImageFilePath := filepath.Join(testTmpDir, "image.qcow2")
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeservices_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeservices_test.go
@@ -4,6 +4,7 @@
 package imagecustomizerlib
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -17,6 +18,8 @@ func TestCustomizeImageServicesEnableDisable(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageServicesEnableDisable")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
@@ -49,6 +52,8 @@ func TestCustomizeImageServicesEnableUnknown(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageServicesEnableUnknown")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
@@ -73,6 +78,8 @@ func TestCustomizeImageServicesDisableUnknown(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageServicesDisableUnknown")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
@@ -4,6 +4,7 @@
 package imagecustomizerlib
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -30,6 +31,8 @@ func TestCustomizeImageVerityUsrUki(t *testing.T) {
 	}
 
 	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageUsrVerityUki")
+	defer os.RemoveAll(testTempDir)
+
 	buildDir := filepath.Join(testTempDir, "build")
 	outImageFilePath := filepath.Join(testTempDir, "image.raw")
 	configFile := filepath.Join(testDir, "verity-usr-uki.yaml")
@@ -74,6 +77,8 @@ func TestCustomizeImageVerityRootUki(t *testing.T) {
 	}
 
 	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageRootVerityUki")
+	defer os.RemoveAll(testTempDir)
+
 	buildDir := filepath.Join(testTempDir, "build")
 	outImageFilePath := filepath.Join(testTempDir, "image.raw")
 	configFile := filepath.Join(testDir, "verity-root-uki.yaml")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeusers_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeusers_test.go
@@ -30,6 +30,8 @@ func TestCustomizeImageUsers(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageUsers")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
@@ -149,6 +151,8 @@ func TestCustomizeImageUsersExitingUserHomeDir(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageUsersExitingUserHomeDir")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
@@ -173,6 +177,8 @@ func TestCustomizeImageUsersExitingUserUid(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageUsersExitingUserUid")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
@@ -197,6 +203,8 @@ func TestCustomizeImageUsersMissingSshPublicKeyFile(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageUsersMissingSshPublicKeyFile")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
@@ -223,6 +231,8 @@ func TestCustomizeImageUsersAddFiles(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageUsersAddFiles")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 	configFile := filepath.Join(testDir, "add-user-files.yaml")
@@ -319,6 +329,7 @@ func TestCustomizeImageUsersExitingUserPassword(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageUsersExitingUserPassword")
+	defer os.RemoveAll(testTmpDir)
 
 	buildDir := filepath.Join(testTmpDir, "build")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
@@ -34,6 +34,8 @@ func testCustomizeImageVerityHelper(t *testing.T, testName string, baseImageInfo
 	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	testTempDir := filepath.Join(tmpDir, testName)
+	defer os.RemoveAll(testTempDir)
+
 	buildDir := filepath.Join(testTempDir, "build")
 	outImageFilePath := filepath.Join(testTempDir, "image.raw")
 	configFile := filepath.Join(testDir, "verity-config.yaml")
@@ -120,6 +122,8 @@ func testCustomizeImageVerityCosiExtractHelper(t *testing.T, testName string, ba
 	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	testTempDir := filepath.Join(tmpDir, testName)
+	defer os.RemoveAll(testTempDir)
+
 	buildDir := filepath.Join(testTempDir, "build")
 	outImageFilePath := filepath.Join(testTempDir, "image.cosi")
 	configFile := filepath.Join(testDir, "verity-partition-labels.yaml")
@@ -343,6 +347,8 @@ func testCustomizeImageVerityUsrHelper(t *testing.T, testName string, baseImageI
 	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	testTempDir := filepath.Join(tmpDir, testName)
+	defer os.RemoveAll(testTempDir)
+
 	buildDir := filepath.Join(testTempDir, "build")
 	outImageFilePath := filepath.Join(testTempDir, "image.raw")
 	configFile := filepath.Join(testDir, "verity-usr-config.yaml")
@@ -424,6 +430,8 @@ func testCustomizeImageVerityUsr2StageHelper(t *testing.T, testName string, base
 	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	testTempDir := filepath.Join(tmpDir, testName)
+	defer os.RemoveAll(testTempDir)
+
 	buildDir := filepath.Join(testTempDir, "build")
 	stage1ConfigFile := filepath.Join(testDir, "verity-2stage-prepare.yaml")
 	stage2ConfigFile := filepath.Join(testDir, "verity-2stage-enable.yaml")
@@ -467,6 +475,8 @@ func testCustomizeImageVerityReinitRootHelper(t *testing.T, testName string, bas
 	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	testTempDir := filepath.Join(tmpDir, testName)
+	defer os.RemoveAll(testTempDir)
+
 	buildDir := filepath.Join(testTempDir, "build")
 	stage1ConfigFile := filepath.Join(testDir, "verity-config.yaml")
 	stage2aConfigFile := filepath.Join(testDir, "verity-reinit.yaml")
@@ -514,6 +524,8 @@ func testCustomizeImageVerityReinitUsrHelper(t *testing.T, testName string, base
 	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	testTempDir := filepath.Join(tmpDir, testName)
+	defer os.RemoveAll(testTempDir)
+
 	buildDir := filepath.Join(testTempDir, "build")
 	stage1ConfigFile := filepath.Join(testDir, "verity-usr-config.yaml")
 	stage2ConfigFile := filepath.Join(testDir, "verity-reinit.yaml")

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
@@ -254,8 +254,10 @@ func TestCustomizeImageNopShrink(t *testing.T) {
 
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
-	configFile := filepath.Join(testDir, "consume-space.yaml")
 	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageNopShrink")
+	defer os.RemoveAll(testTempDir)
+
+	configFile := filepath.Join(testDir, "consume-space.yaml")
 	buildDir := filepath.Join(testTempDir, "build")
 	outImageFilePath := filepath.Join(testTempDir, "image.cosi")
 
@@ -348,6 +350,8 @@ func TestCustomizeImageExtractEmptyPartition(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageExtractEmptyPartition")
+	defer os.RemoveAll(testTempDir)
+
 	buildDir := filepath.Join(testTempDir, "build")
 	configFile := filepath.Join(testDir, "partitions-unformatted-partition.yaml")
 	outImageFilePath := filepath.Join(testTempDir, "image.raw")

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -47,8 +47,11 @@ func TestCustomizeImageEmptyConfig(t *testing.T) {
 
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
-	buildDir := filepath.Join(tmpDir, "TestCustomizeImageEmptyConfig")
-	outImageFilePath := filepath.Join(buildDir, "image.vhd")
+	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageEmptyConfig")
+	defer os.RemoveAll(testTmpDir)
+
+	buildDir := filepath.Join(testTmpDir, "build")
+	outImageFilePath := filepath.Join(testTmpDir, "image.vhd")
 
 	// Customize image.
 	err = CustomizeImage(t.Context(), buildDir, buildDir, &imagecustomizerapi.Config{}, baseImage, nil, outImageFilePath,
@@ -66,6 +69,8 @@ func TestCustomizeImageVhd(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageVhd")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	partitionsConfigFile := filepath.Join(testDir, "partitions-config.yaml")
 	noChangeConfigFile := filepath.Join(testDir, "partitions-config.yaml")
@@ -164,6 +169,7 @@ func TestValidateInput_AcceptsValidPaths(t *testing.T) {
 	inputImageFile := inputImageFileReal
 	rpmSources := []string{}
 	outputImageFile := "out/image.vhdx"
+	defer os.Remove(outputImageFile)
 	outputImageFormat := filepath.Ext(outputImageFile)[1:]
 	useBaseImageRpmRepos := false
 	packageSnapshotTime := ""
@@ -338,7 +344,10 @@ func TestValidateOutput_AcceptsValidPaths(t *testing.T) {
 	cwd, err := os.Getwd()
 	assert.NoError(t, err)
 
-	buildDir := filepath.Join(tmpDir, "TestValidateOutput_AcceptsValidPaths")
+	testTempDir := filepath.Join(tmpDir, "TestValidateOutput_AcceptsValidPaths")
+	defer os.RemoveAll(testTempDir)
+
+	buildDir := filepath.Join(testTempDir, "build")
 	err = os.MkdirAll(buildDir, os.ModePerm)
 	assert.NoError(t, err)
 
@@ -484,16 +493,19 @@ func TestValidateOutput_AcceptsValidPaths(t *testing.T) {
 }
 
 func TestCustomizeImage_InputImageFileSelection(t *testing.T) {
-	buildDir := filepath.Join(tmpDir, "TestCustomizeImage_InputImageFileSelection")
-	baseConfigPath := buildDir
+	testTempDir := filepath.Join(tmpDir, "TestCustomizeImage_InputImageFileSelection")
+	defer os.RemoveAll(testTempDir)
+
+	buildDir := filepath.Join(testTempDir, "build")
+	baseConfigPath := testTempDir
 	config := &imagecustomizerapi.Config{}
 
-	inputImageFileFake := filepath.Join(buildDir, "doesnotexist.xxx")
+	inputImageFileFake := filepath.Join(testTempDir, "doesnotexist.xxx")
 	inputImageFileReal, _ := checkSkipForCustomizeDefaultImage(t)
 
 	inputImageFile := inputImageFileReal
 	rpmSources := []string{}
-	outputImageFile := filepath.Join(buildDir, "image.vhd")
+	outputImageFile := filepath.Join(testTempDir, "image.vhd")
 	outputImageFormat := filepath.Ext(outputImageFile)[1:]
 	useBaseImageRpmRepos := false
 	packageSnapshotTime := ""
@@ -533,11 +545,14 @@ func TestCustomizeImage_InputImageFileSelection(t *testing.T) {
 }
 
 func TestCustomizeImage_InputImageFileAsRelativePath(t *testing.T) {
-	buildDir := filepath.Join(tmpDir, "TestCustomizeImage_InputImageFileAsRelativePathOnCommandLine")
-	baseConfigPath := buildDir
+	testTempDir := filepath.Join(tmpDir, "TestCustomizeImage_InputImageFileAsRelativePathOnCommandLine")
+	defer os.RemoveAll(testTempDir)
+
+	buildDir := filepath.Join(testTempDir, "build")
+	baseConfigPath := testTempDir
 	config := &imagecustomizerapi.Config{}
 
-	inputImageFileAbsoluteFake := filepath.Join(buildDir, "doesnotexist.xxx")
+	inputImageFileAbsoluteFake := filepath.Join(testTempDir, "doesnotexist.xxx")
 	inputImageFileReal, _ := checkSkipForCustomizeDefaultImage(t)
 
 	inputImageFileAbsoluteReal, err := filepath.Abs(inputImageFileReal)
@@ -557,7 +572,7 @@ func TestCustomizeImage_InputImageFileAsRelativePath(t *testing.T) {
 
 	inputImageFile := inputImageFileRelativeToCwdReal
 	rpmSources := []string{}
-	outputImageFile := filepath.Join(buildDir, "image.vhd")
+	outputImageFile := filepath.Join(testTempDir, "image.vhd")
 	outputImageFormat := filepath.Ext(outputImageFile)[1:]
 	useBaseImageRpmRepos := false
 	packageSnapshotTime := ""
@@ -651,14 +666,17 @@ func testCustomizeImageKernelCommandLineAddHelper(t *testing.T, testName string,
 }
 
 func TestCustomizeImage_OutputImageFileSelection(t *testing.T) {
-	buildDir := filepath.Join(tmpDir, "TestCustomizeImage_OutputImageFileSelection")
-	baseConfigPath := buildDir
+	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImage_OutputImageFileSelection")
+	defer os.RemoveAll(testTmpDir)
+
+	buildDir := filepath.Join(testTmpDir, "build")
+	baseConfigPath := testTmpDir
 	config := &imagecustomizerapi.Config{}
 	inputImageFile, _ := checkSkipForCustomizeDefaultImage(t)
 	rpmSources := []string{}
 
-	outputImageFileAsArgument := filepath.Join(buildDir, "image-as-arg.vhd")
-	outputImageFilePathAsConfig := filepath.Join(buildDir, "image-as-config.vhd")
+	outputImageFileAsArgument := filepath.Join(testTmpDir, "image-as-arg.vhd")
+	outputImageFilePathAsConfig := filepath.Join(testTmpDir, "image-as-config.vhd")
 
 	outputImageFile := outputImageFileAsArgument
 	outputImageFormat := filepath.Ext(outputImageFile)[1:]
@@ -699,13 +717,16 @@ func TestCustomizeImage_OutputImageFileSelection(t *testing.T) {
 }
 
 func TestCustomizeImage_OutputImageFileAsRelativePath(t *testing.T) {
-	buildDir := filepath.Join(tmpDir, "TestCustomizeImage_OutputImageFileAsRelativePathOnCommandLine")
-	baseConfigPath := buildDir
+	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImage_OutputImageFileAsRelativePath")
+	defer os.RemoveAll(testTmpDir)
+
+	buildDir := filepath.Join(testTmpDir, "build")
+	baseConfigPath := testTmpDir
 	config := &imagecustomizerapi.Config{}
 	inputImageFile, _ := checkSkipForCustomizeDefaultImage(t)
 	rpmSources := []string{}
 
-	outputImageFileAbsolute := filepath.Join(buildDir, "image.vhdx")
+	outputImageFileAbsolute := filepath.Join(testTmpDir, "image.vhdx")
 
 	cwd, err := os.Getwd()
 	assert.NoError(t, err)
@@ -745,8 +766,11 @@ func TestCustomizeImage_OutputImageFileAsRelativePath(t *testing.T) {
 func TestCustomizeImage_OutputImageFormatSelection(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
-	buildDir := filepath.Join(tmpDir, "TestCustomizeImage_OutputImageFormatSelection")
-	outputImageFile := filepath.Join(buildDir, "image.dat")
+	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImage_OutputImageFormatSelection")
+	defer os.RemoveAll(testTmpDir)
+
+	buildDir := filepath.Join(testTmpDir, "build")
+	outputImageFile := filepath.Join(testTmpDir, "image.raw")
 	outputImageFormatAsArg := "vhd"
 	outputImageFormatAsConfig := "vhdx"
 
@@ -759,7 +783,7 @@ func TestCustomizeImage_OutputImageFormatSelection(t *testing.T) {
 			},
 		},
 	}
-	err := CustomizeImage(t.Context(), buildDir, buildDir, config, baseImage, nil, "", "",
+	err := CustomizeImage(t.Context(), buildDir, testTmpDir, config, baseImage, nil, "", "",
 		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	assert.NoError(t, err)
 	assert.FileExists(t, outputImageFile)
@@ -771,7 +795,7 @@ func TestCustomizeImage_OutputImageFormatSelection(t *testing.T) {
 
 	// Pass the output image format only through the argument.
 	config.Output.Image.Format = imagecustomizerapi.ImageFormatTypeNone
-	err = CustomizeImage(t.Context(), buildDir, buildDir, config, baseImage, nil, "", outputImageFormatAsArg,
+	err = CustomizeImage(t.Context(), buildDir, testTmpDir, config, baseImage, nil, "", outputImageFormatAsArg,
 		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	assert.NoError(t, err)
 	assert.FileExists(t, outputImageFile)
@@ -783,7 +807,7 @@ func TestCustomizeImage_OutputImageFormatSelection(t *testing.T) {
 
 	// Pass the output image format through both the config and the argument.
 	config.Output.Image.Format = imagecustomizerapi.ImageFormatType(outputImageFormatAsConfig)
-	err = CustomizeImage(t.Context(), buildDir, buildDir, config, baseImage, nil, "", outputImageFormatAsArg,
+	err = CustomizeImage(t.Context(), buildDir, testTmpDir, config, baseImage, nil, "", outputImageFormatAsArg,
 		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 	assert.NoError(t, err)
 	assert.FileExists(t, outputImageFile)
@@ -791,10 +815,13 @@ func TestCustomizeImage_OutputImageFormatSelection(t *testing.T) {
 }
 
 func TestCreateImageCustomizerParameters_InputImageFileSelection(t *testing.T) {
-	buildDir := filepath.Join(tmpDir, "TestCreateImageCustomizerParameters_InputImageFileSelection")
-	inputImageFileAsArg := filepath.Join(buildDir, "image-as-arg.vhdx")
-	inputImageFileIsoAsArg := filepath.Join(buildDir, "image-as-arg.iso")
-	inputImageFileAsConfig := filepath.Join(buildDir, "image-as-config.vhdx")
+	testTmpDir := filepath.Join(tmpDir, "TestCreateImageCustomizerParameters_InputImageFileSelection")
+	defer os.RemoveAll(testTmpDir)
+
+	buildDir := filepath.Join(testTmpDir, "build")
+	inputImageFileAsArg := filepath.Join(testTmpDir, "image-as-arg.vhdx")
+	inputImageFileIsoAsArg := filepath.Join(testTmpDir, "image-as-arg.iso")
+	inputImageFileAsConfig := filepath.Join(testTmpDir, "image-as-config.vhdx")
 
 	err := os.MkdirAll(buildDir, os.ModePerm)
 	assert.NoError(t, err)
@@ -868,10 +895,13 @@ func TestCreateImageCustomizerParameters_InputImageFileSelection(t *testing.T) {
 }
 
 func TestCreateImageCustomizerParameters_OutputImageFileSelection(t *testing.T) {
-	buildDir := filepath.Join(tmpDir, "TestCreateImageCustomizerParameters_OutputImageFileSelection")
-	outputImageFilePathAsArg := filepath.Join(buildDir, "image-as-arg.vhd")
-	outputImageFilePathAsConfig := filepath.Join(buildDir, "image-as-config.vhd")
-	inputImageFile := filepath.Join(buildDir, "image.vhd")
+	testTmpDir := filepath.Join(tmpDir, "TestCreateImageCustomizerParameters_OutputImageFileSelection")
+	defer os.RemoveAll(testTmpDir)
+
+	buildDir := filepath.Join(testTmpDir, "build")
+	outputImageFilePathAsArg := filepath.Join(testTmpDir, "image-as-arg.vhd")
+	outputImageFilePathAsConfig := filepath.Join(testTmpDir, "image-as-config.vhd")
+	inputImageFile := filepath.Join(testTmpDir, "image.vhd")
 
 	err := os.MkdirAll(buildDir, os.ModePerm)
 	assert.NoError(t, err)
@@ -901,7 +931,7 @@ func TestCreateImageCustomizerParameters_OutputImageFileSelection(t *testing.T) 
 		rpmsSources, outputImageFormat, outputImageFile, packageSnapshotTime)
 	assert.NoError(t, err)
 	assert.Equal(t, ic.outputImageFile, outputImageFilePathAsConfig)
-	assert.Equal(t, ic.outputImageDir, buildDir)
+	assert.Equal(t, ic.outputImageDir, testTmpDir)
 
 	// Pass the output image file only as an argument.
 	config.Output.Image.Path = ""
@@ -912,7 +942,7 @@ func TestCreateImageCustomizerParameters_OutputImageFileSelection(t *testing.T) 
 		rpmsSources, outputImageFormat, outputImageFile, packageSnapshotTime)
 	assert.NoError(t, err)
 	assert.Equal(t, ic.outputImageFile, outputImageFilePathAsArg)
-	assert.Equal(t, ic.outputImageDir, buildDir)
+	assert.Equal(t, ic.outputImageDir, testTmpDir)
 
 	// Pass the output image file in both the config and as an argument.
 	config.Output.Image.Path = outputImageFilePathAsConfig
@@ -923,12 +953,15 @@ func TestCreateImageCustomizerParameters_OutputImageFileSelection(t *testing.T) 
 		rpmsSources, outputImageFormat, outputImageFile, packageSnapshotTime)
 	assert.NoError(t, err)
 	assert.Equal(t, ic.outputImageFile, outputImageFilePathAsArg)
-	assert.Equal(t, ic.outputImageDir, buildDir)
+	assert.Equal(t, ic.outputImageDir, testTmpDir)
 }
 
 func TestCreateImageCustomizerParameters_OutputImageFormatSelection(t *testing.T) {
-	buildDir := filepath.Join(tmpDir, "TestCreateImageCustomizerParameters_OutputImageFormatSelection")
-	inputImageFile := filepath.Join(buildDir, "base.dat")
+	testTmpDir := filepath.Join(tmpDir, "TestCreateImageCustomizerParameters_OutputImageFormatSelection")
+	defer os.RemoveAll(testTmpDir)
+
+	buildDir := filepath.Join(testTmpDir, "build")
+	inputImageFile := filepath.Join(testTmpDir, "base.dat")
 	outputImageFormatAsArg := "vhd"
 	outputImageFormatAsConfig := "vhdx"
 
@@ -943,7 +976,7 @@ func TestCreateImageCustomizerParameters_OutputImageFormatSelection(t *testing.T
 	useBaseImageRpmRepos := false
 	rpmsSources := []string{}
 	outputImageFormat := ""
-	outputImageFile := filepath.Join(buildDir, "image.vhd")
+	outputImageFile := filepath.Join(testTmpDir, "image.vhd")
 	packageSnapshotTime := ""
 
 	// The output image format is not specified in the config or as an
@@ -1059,6 +1092,8 @@ func TestCustomizeImageBaseImageMissing(t *testing.T) {
 	}
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageBaseImageMissing")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	configFile := filepath.Join(testDir, "partitions-config.yaml")
 	baseImage := filepath.Join(testTmpDir, "missing.qcow2")
@@ -1079,6 +1114,8 @@ func TestCustomizeImageBaseImageInvalid(t *testing.T) {
 	}
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageBaseImageInvalid")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	configFile := filepath.Join(testDir, "partitions-config.yaml")
 	baseImage := configFile

--- a/toolkit/tools/pkg/imagecustomizerlib/imagehistory_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagehistory_test.go
@@ -24,9 +24,10 @@ func createTestConfig(configFilePath string, t *testing.T) imagecustomizerapi.Co
 }
 
 func TestAddImageHistory(t *testing.T) {
-	tempDir := filepath.Join(tmpDir, "TestAddImageHistory")
+	testTmpDir := filepath.Join(tmpDir, "TestAddImageHistory")
+	defer os.RemoveAll(testTmpDir)
 
-	historyDir := filepath.Join(tempDir, customizerLoggingDir)
+	historyDir := filepath.Join(testTmpDir, customizerLoggingDir)
 	historyFilePath := filepath.Join(historyDir, historyFileName)
 	config := createTestConfig("imagehistory-config.yaml", t)
 	// Serialize the config before calling addImageHistory
@@ -39,7 +40,7 @@ func TestAddImageHistory(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Test adding the first entry
-	err = addImageHistoryHelper(t.Context(), tempDir, expectedUuid, testDir, expectedVersion, expectedDate, &config)
+	err = addImageHistoryHelper(t.Context(), testTmpDir, expectedUuid, testDir, expectedVersion, expectedDate, &config)
 	assert.NoError(t, err, "addImageHistory should not return an error")
 
 	verifyHistoryFile(t, 1, expectedUuid, expectedVersion, expectedDate, config, historyFilePath)
@@ -52,7 +53,7 @@ func TestAddImageHistory(t *testing.T) {
 	// Test adding another entry with a different uuid
 	_, expectedUuid, err = randomization.CreateUuid()
 	assert.NoError(t, err)
-	err = addImageHistoryHelper(t.Context(), tempDir, expectedUuid, testDir, expectedVersion, expectedDate, &config)
+	err = addImageHistoryHelper(t.Context(), testTmpDir, expectedUuid, testDir, expectedVersion, expectedDate, &config)
 	assert.NoError(t, err, "addImageHistory should not return an error")
 
 	allHistory := verifyHistoryFile(t, 2, expectedUuid, expectedVersion, expectedDate, config, historyFilePath)

--- a/toolkit/tools/pkg/imagecustomizerlib/installedkernelcheck_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/installedkernelcheck_test.go
@@ -4,6 +4,7 @@
 package imagecustomizerlib
 
 import (
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -14,6 +15,8 @@ func TestCustomizeImageMissingKernel(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageMissingKernel")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	configFile := filepath.Join(testDir, "no-kernel-config.yaml")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")

--- a/toolkit/tools/pkg/imagecustomizerlib/kernelmoduleutils_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/kernelmoduleutils_test.go
@@ -15,7 +15,10 @@ import (
 )
 
 func TestLoadOrDisableModules(t *testing.T) {
-	rootDir := filepath.Join(tmpDir, "TestLoadOrDisableModules")
+	testTmpDir := filepath.Join(tmpDir, "TestLoadOrDisableModules")
+	defer os.RemoveAll(testTmpDir)
+
+	rootDir := testTmpDir
 	modules := []imagecustomizerapi.Module{
 		{
 			Name:     "module1",
@@ -118,7 +121,10 @@ func TestLoadOrDisableModules(t *testing.T) {
 }
 
 func TestEnsureModulesLoaded(t *testing.T) {
-	buildDir := filepath.Join(tmpDir, "TestEnsureModulesLoaded")
+	testTmpDir := filepath.Join(tmpDir, "TestEnsureModulesLoaded")
+	defer os.RemoveAll(testTmpDir)
+
+	buildDir := testTmpDir
 	modulesLoadPath := filepath.Join(buildDir, modulesLoadConfigDir)
 	moduleLoadFilePath := filepath.Join(modulesLoadPath, moduleLoadFileName)
 
@@ -153,7 +159,10 @@ func TestEnsureModulesLoaded(t *testing.T) {
 }
 
 func TestEnsureModulesDisabled(t *testing.T) {
-	buildDir := filepath.Join(tmpDir, "TestEnsureModulesDisabled")
+	testTmpDir := filepath.Join(tmpDir, "TestEnsureModulesDisabled")
+	defer os.RemoveAll(testTmpDir)
+
+	buildDir := testTmpDir
 	modprobePath := filepath.Join(buildDir, modprobeConfigDir)
 	moduleDisableFilePath := filepath.Join(modprobePath, moduleDisabledFileName)
 	err := os.MkdirAll(modprobePath, os.ModePerm)
@@ -185,7 +194,10 @@ func TestEnsureModulesDisabled(t *testing.T) {
 }
 
 func TestRemoveModuleFromDisableList(t *testing.T) {
-	buildDir := filepath.Join(tmpDir, "TestRemoveModuleFromDisableList")
+	testTmpDir := filepath.Join(tmpDir, "TestRemoveModuleFromDisableList")
+	defer os.RemoveAll(testTmpDir)
+
+	buildDir := testTmpDir
 	modprobePath := filepath.Join(buildDir, modprobeConfigDir)
 	moduleDisableFilePath := filepath.Join(modprobePath, moduleDisabledFileName)
 	err := os.MkdirAll(modprobePath, os.ModePerm)
@@ -222,6 +234,8 @@ func TestCustomizeImageKernelModules(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageKernelModules")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	configFile := filepath.Join(testDir, "modules-config.yaml")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
@@ -433,6 +433,8 @@ func testCustomizeImageLiveOSKeepKdumpFilesA(t *testing.T, testName string, base
 	baseImage := *baseImageInfo.Param
 
 	testTempDir := filepath.Join(tmpDir, testName)
+	defer os.RemoveAll(testTempDir)
+
 	buildDir := filepath.Join(testTempDir, "build")
 	outImageFilePath := filepath.Join(testTempDir, defaultIsoImageName)
 
@@ -552,6 +554,8 @@ func testCustomizeImageLiveOSKeepKdumpFilesBC(t *testing.T, testName string, bas
 	baseImage := *baseImageInfo.Param
 
 	testTempDir := filepath.Join(tmpDir, testName)
+	defer os.RemoveAll(testTempDir)
+
 	buildDir := filepath.Join(testTempDir, "build")
 	outImageFilePath := filepath.Join(testTempDir, defaultIsoImageName)
 
@@ -615,6 +619,8 @@ func testCustomizeImageLiveOSMultiKernel(t *testing.T, testName string, baseImag
 	baseImage := *baseImageInfo.Param
 
 	testTempDir := filepath.Join(tmpDir, testName)
+	defer os.RemoveAll(testTempDir)
+
 	buildDir := filepath.Join(testTempDir, "build")
 	outImageFilePath := filepath.Join(testTempDir, defaultIsoImageName)
 
@@ -656,6 +662,8 @@ func TestCustomizeImageLiveOSInitramfs1(t *testing.T) {
 	baseImage, baseImageInfo := checkSkipForCustomizeDefaultImage(t)
 
 	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageLiveOSInitramfs1")
+	defer os.RemoveAll(testTempDir)
+
 	buildDir := filepath.Join(testTempDir, "build")
 	outImageFilePath := filepath.Join(testTempDir, defaultIsoImageName)
 
@@ -715,6 +723,8 @@ func TestCustomizeImageLiveOSInitramfs2(t *testing.T) {
 	baseImage, baseImageInfo := checkSkipForCustomizeDefaultImage(t)
 
 	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageLiveOSInitramfs2")
+	defer os.RemoveAll(testTempDir)
+
 	buildDir := filepath.Join(testTempDir, "build")
 	outImageFilePath := filepath.Join(testTempDir, defaultIsoImageName)
 
@@ -771,6 +781,8 @@ func TestCustomizeImageLiveOSInitramfs3(t *testing.T) {
 	baseImage, baseImageInfo := checkSkipForCustomizeDefaultImage(t)
 
 	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageLiveOSInitramfs3")
+	defer os.RemoveAll(testTempDir)
+
 	buildDir := filepath.Join(testTempDir, "build")
 	outImageFilePath := filepath.Join(testTempDir, defaultIsoImageName)
 
@@ -794,6 +806,8 @@ func TestCustomizeImageLiveOSPxe1(t *testing.T) {
 	}
 
 	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageLiveOSPxe1")
+	defer os.RemoveAll(testTempDir)
+
 	buildDir := filepath.Join(testTempDir, "build")
 	outImageFilePath := filepath.Join(testTempDir, "pxe-artifacts.tar.gz")
 	pxeBootstrapUrl := "http://my-pxe-server-1/" + defaultIsoImageName
@@ -817,6 +831,8 @@ func TestCustomizeImageLiveOSPxe2(t *testing.T) {
 	baseImage, baseImageInfo := checkSkipForCustomizeDefaultImage(t)
 
 	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageLiveOSPxe2")
+	defer os.RemoveAll(testTempDir)
+
 	buildDir := filepath.Join(testTempDir, "build")
 	outImageFilePath := filepath.Join(testTempDir, "pxe-artifacts.tar.gz")
 
@@ -844,8 +860,11 @@ func TestCustomizeImageLiveOSIsoNoShimEfi(t *testing.T) {
 func testCustomizeImageLiveOSIsoNoShimEfi(t *testing.T, testName string, baseImageInfo testBaseImageInfo) {
 	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
-	buildDir := filepath.Join(tmpDir, testName)
-	outImageFilePath := filepath.Join(buildDir, defaultIsoImageName)
+	testTempDir := filepath.Join(tmpDir, testName)
+	defer os.RemoveAll(testTempDir)
+
+	buildDir := filepath.Join(testTempDir, "build")
+	outImageFilePath := filepath.Join(testTempDir, defaultIsoImageName)
 	shimPackage := "shim"
 
 	// For arm64 and baseImageVersionAzl2, the shim package is shim-unsigned.
@@ -873,8 +892,11 @@ func testCustomizeImageLiveOSIsoNoShimEfi(t *testing.T, testName string, baseIma
 func TestCustomizeImageLiveOSIsoNoGrubEfi(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
-	buildDir := filepath.Join(tmpDir, "TestCustomizeImageLiveOSIsoNoGrubEfi")
-	outImageFilePath := filepath.Join(buildDir, defaultIsoImageName)
+	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageLiveOSIsoNoGrubEfi")
+	defer os.RemoveAll(testTempDir)
+
+	buildDir := filepath.Join(testTempDir, "build")
+	outImageFilePath := filepath.Join(testTempDir, defaultIsoImageName)
 
 	config := &imagecustomizerapi.Config{
 		OS: &imagecustomizerapi.OS{

--- a/toolkit/tools/pkg/imagecustomizerlib/releasefile_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/releasefile_test.go
@@ -20,7 +20,10 @@ func TestAddCustomizerRelease(t *testing.T) {
 		t.Skip("Test must be run as root because it uses a chroot")
 	}
 
-	proposedDir := filepath.Join(tmpDir, "TestAddCustomizerRelease")
+	testTempDir := filepath.Join(tmpDir, "TestAddCustomizerRelease")
+	defer os.RemoveAll(testTempDir)
+
+	proposedDir := testTempDir
 
 	err := os.MkdirAll(filepath.Join(proposedDir, "etc"), os.ModePerm)
 	assert.NoError(t, err)

--- a/toolkit/tools/pkg/imagecustomizerlib/resolvconf_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/resolvconf_test.go
@@ -17,6 +17,8 @@ func TestCustomizeImageResolvConfDelete(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageResolvConfDelete")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
@@ -54,6 +56,8 @@ func TestCustomizeImageResolvConfRestoreFile(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageResolvConfRestoreFile")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
@@ -125,6 +129,8 @@ func TestCustomizeImageResolvConfRestoreSymlink(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageResolvConfRestoreSymlink")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
@@ -188,6 +194,8 @@ func TestCustomizeImageResolvConfNewSymlink(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageResolvConfNewSymlink")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 

--- a/toolkit/tools/pkg/imagecustomizerlib/runscripts_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/runscripts_test.go
@@ -17,6 +17,8 @@ func TestCustomizeImageRunScripts(t *testing.T) {
 	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageRunScripts")
+	defer os.RemoveAll(testTmpDir)
+
 	buildDir := filepath.Join(testTmpDir, "build")
 	configFile := filepath.Join(testDir, "runscripts-writefiles-config.yaml")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")


### PR DESCRIPTION
Currently, the test temporary directory is removed at the end of all the tests. So, as more tests are added, the temp directory has gotten larger and larger and now the tests are failing due to out of disk space errors.

This change removes the test specific temporary directories after a test has completed. This change also makes the creation of the temporary directories more consistent between tests.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
