### PR TITLE
Enhance Error Checking 

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
@@ -288,7 +288,7 @@ func TestCustomizeImagePackagesBadRepo(t *testing.T) {
 	// Customize image.
 	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, []string{repoFile}, outImageFilePath, "raw",
 		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
-	assert.ErrorContains(t, err, "failed to refresh tdnf repo metadata")
+	assert.ErrorContains(t, err, ErrPackageRepoMetadataRefresh.Error())
 }
 
 func ensureTdnfCacheCleanup(t *testing.T, imageConnection *imageconnection.ImageConnection, dirPath string,

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
@@ -288,7 +288,7 @@ func TestCustomizeImagePackagesBadRepo(t *testing.T) {
 	// Customize image.
 	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, []string{repoFile}, outImageFilePath, "raw",
 		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
-	assert.ErrorContains(t, err, ErrPackageRepoMetadataRefresh.Error())
+	assert.ErrorIs(t, err, ErrPackageRepoMetadataRefresh)
 }
 
 func ensureTdnfCacheCleanup(t *testing.T, imageConnection *imageconnection.ImageConnection, dirPath string,


### PR DESCRIPTION

Enhanced error assertion in tests to verify the specific error type.

## Changes
Modified test assertion to check 
- The specific error type using `ErrPackageRepoMetadataRefresh`

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] Code conforms to style guidelines
