### PR TITLE
Optimize Target OS Detection by Reusing Result Across Functions

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitions.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/logger"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/targetos"
 	"go.opentelemetry.io/otel"
 )
 
@@ -20,7 +21,7 @@ var (
 )
 
 func customizePartitions(ctx context.Context, buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
-	buildImageFile string,
+	buildImageFile string, targetOS targetos.TargetOs,
 ) (bool, string, map[string]string, error) {
 	switch {
 	case config.CustomizePartitions():
@@ -34,7 +35,7 @@ func customizePartitions(ctx context.Context, buildDir string, baseConfigPath st
 		// If there is no known way to create the new partition layout from the old one,
 		// then fallback to creating the new partitions from scratch and doing a file copy.
 		partIdToPartUuid, err := customizePartitionsUsingFileCopy(ctx, buildDir, baseConfigPath, config,
-			buildImageFile, newBuildImageFile)
+			buildImageFile, newBuildImageFile, targetOS)
 		if err != nil {
 			os.Remove(newBuildImageFile)
 			return false, "", nil, fmt.Errorf("%w:\n%w", ErrPartitionsCustomize, err)

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
@@ -22,7 +22,7 @@ var (
 )
 
 func customizePartitionsUsingFileCopy(ctx context.Context, buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
-	buildImageFile string, newBuildImageFile string,
+	buildImageFile string, newBuildImageFile string, targetOS targetos.TargetOs,
 ) (map[string]string, error) {
 	existingImageConnection, _, _, _, err := connectToExistingImage(ctx, buildImageFile, buildDir, "imageroot", false,
 		true, false, false)
@@ -31,18 +31,13 @@ func customizePartitionsUsingFileCopy(ctx context.Context, buildDir string, base
 	}
 	defer existingImageConnection.Close()
 
-	targetOs, err := targetos.GetInstalledTargetOs(existingImageConnection.Chroot().RootDir())
-	if err != nil {
-		return nil, fmt.Errorf("%w:\n%w", ErrPartitionCopyTargetOsDetermination, err)
-	}
-
 	diskConfig := config.Storage.Disks[0]
 
 	installOSFunc := func(imageChroot *safechroot.Chroot) error {
 		return copyFilesIntoNewDisk(existingImageConnection.Chroot(), imageChroot)
 	}
 
-	partIdToPartUuid, err := CreateNewImage(targetOs, newBuildImageFile, diskConfig, config.Storage.FileSystems,
+	partIdToPartUuid, err := CreateNewImage(targetOS, newBuildImageFile, diskConfig, config.Storage.FileSystems,
 		buildDir, "newimageroot", installOSFunc)
 	if err != nil {
 		return nil, err

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler.go
@@ -7,7 +7,6 @@ import (
 	"context"
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
-	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/imageconnection"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safechroot"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/targetos"
 )
@@ -53,16 +52,6 @@ func NewDistroHandlerFromTargetOs(targetOs targetos.TargetOs) distroHandler {
 	default:
 		panic("unsupported target OS: " + string(targetOs))
 	}
-}
-
-// NewDistroHandlerFromImageConnection detects the OS from the image and creates the appropriate handler
-func NewDistroHandlerFromImageConnection(imageConnection *imageconnection.ImageConnection) (distroHandler, error) {
-	targetOs, err := targetos.GetInstalledTargetOs(imageConnection.Chroot().RootDir())
-	if err != nil {
-		return nil, err
-	}
-
-	return NewDistroHandlerFromTargetOs(targetOs), nil
 }
 
 // NewDistroHandler creates the appropriate distro handler with version support (legacy)


### PR DESCRIPTION

This PR optimizes the target OS detection process by detecting it once and reusing the result across multiple functions, eliminating redundant filesystem access and improving performance.

## Changes Made
- Added `targetOS` field to `ImageCustomizerParameters` to store detected OS information
- Modified `validateTargetOs` to return the detected target OS value
- Updated `customizePartitions` and `customizePartitionsUsingFileCopy` to accept target OS parameter
- Removed redundant target OS detection from `customizePartitionsUsingFileCopy`
- Updated function calls to pass the target OS through the call chain

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] Code conforms to style guidelines
