### PR TITLE
Update quick start guide by specifying Linux distribution and version in Image Creator command.

### DIFF
--- a/docs/imagecreator/quick-start/quick-start.md
+++ b/docs/imagecreator/quick-start/quick-start.md
@@ -118,6 +118,8 @@ nav_order: 1
     sudo ./imagecreator \
       --build-dir ./build \
       --tools-file <tools-file.tar.gz> \
+      --distro azurelinux \
+      --distro-version 3.0 \
       --rpm-source azure-linux-rpms.repo \
       --output-image-file ./out/image.vhdx \
       --output-image-format vhdx \


### PR DESCRIPTION
The quick-start guide documentation has been updated to clearly specify the Linux distribution and version parameters in the Image Creator command example. This helps users by indicating the exact distribution (azurelinux) and version (3.0) to use.

Included the --distro azurelinux parameter in the command example
Included the --distro-version 3.0 parameter in the command example

### **Checklist**
- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
