### PR TITLE
docs: Fix typo in things-to-avoid.md

### DIFF
--- a/docs/imagecustomizer/concepts/things-to-avoid.md
+++ b/docs/imagecustomizer/concepts/things-to-avoid.md
@@ -27,7 +27,7 @@ Examples of commands to avoid:
 - `modprobe`
 - `sysctl`
 
-Instead, you should you make use of config files that set the runtime kernel settings
+Instead, you should make use of config files that set the runtime kernel settings
 during OS boot.
 
 Example config directories to use instead:


### PR DESCRIPTION
Corrected a typo in the documentation regarding kernel settings.

<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

---

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] Code conforms to style guidelines
