### PR TITLE
Add BTRFS subvolume support for rootfs detection and fstab reading in image customizer

### DIFF
--- a/docs/imagecustomizer/quick-start/quick-start-binary.md
+++ b/docs/imagecustomizer/quick-start/quick-start-binary.md
@@ -38,14 +38,14 @@ Note: Using the [Image Customizer container](../quick-start/quick-start.md) is t
    `udevadm`, `flock`, `blkid`, `openssl`, `sed`, `createrepo`, `mksquashfs`,
    `genisoimage`, `mkfs`, `mkfs.ext4`, `mkfs.vfat`, `mkfs.xfs`, `fsck`,
    `e2fsck`, `xfs_repair`, `resize2fs`, `tune2fs`, `xfs_admin`, `fatlabel`, `zstd`,
-   `veritysetup`, `grub2-install` (or `grub-install`), `ukify`, `objcopy`, `lsof`.
+   `veritysetup`, `grub2-install` (or `grub-install`), `ukify`, `objcopy`, `lsof`, `btrfs`.
 
    - For Ubuntu 22.04 images, run:
 
      ```bash
      sudo apt -y install qemu-utils rpm coreutils util-linux mount fdisk udev openssl \
         sed createrepo-c squashfs-tools genisoimage e2fsprogs dosfstools \
-        xfsprogs zstd cryptsetup-bin grub2-common binutils lsof
+        xfsprogs btrfs-progs zstd cryptsetup-bin grub2-common binutils lsof
      ```
 
    - For Azure Linux (2.0 and 3.0, x86_64 and arm64), run:
@@ -53,7 +53,7 @@ Note: Using the [Image Customizer container](../quick-start/quick-start.md) is t
      ```bash
      sudo tdnf install -y qemu-img rpm coreutils util-linux systemd openssl \
        sed createrepo_c squashfs-tools cdrkit e2fsprogs dosfstools \
-       xfsprogs zstd veritysetup grub2 binutils lsof systemd-ukify
+       xfsprogs btrfs-progs zstd veritysetup grub2 binutils lsof systemd-ukify
      ```
 
      - On x86_64, to install libraries for BIOS booting, additionally run:

--- a/toolkit/tools/imagecustomizer/container/imagecustomizer.Dockerfile
+++ b/toolkit/tools/imagecustomizer/container/imagecustomizer.Dockerfile
@@ -14,7 +14,7 @@ RUN tdnf update -y && \
    tdnf update -y && \
    tdnf install -y qemu-img rpm coreutils util-linux systemd openssl \
       sed createrepo_c squashfs-tools cdrkit parted e2fsprogs dosfstools \
