### PR TITLE
Fix when /boot is on an XFS filesystem.

### DIFF
--- a/toolkit/tools/imagegen/configuration/partition.go
+++ b/toolkit/tools/imagegen/configuration/partition.go
@@ -28,6 +28,8 @@ type Partition struct {
 	Start     uint64          `json:"Start"`
 	Flags     []PartitionFlag `json:"Flags"`
 	Artifacts []Artifact      `json:"Artifacts"`
+	// If the partition will contain pre-kernel/initramfs boot resources (e.g. /boot partition).
+	IsBootPartition bool `json:"IsBootPartition"`
 }
 
 // HasFlag returns true if a given partition has a specific flag set.

--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -459,7 +459,8 @@ func CreatePartitions(targetOs targetos.TargetOs, diskDevPath string, disk confi
 			return partDevPathMap, partIDToFsTypeMap, encryptedRoot, err
 		}
 
-		partFsType, err := formatSinglePartition(targetOs, diskDevPath, partDevPath, partition)
+		partFsType, err := formatSinglePartition(targetOs, diskDevPath, partDevPath, partition,
+			partition.IsBootPartition)
 		if err != nil {
 			err = fmt.Errorf("failed to format partition:\n%w", err)
 			return partDevPathMap, partIDToFsTypeMap, encryptedRoot, err
@@ -696,7 +697,7 @@ func isDigit(c byte) bool {
 
 // formatSinglePartition formats the given partition to the type specified in the partition configuration
 func formatSinglePartition(targetOs targetos.TargetOs, diskDevPath string, partDevPath string,
-	partition configuration.Partition,
+	partition configuration.Partition, isBootPartition bool,
 ) (fsType string, err error) {
 	const (
 		totalAttempts = 5
@@ -714,7 +715,7 @@ func formatSinglePartition(targetOs targetos.TargetOs, diskDevPath string, partD
 			fsType = "vfat"
 		}
 
-		mkfsOptions, err := getFileSystemOptions(targetOs, fsType)
+		mkfsOptions, err := getFileSystemOptions(targetOs, fsType, isBootPartition)
 		if err != nil {
 			err = fmt.Errorf("failed to get mkfs args for filesystem type (%s) and target os (%s):\n%w", fsType,
 				targetOs, err)

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/partitions-xfs-boot.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/partitions-xfs-boot.yaml
@@ -1,0 +1,28 @@
+storage:
+  disks:
+  - partitionTableType: gpt
+    partitions:
+    - id: esp
+      type: esp
+      size: 8M
+
+    - id: rootfs
+      size: 1G
+
+  bootType: efi
+
+  filesystems:
+  - deviceId: esp
+    type: fat32
+    mountPoint:
+      path: /boot/efi
+      options: umask=0077
+
+  - deviceId: rootfs
+    type: xfs
+    mountPoint:
+      path: /
+
+os:
+  bootloader:
+    resetType: hard-reset


### PR DESCRIPTION
GRUB 2.06, which is used in AZL3, doesn't support the xfs feature `nrext64`. However, currently MIC's default features for AZL3 include the `nrext64` feature. So, if the `/boot` directory is on an xfs partition, then the image will fail to boot. This change fixes this by excluding the `nrext64` feature when the `/boot` directory is on an xfs partition.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
