### PR TITLE
Add merge queue trigger to workflow.

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -9,6 +9,8 @@ on:
   push:
     branches:
     - main
+  merge_group:
+    types: [checks_requested]
 
 jobs:
   build:


### PR DESCRIPTION
Trigger the main workflow on merge_queue event. This will cause the workflow to run when a change is placed in a merge queue.

The purpose of this change is to ensure the tests suite succeed before a change is merged into main, but avoid running these long tests on every iteration of a PR.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
