### PR TITLE
Fix Image Customizer docs

### DIFF
--- a/docs/imagecustomizer/api/configuration/group.md
+++ b/docs/imagecustomizer/api/configuration/group.md
@@ -1,5 +1,6 @@
 ---
 parent: Configuration
+ancestor: Image Customizer
 ---
 
 # group type

--- a/docs/imagecustomizer/api/configuration/kdumpbootfiles.md
+++ b/docs/imagecustomizer/api/configuration/kdumpbootfiles.md
@@ -1,5 +1,6 @@
 ---
 parent: Configuration
+ancestor: Image Customizer
 ---
 
 # kdumpBootFiles [string]
@@ -15,7 +16,7 @@ formats (iso and pxe).
 The kdump boot files include:
 
 - a crashdump initramfs image named `initramfs-<kernel-version>kdump.img`.
-- a kernel named  `vmlinuz-<kernel-version>` - where its version matches that of
+- a kernel named `vmlinuz-<kernel-version>` - where its version matches that of
   the `initramfs-<kernel-version>kdump.img`.
 
 By default, the Image Customizer tool removes the `/boot` folder from the full


### PR DESCRIPTION
<!-- Description: Please provide a summary of the changes and the motivation behind them. -->


<img width="300" height="300" alt="image" src="https://github.com/user-attachments/assets/71219c8f-a7d5-4e11-af4a-5e2cc3f9a06c" />


the docs from customizer show up in image creator docs, updating the ancestor of the docs to fix the issue.
---

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] Code conforms to style guidelines
