### PR TITLE
Cleanup `ValidateConfig` function.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -344,7 +344,7 @@ func TestValidateConfig_CallsValidateOutput(t *testing.T) {
 		},
 	}
 	options := ImageCustomizerOptions{
-		OutputImageFormat: imagecustomizerapi.ImageFormatTypeNone,
+		OutputImageFormat: imagecustomizerapi.ImageFormatTypeQcow2,
 	}
 
 	// Test that the output is being validated in validateConfig by triggering an error in validateOutput.


### PR DESCRIPTION
1. Use `switch` statement when handling input and output paths, so that the priority ordering is clearer. (This will also help when support for OCI input images is added.)

2. Fix the check that checks if the output is PXE.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
