### PR TITLE
Remove requirement for /boot partition for usr verity.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput.go
@@ -343,7 +343,7 @@ func injectFilesIntoImage(buildDir string, baseConfigPath string, rawImageFile s
 		if _, exists := partitionsToMountpoints[partitionKey]; !exists {
 			partitionsToMountpoints[partitionKey] = filepath.Join(buildDir, fmt.Sprintf("inject-partition-%d", idx))
 
-			partition, _, err := findPartition(item.Partition.MountIdType, item.Partition.Id, diskPartitions, buildDir)
+			partition, _, err := findPartition(item.Partition.MountIdType, item.Partition.Id, diskPartitions)
 			if err != nil {
 				return err
 			}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
@@ -379,13 +379,8 @@ func verityUsrVerity(t *testing.T, baseImageInfo testBaseImageInfo, buildDir str
 	// Connect to usr verity image.
 	mountPoints := []testutils.MountPoint{
 		{
-			PartitionNum:   5,
+			PartitionNum:   4,
 			Path:           "/",
-			FileSystemType: "ext4",
-		},
-		{
-			PartitionNum:   2,
-			Path:           "/boot",
 			FileSystemType: "ext4",
 		},
 		{
@@ -394,7 +389,7 @@ func verityUsrVerity(t *testing.T, baseImageInfo testBaseImageInfo, buildDir str
 			FileSystemType: "vfat",
 		},
 		{
-			PartitionNum:   3,
+			PartitionNum:   2,
 			Path:           "/usr",
 			FileSystemType: "ext4",
 			Flags:          unix.MS_RDONLY,
@@ -412,10 +407,10 @@ func verityUsrVerity(t *testing.T, baseImageInfo testBaseImageInfo, buildDir str
 
 	// Verify that usr verity is configured correctly.
 	bootPath := filepath.Join(imageConnection.Chroot().RootDir(), "/boot")
-	usrDevice := testutils.PartitionDevPath(imageConnection, 3)
-	hashDevice := testutils.PartitionDevPath(imageConnection, 4)
-	verifyVerityGrub(t, bootPath, usrDevice, hashDevice, "UUID="+partitions[3].Uuid,
-		"UUID="+partitions[4].Uuid, "usr", "rd.info", baseImageInfo, corruptionOption)
+	usrDevice := testutils.PartitionDevPath(imageConnection, 2)
+	hashDevice := testutils.PartitionDevPath(imageConnection, 3)
+	verifyVerityGrub(t, bootPath, usrDevice, hashDevice, "UUID="+partitions[2].Uuid,
+		"UUID="+partitions[3].Uuid, "usr", "rd.info", baseImageInfo, corruptionOption)
 }
 
 func TestCustomizeImageVerityUsr2Stage(t *testing.T) {

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -519,7 +519,7 @@ func customizeOSContents(ctx context.Context, rc *ResolvedConfig) (imageMetadata
 	if len(rc.Config.Storage.Verity) > 0 || len(im.baseImageVerityMetadata) > 0 {
 		// Customize image for dm-verity, setting up verity metadata and security features.
 		verityMetadata, err := customizeVerityImageHelper(ctx, rc.BuildDirAbs, rc.Config, rc.RawImageFile,
-			partIdToPartUuid, shrinkPartitions, im.baseImageVerityMetadata, readonlyPartUuids)
+			partIdToPartUuid, shrinkPartitions, im.baseImageVerityMetadata, readonlyPartUuids, partUuidToFstabEntry)
 		if err != nil {
 			return im, fmt.Errorf("%w:\n%w", ErrCustomizeProvisionVerity, err)
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-2stage-prepare.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-2stage-prepare.yaml
@@ -10,9 +10,6 @@ storage:
       type: esp
       size: 8M
 
-    - id: boot
-      size: 1G
-
     - id: usr
       size: 2G
       label: usr
@@ -30,11 +27,6 @@ storage:
     mountPoint:
       path: /boot/efi
       options: umask=0077
-
-  - deviceId: boot
-    type: ext4
-    mountPoint:
-      path: /boot
 
   - deviceId: root
     type: ext4

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-config.yaml
@@ -7,9 +7,6 @@ storage:
       type: esp
       size: 8M
 
-    - id: boot
-      size: 1G
-
     - id: usr
       size: 2G
 
@@ -34,11 +31,6 @@ storage:
     mountPoint:
       path: /boot/efi
       options: umask=0077
-
-  - deviceId: boot
-    type: ext4
-    mountPoint:
-      path: /boot
 
   - deviceId: root
     type: ext4


### PR DESCRIPTION
When using usr verity, the OS image is not required to have a separate /boot partition. But Image Customizer's implementation has some flaws preventing this at the moment.

This change is primarily focused on using the `/etc/fstab` file to find the `/boot` directory instead of relying on the `grub.cfg` file on the ESP partition. We already use the fstab file to discover the partition layout. So, it is goodness to use it everywhere instead of having multiple mechanisms. Also, this will make it easier to produce GRUB-less OS images.

The primary fix comes from knowing if the /boot directory sits on its own partition or if it is a subdirectory of the root partition. This ensures that the code searches for files (e.g. `grub.cfg`) in the correct locations.

This change switches the usr verity tests to use parition layouts without a separate /boot partition. Whereas, the root verity tests keep the separate /boot partition since it is required for root verity.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
