### PR TITLE
Give `ImageCustomizerOptions` a `IsValid` function.

### DIFF
--- a/toolkit/tools/imagecustomizer/main.go
+++ b/toolkit/tools/imagecustomizer/main.go
@@ -119,9 +119,9 @@ func customizeImage(ctx context.Context, cmd CustomizeCmd) error {
 			InputImageFile:       cmd.InputImageFile,
 			RpmsSources:          cmd.RpmSources,
 			OutputImageFile:      cmd.OutputImageFile,
-			OutputImageFormat:    cmd.OutputImageFormat,
+			OutputImageFormat:    imagecustomizerapi.ImageFormatType(cmd.OutputImageFormat),
 			UseBaseImageRpmRepos: !cmd.DisableBaseImageRpmRepos,
-			PackageSnapshotTime:  cmd.PackageSnapshotTime,
+			PackageSnapshotTime:  imagecustomizerapi.PackageSnapshotTime(cmd.PackageSnapshotTime),
 		})
 	if err != nil {
 		return err

--- a/toolkit/tools/pkg/imagecreatorlib/validation.go
+++ b/toolkit/tools/pkg/imagecreatorlib/validation.go
@@ -85,8 +85,8 @@ func validateConfig(ctx context.Context, baseConfigPath string, config *imagecus
 		imagecustomizerlib.ImageCustomizerOptions{
 			RpmsSources:         rpmsSources,
 			OutputImageFile:     outputImageFile,
-			OutputImageFormat:   outputImageFormat,
-			PackageSnapshotTime: packageSnapshotTime,
+			OutputImageFormat:   imagecustomizerapi.ImageFormatType(outputImageFormat),
+			PackageSnapshotTime: imagecustomizerapi.PackageSnapshotTime(packageSnapshotTime),
 		})
 	if err != nil {
 		return err

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
@@ -20,7 +20,7 @@ func doOsCustomizations(
 	ctx context.Context, buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
 	imageConnection *imageconnection.ImageConnection, rpmsSources []string, useBaseImageRpmRepos bool,
 	partitionsCustomized bool, imageUuid string, partUuidToFstabEntry map[string]diskutils.FstabEntry,
-	packageSnapshotTime string, distroHandler distroHandler,
+	packageSnapshotTime imagecustomizerapi.PackageSnapshotTime, distroHandler distroHandler,
 ) error {
 	var err error
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages.go
@@ -30,13 +30,14 @@ var (
 // addRemoveAndUpdatePackages orchestrates the complete package management workflow
 func addRemoveAndUpdatePackages(ctx context.Context, buildDir string, baseConfigPath string,
 	config *imagecustomizerapi.OS, imageChroot *safechroot.Chroot, toolsChroot *safechroot.Chroot,
-	rpmsSources []string, useBaseImageRpmRepos bool, distroHandler distroHandler, snapshotTime string,
+	rpmsSources []string, useBaseImageRpmRepos bool, distroHandler distroHandler,
+	snapshotTime imagecustomizerapi.PackageSnapshotTime,
 ) error {
 	ctx, span := otel.GetTracerProvider().Tracer(OtelTracerName).Start(ctx, "configure_packages")
 	defer span.End()
 
 	if snapshotTime == "" {
-		snapshotTime = string(config.Packages.SnapshotTime)
+		snapshotTime = config.Packages.SnapshotTime
 	}
 
 	// Delegate the entire package management workflow to the distribution-specific implementation

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_rpm.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_rpm.go
@@ -20,7 +20,7 @@ import (
 // managePackagesRpm provides a shared implementation for RPM-based package management
 func managePackagesRpm(ctx context.Context, buildDir string, baseConfigPath string, config *imagecustomizerapi.OS,
 	imageChroot *safechroot.Chroot, toolsChroot *safechroot.Chroot, rpmsSources []string, useBaseImageRpmRepos bool,
-	snapshotTime string, pmHandler rpmPackageManagerHandler,
+	snapshotTime imagecustomizerapi.PackageSnapshotTime, pmHandler rpmPackageManagerHandler,
 ) error {
 	var err error
 

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler.go
@@ -37,7 +37,7 @@ type distroHandler interface {
 	// Package management operations
 	managePackages(ctx context.Context, buildDir string, baseConfigPath string, config *imagecustomizerapi.OS,
 		imageChroot *safechroot.Chroot, toolsChroot *safechroot.Chroot, rpmsSources []string, useBaseImageRpmRepos bool,
-		snapshotTime string) error
+		snapshotTime imagecustomizerapi.PackageSnapshotTime) error
 }
 
 // NewDistroHandlerFromTargetOs creates a distro handler directly from TargetOs

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux.go
@@ -38,7 +38,7 @@ func (d *azureLinuxDistroHandler) GetTargetOs() targetos.TargetOs {
 // managePackages handles the complete package management workflow for Azure Linux
 func (d *azureLinuxDistroHandler) managePackages(ctx context.Context, buildDir string, baseConfigPath string,
 	config *imagecustomizerapi.OS, imageChroot *safechroot.Chroot, toolsChroot *safechroot.Chroot,
-	rpmsSources []string, useBaseImageRpmRepos bool, snapshotTime string,
+	rpmsSources []string, useBaseImageRpmRepos bool, snapshotTime imagecustomizerapi.PackageSnapshotTime,
 ) error {
 	return managePackagesRpm(
 		ctx, buildDir, baseConfigPath, config, imageChroot, toolsChroot, rpmsSources, useBaseImageRpmRepos,

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
@@ -36,7 +36,7 @@ func (d *fedoraDistroHandler) GetTargetOs() targetos.TargetOs {
 // managePackages handles the complete package management workflow for Fedora
 func (d *fedoraDistroHandler) managePackages(ctx context.Context, buildDir string, baseConfigPath string,
 	config *imagecustomizerapi.OS, imageChroot *safechroot.Chroot, toolsChroot *safechroot.Chroot,
-	rpmsSources []string, useBaseImageRpmRepos bool, snapshotTime string,
+	rpmsSources []string, useBaseImageRpmRepos bool, snapshotTime imagecustomizerapi.PackageSnapshotTime,
 ) error {
 	return managePackagesRpm(
 		ctx, buildDir, baseConfigPath, config, imageChroot, toolsChroot, rpmsSources, useBaseImageRpmRepos,

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecreator.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecreator.go
@@ -41,7 +41,7 @@ func CustomizeImageHelperImageCreator(ctx context.Context, buildDir string, base
 	// Do the actual customizations.
 	err = doOsCustomizationsImageCreator(ctx, buildDir, baseConfigPath, config, imageConnection, toolsChroot, rpmsSources,
 		useBaseImageRpmRepos, imageUuidStr,
-		partUuidToFstabEntry, packageSnapshotTime, distroHandler)
+		partUuidToFstabEntry, imagecustomizerapi.PackageSnapshotTime(packageSnapshotTime), distroHandler)
 
 	// Out of disk space errors can be difficult to diagnose.
 	// So, warn about any partitions with low free space.
@@ -80,7 +80,7 @@ func doOsCustomizationsImageCreator(
 	useBaseImageRpmRepos bool,
 	imageUuid string,
 	partUuidToFstabEntry map[string]diskutils.FstabEntry,
-	packageSnapshotTime string,
+	packageSnapshotTime imagecustomizerapi.PackageSnapshotTime,
 	distroHandler distroHandler,
 ) error {
 	imageChroot := imageConnection.Chroot()

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -96,16 +96,6 @@ const (
 // The value of this string is inserted during compilation via a linker flag.
 var ToolVersion = ""
 
-type ImageCustomizerOptions struct {
-	BuildDir             string
-	InputImageFile       string
-	RpmsSources          []string
-	OutputImageFile      string
-	OutputImageFormat    string
-	UseBaseImageRpmRepos bool
-	PackageSnapshotTime  string
-}
-
 type ImageCustomizerParameters struct {
 	// build dirs
 	buildDirAbs string
@@ -121,7 +111,7 @@ type ImageCustomizerParameters struct {
 	customizeOSPartitions bool
 	useBaseImageRpmRepos  bool
 	rpmsSources           []string
-	packageSnapshotTime   string
+	packageSnapshotTime   imagecustomizerapi.PackageSnapshotTime
 
 	// intermediate writeable image
 	rawImageFile string
@@ -210,10 +200,6 @@ func createImageCustomizerParameters(ctx context.Context, configPath string, con
 
 	// output image
 	ic.outputImageFormat = imagecustomizerapi.ImageFormatType(options.OutputImageFormat)
-	if err := ic.outputImageFormat.IsValid(); err != nil {
-		return nil, fmt.Errorf("%w (format='%s'):\n%w", ErrInvalidOutputFormat, options.OutputImageFormat, err)
-	}
-
 	if ic.outputImageFormat == "" {
 		ic.outputImageFormat = config.Output.Image.Format
 	}
@@ -258,9 +244,9 @@ func CustomizeImageWithConfigFile(ctx context.Context, buildDir string, configFi
 		InputImageFile:       inputImageFile,
 		RpmsSources:          rpmsSources,
 		OutputImageFile:      outputImageFile,
-		OutputImageFormat:    outputImageFormat,
+		OutputImageFormat:    imagecustomizerapi.ImageFormatType(outputImageFormat),
 		UseBaseImageRpmRepos: useBaseImageRpmRepos,
-		PackageSnapshotTime:  packageSnapshotTime,
+		PackageSnapshotTime:  imagecustomizerapi.PackageSnapshotTime(packageSnapshotTime),
 	})
 }
 
@@ -307,9 +293,9 @@ func CustomizeImage(ctx context.Context, buildDir string, baseConfigPath string,
 		InputImageFile:       inputImageFile,
 		RpmsSources:          rpmsSources,
 		OutputImageFile:      outputImageFile,
-		OutputImageFormat:    outputImageFormat,
+		OutputImageFormat:    imagecustomizerapi.ImageFormatType(outputImageFormat),
 		UseBaseImageRpmRepos: useBaseImageRpmRepos,
-		PackageSnapshotTime:  packageSnapshotTime,
+		PackageSnapshotTime:  imagecustomizerapi.PackageSnapshotTime(packageSnapshotTime),
 	})
 }
 
@@ -786,7 +772,8 @@ func toQemuImageFormat(imageFormat imagecustomizerapi.ImageFormatType) (string, 
 
 func customizeImageHelper(ctx context.Context, buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
 	rawImageFile string, rpmsSources []string, useBaseImageRpmRepos bool, partitionsCustomized bool,
-	imageUuidStr string, packageSnapshotTime string, outputImageFormatType imagecustomizerapi.ImageFormatType, targetOS targetos.TargetOs,
+	imageUuidStr string, packageSnapshotTime imagecustomizerapi.PackageSnapshotTime,
+	outputImageFormatType imagecustomizerapi.ImageFormatType, targetOS targetos.TargetOs,
 ) (map[string]diskutils.FstabEntry, []verityDeviceMetadata, []string, string, error) {
 	logger.Log.Debugf("Customizing OS")
 

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -180,7 +180,7 @@ func TestValidateInput_AcceptsValidPaths(t *testing.T) {
 	options := ImageCustomizerOptions{
 		InputImageFile:    inputImageFileReal,
 		OutputImageFile:   outputImageFile,
-		OutputImageFormat: filepath.Ext(outputImageFile)[1:],
+		OutputImageFormat: imagecustomizerapi.ImageFormatType(filepath.Ext(outputImageFile)[1:]),
 	}
 
 	// The input image file can be specified as an argument without being specified in the config.
@@ -344,7 +344,7 @@ func TestValidateConfig_CallsValidateOutput(t *testing.T) {
 		},
 	}
 	options := ImageCustomizerOptions{
-		OutputImageFormat: string(imagecustomizerapi.ImageFormatTypeNone),
+		OutputImageFormat: imagecustomizerapi.ImageFormatTypeNone,
 	}
 
 	// Test that the output is being validated in validateConfig by triggering an error in validateOutput.
@@ -398,7 +398,7 @@ func TestValidateOutput_AcceptsValidPaths(t *testing.T) {
 	assert.NoError(t, err)
 
 	options.OutputImageFile = outputImageFileNew
-	options.OutputImageFormat = filepath.Ext(options.OutputImageFile)[1:]
+	options.OutputImageFormat = imagecustomizerapi.ImageFormatType(filepath.Ext(options.OutputImageFile)[1:])
 
 	// The output image file can be sepcified as an argument without being in specified the config.
 	err = ValidateConfig(t.Context(), baseConfigPath, config, false, options)
@@ -983,7 +983,7 @@ func TestCreateImageCustomizerParameters_OutputImageFormatSelection(t *testing.T
 
 	// Pass the output image format only as an argument.
 	config.Output.Image.Format = imagecustomizerapi.ImageFormatTypeNone
-	options.OutputImageFormat = outputImageFormatAsArg
+	options.OutputImageFormat = imagecustomizerapi.ImageFormatType(outputImageFormatAsArg)
 
 	// The output image file should be set to the value passed as an
 	// argument.

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizeroptions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizeroptions.go
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerlib
+
+import (
+	"fmt"
+
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
+)
+
+type ImageCustomizerOptions struct {
+	BuildDir             string
+	InputImageFile       string
+	RpmsSources          []string
+	OutputImageFile      string
+	OutputImageFormat    imagecustomizerapi.ImageFormatType
+	UseBaseImageRpmRepos bool
+	PackageSnapshotTime  imagecustomizerapi.PackageSnapshotTime
+}
+
+func (o *ImageCustomizerOptions) IsValid() error {
+	if err := o.OutputImageFormat.IsValid(); err != nil {
+		return fmt.Errorf("%w (format='%s'):\n%w", ErrInvalidOutputFormat, o.OutputImageFormat, err)
+	}
+
+	if err := o.PackageSnapshotTime.IsValid(); err != nil {
+		return fmt.Errorf("%w (time='%s'):\n%w", ErrInvalidPackageSnapshotTime, o.PackageSnapshotTime, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
1. Move the `ImageCustomizerOptions` into its own source file.

2. Use dedicated API types for the `OutputImageFormat` and `PackageSnapshotTime` fields.

3. Add a `IsValid` function to `ImageCustomizerOptions` and move the existing validation checks into that function. This will centralize the these checks, making them easier to maintain.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