-      xfsprogs zstd veritysetup grub2 grub2-pc systemd-ukify binutils lsof \
+      xfsprogs btrfs-progs zstd veritysetup grub2 grub2-pc systemd-ukify binutils lsof \
       python3 python3-pip jq oras && \
    tdnf clean all
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsuuids.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsuuids.go
@@ -163,7 +163,7 @@ func resetPartitionUuid(device string, partNum int) (string, error) {
 func fixPartitionUuidsInFstabFile(partitions []diskutils.PartitionInfo, newUuids []string, newPartUuids []string,
 	buildDir string,
 ) error {
-	rootfsPartition, err := findRootfsPartition(partitions, buildDir)
+	rootfsPartition, rootfsPath, err := findRootfsPartition(partitions, buildDir)
 	if err != nil {
 		return err
 	}
@@ -177,7 +177,8 @@ func fixPartitionUuidsInFstabFile(partitions []diskutils.PartitionInfo, newUuids
 	defer partitionMount.Close()
 
 	// Read the existing fstab file.
-	fsTabFilePath := filepath.Join(partitionMount.Target(), "/etc/fstab")
+	fsTabFilePath := filepath.Join(partitionMount.Target(), rootfsPath, "etc/fstab")
+
 	fstabEntries, err := diskutils.ReadFstabFile(fsTabFilePath)
 	if err != nil {
 		return err

--- a/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
@@ -64,12 +64,12 @@ func connectToExistingImageHelper(imageConnection *imageconnection.ImageConnecti
 		return nil, nil, nil, err
 	}
 
-	rootfsPartition, err := findRootfsPartition(partitions, buildDir)
+	rootfsPartition, rootfsPath, err := findRootfsPartition(partitions, buildDir)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to find rootfs partition:\n%w", err)
 	}
 
-	fstabEntries, err := readFstabEntriesFromRootfs(rootfsPartition, partitions, buildDir)
+	fstabEntries, err := readFstabEntriesFromRootfs(rootfsPartition, buildDir, rootfsPath)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("failed to read fstab entries from rootfs partition:\n%w", err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
@@ -22,6 +22,7 @@ import (
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safemount"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/shell"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/sliceutils"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
@@ -105,12 +106,13 @@ func findBootPartitionFromEsp(efiSystemPartition *diskutils.PartitionInfo, diskP
 // Searches for the partition that contains the /etc/fstab file.
 // While technically it is possible to place /etc on a different partition, doing so is fairly difficult and requires
 // a custom initramfs module.
-func findRootfsPartition(diskPartitions []diskutils.PartitionInfo, buildDir string) (*diskutils.PartitionInfo, error) {
+func findRootfsPartition(diskPartitions []diskutils.PartitionInfo, buildDir string) (*diskutils.PartitionInfo, string, error) {
 	logger.Log.Debugf("Searching for rootfs partition")
 
 	tmpDir := filepath.Join(buildDir, tmpPartitionDirName)
 
 	var rootfsPartitions []*diskutils.PartitionInfo
+	var rootfsPaths []string
 	for i := range diskPartitions {
 		diskPartition := diskPartitions[i]
 
@@ -121,67 +123,137 @@ func findRootfsPartition(diskPartitions []diskutils.PartitionInfo, buildDir stri
 
 		// Skip over file-system types that can't be used for the rootfs partition.
 		switch diskPartition.FileSystemType {
-		case "ext2", "ext3", "ext4", "xfs":
+		case "ext2", "ext3", "ext4", "xfs", "btrfs":
 
 		default:
-			logger.Log.Debugf("Skip partition (%s) with unsupported rootfs filesystem type (%s)", diskPartition.Path,
-				diskPartition.FileSystemType)
+			logger.Log.Debugf("Skip partition (%s) with unsupported rootfs filesystem type (%s)",
+				diskPartition.Path, diskPartition.FileSystemType)
 			continue
 		}
 
-		// Temporarily mount the partition.
-		partitionMount, err := safemount.NewMount(diskPartition.Path, tmpDir, diskPartition.FileSystemType, unix.MS_RDONLY,
-			"", true)
+		exists, rootfsPath, err := findFstabInRoot(diskPartition, tmpDir)
 		if err != nil {
-			return nil, fmt.Errorf("failed to mount partition (%s):\n%w", diskPartition.Path, err)
+			return nil, "", fmt.Errorf("failed to search for fstab in partition (%s):\n%w", diskPartition.Path, err)
 		}
-		defer partitionMount.Close()
-
-		// Check if the /etc/fstab file exists.
-		fstabPath := filepath.Join(tmpDir, "/etc/fstab")
-		exists, err := file.PathExists(fstabPath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to check if /etc/fstab file exists (%s):\n%w", diskPartition.Path, err)
-		}
-
 		if exists {
 			rootfsPartitions = append(rootfsPartitions, &diskPartition)
-		}
-
-		// Close the rootfs partition mount.
-		err = partitionMount.CleanClose()
-		if err != nil {
-			return nil, fmt.Errorf("failed to close partition mount (%s):\n%w", diskPartition.Path, err)
+			rootfsPaths = append(rootfsPaths, rootfsPath)
 		}
 	}
 
 	if len(rootfsPartitions) > 1 {
-		return nil, fmt.Errorf("found too many rootfs partition candidates (%d)", len(rootfsPartitions))
+		return nil, "", fmt.Errorf("found too many rootfs partition candidates (%d)",
+			len(rootfsPartitions))
 	} else if len(rootfsPartitions) < 1 {
-		return nil, fmt.Errorf("failed to find rootfs partition")
+		return nil, "", fmt.Errorf("failed to find rootfs partition")
 	}
 
 	rootfsPartition := rootfsPartitions[0]
-	return rootfsPartition, nil
+	rootfsPath := rootfsPaths[0]
+	return rootfsPartition, rootfsPath, nil
 }
 
-func readFstabEntriesFromRootfs(rootfsPartition *diskutils.PartitionInfo, diskPartitions []diskutils.PartitionInfo,
-	buildDir string,
+// findFstabInRoot searches for fstab in the root filesystem and in BTRFS subvolumes
+func findFstabInRoot(diskPartition diskutils.PartitionInfo, tmpDir string) (bool, string, error) {
+	partitionMount, err := safemount.NewMount(diskPartition.Path, tmpDir, diskPartition.FileSystemType,
+		unix.MS_RDONLY, "", true)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to mount partition (%s):\n%w", diskPartition.Path, err)
+	}
+	defer partitionMount.Close()
+
+	// Check the root of the filesystem
+	subvolume := ""
+	fstabPath := filepath.Join(tmpDir, "etc/fstab")
+	exists, err := file.PathExists(fstabPath)
+	if err != nil {
+		return false, "", err
+	}
+
+	if !exists && diskPartition.FileSystemType == "btrfs" {
+		// List actual subvolumes using btrfs tools
+		subvolumes, err := listBtrfsSubvolumes(tmpDir)
+		if err != nil {
+			return false, "", err
+		}
+
+		// Search for fstab in each subvolume directory
+		for _, subvolume = range subvolumes {
+			fstabPath := filepath.Join(tmpDir, subvolume, "etc/fstab")
+			exists, err := file.PathExists(fstabPath)
+			if err != nil {
+				return false, "", err
+			}
+			if exists {
+				break
+			}
+		}
+	}
+
+	// Close the rootfs partition mount.
+	err = partitionMount.CleanClose()
+	if err != nil {
+		return false, "", fmt.Errorf("failed to close partition mount (%s):\n%w",
+			diskPartition.Path, err)
+	}
+	return exists, subvolume, nil
+}
+
+// listBtrfsSubvolumes uses btrfs tools to discover actual subvolumes in a mounted BTRFS filesystem
+func listBtrfsSubvolumes(mountPoint string) ([]string, error) {
+	stdout, _, err := shell.NewExecBuilder("btrfs", "subvolume", "list", "-a", mountPoint).
+		LogLevel(logrus.DebugLevel, logrus.DebugLevel).
+		ErrorStderrLines(1).
+		ExecuteCaptureOutput()
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to list BTRFS subvolumes:\n%w", err)
+	}
+
+	// Regex to parse btrfs subvolume list output format:
+	// ID 256 gen 7 top level 5 path @
+	// ID 257 gen 7 top level 5 path @home
+	subvolumeRegex := regexp.MustCompile(
+		`^ID\s+\d+\s+gen\s+\d+\s+top\s+level\s+\d+\s+path\s+(.+)$`)
+
+	var subvolumes []string
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		match := subvolumeRegex.FindStringSubmatch(line)
+		if match == nil {
+			return nil, fmt.Errorf("failed to parse btrfs subvolume list output line: %s", line)
+		}
+
+		subvolPath := match[1]
+		subvolumes = append(subvolumes, subvolPath)
+	}
+
+	logger.Log.Debugf("Found BTRFS subvolumes: %v", subvolumes)
+	return subvolumes, nil
+}
+
+func readFstabEntriesFromRootfs(rootfsPartition *diskutils.PartitionInfo,
+	buildDir string, rootfsPath string,
 ) ([]diskutils.FstabEntry, error) {
 	logger.Log.Debugf("Reading fstab entries")
 
 	tmpDir := filepath.Join(buildDir, tmpPartitionDirName)
 
 	// Temporarily mount the rootfs partition so that the fstab file can be read.
-	rootfsPartitionMount, err := safemount.NewMount(rootfsPartition.Path, tmpDir, rootfsPartition.FileSystemType, unix.MS_RDONLY, "",
-		true)
+	rootfsPartitionMount, err := safemount.NewMount(rootfsPartition.Path, tmpDir,
+		rootfsPartition.FileSystemType, unix.MS_RDONLY, "", true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to mount rootfs partition (%s):\n%w", rootfsPartition.Path, err)
 	}
 	defer rootfsPartitionMount.Close()
 
-	// Read the fstab file.
-	fstabPath := filepath.Join(tmpDir, "/etc/fstab")
+	fstabPath := filepath.Join(tmpDir, rootfsPath, "etc/fstab")
 
 	// Read the fstab file.
 	fstabEntries, err := diskutils.ReadFstabFile(fstabPath)
@@ -192,7 +264,8 @@ func readFstabEntriesFromRootfs(rootfsPartition *diskutils.PartitionInfo, diskPa
 	// Close the rootfs partition mount.
 	err = rootfsPartitionMount.CleanClose()
 	if err != nil {
-		return nil, fmt.Errorf("failed to close rootfs partition mount (%s):\n%w", rootfsPartition.Path, err)
+		return nil, fmt.Errorf("failed to close rootfs partition mount (%s):\n%w",
+			rootfsPartition.Path, err)
 	}
 
 	return fstabEntries, nil


### PR DESCRIPTION
<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

---
This PR adds comprehensive BTRFS subvolume support to the image customizer library to properly handle BTRFS filesystems with subvolumes when detecting rootfs partitions and reading fstab entries. Previously, the image customizer only checked default mount locations, which would fail for BTRFS systems using subvolumes where /etc/fstab might be located in a specific subvolume rather than the filesystem root

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] Code conforms to style guidelines
