### PR TITLE
Prevent Package Snapshot Time Usage with Fedora 42 Images

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/configvalidation.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/configvalidation.go
@@ -316,6 +316,12 @@ func validateSnapshotTimeInput(snapshotTime string, previewFeatures []imagecusto
 		return ErrPackageSnapshotPreviewRequired
 	}
 
+	// snapshot time for fedora-42 images is not supported
+	if slices.Contains(previewFeatures, imagecustomizerapi.PreviewFeatureFedora42) {
+		return fmt.Errorf("'%s' feature is not supported with '%s' feature",
+			imagecustomizerapi.PreviewFeaturePackageSnapshotTime, imagecustomizerapi.PreviewFeatureFedora42)
+	}
+
 	if err := imagecustomizerapi.PackageSnapshotTime(snapshotTime).IsValid(); err != nil {
 		return fmt.Errorf("%w (time='%s'):\n%w", ErrInvalidPackageSnapshotTime, snapshotTime, err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/configvalidation_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/configvalidation_test.go
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerlib
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateSnapshotTimeInput(t *testing.T) {
+	// Test both features - should fail as they are incompatible
+	previewFeatures := []imagecustomizerapi.PreviewFeature{
+		imagecustomizerapi.PreviewFeaturePackageSnapshotTime,
+		imagecustomizerapi.PreviewFeatureFedora42,
+	}
+
+	err := validateSnapshotTimeInput("2023-10-10T10:10:10Z", previewFeatures)
+	assert.ErrorContains(t, err, fmt.Sprintf("'%s' feature is not supported with '%s' feature",
+		imagecustomizerapi.PreviewFeaturePackageSnapshotTime, imagecustomizerapi.PreviewFeatureFedora42))
+
+	// Test with no preview features enabled
+	err = validateSnapshotTimeInput("2023-10-10T10:10:10Z", []imagecustomizerapi.PreviewFeature{})
+	assert.ErrorIs(t, err, ErrPackageSnapshotPreviewRequired)
+
+	// Test with only package-snapshot-time feature - should succeed
+	err = validateSnapshotTimeInput("2023-10-10T10:10:10Z", []imagecustomizerapi.PreviewFeature{imagecustomizerapi.PreviewFeaturePackageSnapshotTime})
+	assert.NoError(t, err)
+
+	// Test with only fedora-42 feature - should fail with preview required error
+	err = validateSnapshotTimeInput("2023-10-10T10:10:10Z", []imagecustomizerapi.PreviewFeature{imagecustomizerapi.PreviewFeatureFedora42})
+	assert.ErrorIs(t, err, ErrPackageSnapshotPreviewRequired)
+}


### PR DESCRIPTION

Currently, there is no explicit validation preventing users from attempting to use package snapshot time feature with Fedora 42 images, which is an unsupported combination. This can lead to confusing errors or undefined behavior.

Added validation in `validateSnapshotTimeInput` to:
- Check for the presence of both preview features
- Return a clear error message when both features are enabled
- Maintain existing validation for other preview feature requirements

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] Code conforms to style guidelines
