### PR TITLE
Generic package manager error messages

### DIFF
--- a/toolkit/tools/imagecreator/main.go
+++ b/toolkit/tools/imagecreator/main.go
@@ -24,7 +24,7 @@ type ImageCreatorCmd struct {
 	BuildDir          string   `name:"build-dir" help:"Directory to run build out of." required:""`
 	ConfigFile        string   `name:"config-file" help:"Path of the image creator config file." required:""`
 	RpmSources        []string `name:"rpm-source" help:"Path to a RPM repo config file or a directory containing RPMs." required:""`
-	ToolsTar          string   `name:"tools-file" help:"Path to tdnf worker tarball" required:""`
+	ToolsTar          string   `name:"tools-file" help:"Path to tdnf/dnf worker tarball" required:""`
 	OutputImageFile   string   `name:"output-image-file" help:"Path to write the customized image to."`
 	OutputImageFormat string   `name:"output-image-format" placeholder:"(vhd|vhd-fixed|vhdx|qcow2|raw)" help:"Format of output image." enum:"${imageformat}" default:""`
 	Distro            string   `name:"distro" help:"Target distribution for the image." enum:"azurelinux,fedora" default:"azurelinux"`

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages.go
@@ -16,13 +16,13 @@ import (
 
 var (
 	// Package-related errors
-	ErrPackageRepoMetadataRefresh = NewImageCustomizerError("Packages:RepoMetadataRefresh", "failed to refresh tdnf repo metadata")
+	ErrPackageRepoMetadataRefresh = NewImageCustomizerError("Packages:RepoMetadataRefresh", "failed to refresh repo metadata")
 	ErrInvalidPackageListFile     = NewImageCustomizerError("Packages:InvalidPackageListFile", "failed to read package list file")
 	ErrPackageRemove              = NewImageCustomizerError("Packages:Remove", "failed to remove packages")
 	ErrPackageUpdate              = NewImageCustomizerError("Packages:Update", "failed to update packages")
 	ErrPackagesUpdateInstalled    = NewImageCustomizerError("Packages:UpdateInstalled", "failed to update installed packages")
 	ErrPackageInstall             = NewImageCustomizerError("Packages:Install", "failed to install packages")
-	ErrPackageCacheClean          = NewImageCustomizerError("Packages:CacheClean", "failed to clean tdnf cache")
+	ErrPackageCacheClean          = NewImageCustomizerError("Packages:CacheClean", "failed to clean cache")
 	ErrMountRpmSources            = NewImageCustomizerError("Packages:MountRpmSources", "failed to mount RPM sources")
 	ErrSnapshotTimeNotSupported   = NewImageCustomizerError("Packages:SnapshotTimeNotSupported", "snapshot time is not supported")
 )

--- a/toolkit/tools/pkg/imagecustomizerlib/packagemanager_dnf.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/packagemanager_dnf.go
@@ -19,7 +19,7 @@ func newDnfPackageManager(version string) *dnfPackageManager {
 	return &dnfPackageManager{version: version}
 }
 
-func (pm *dnfPackageManager) getPackageManagerBinary() string { return "dnf" }
+func (pm *dnfPackageManager) getPackageManagerBinary() string { return string(packageManagerDNF) }
 func (pm *dnfPackageManager) getReleaseVersion() string       { return pm.version }
 func (pm *dnfPackageManager) getConfigFile() string           { return "etc/dnf/dnf.conf" }
 

--- a/toolkit/tools/pkg/imagecustomizerlib/packagemanager_tdnf.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/packagemanager_tdnf.go
@@ -20,7 +20,7 @@ func newTdnfPackageManager(version string) *tdnfPackageManager {
 	return &tdnfPackageManager{version: version}
 }
 
-func (pm *tdnfPackageManager) getPackageManagerBinary() string { return "tdnf" }
+func (pm *tdnfPackageManager) getPackageManagerBinary() string { return string(packageManagerTDNF) }
 func (pm *tdnfPackageManager) getReleaseVersion() string       { return pm.version }
 func (pm *tdnfPackageManager) getConfigFile() string           { return customTdnfConfRelPath }
 


### PR DESCRIPTION
Updated package manager methods to use constants instead of hardcoded strings
Generalized error messages to remove TDNF-specific references
Updated help text to mention both TDNF and DNF package managers

---

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] Code conforms to style guidelines
