### PR TITLE
Fix verity test regex to support optional root-hash-signature parameter

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
@@ -298,7 +298,7 @@ func verifyVerityHelper(t *testing.T, kernelArgsList []string, dataDevice string
 			assert.Regexp(t, ` rd.systemd.verity=1 `, kernelArgs)
 			assert.Regexp(t, fmt.Sprintf(` systemd.verity_root_data=%s `, dataId), kernelArgs)
 			assert.Regexp(t, fmt.Sprintf(` systemd.verity_root_hash=%s `, hashId), kernelArgs)
-			assert.Regexp(t, fmt.Sprintf(` systemd.verity_root_options=%s`, regexp.QuoteMeta(corruptionOption)), kernelArgs)
+			assert.Regexp(t, fmt.Sprintf(` systemd.verity_root_options=%s(,| |$)`, corruptionOption), kernelArgs)
 
 			hashRegexp = regexp.MustCompile(` roothash=([a-fA-F0-9]*) `)
 
@@ -306,7 +306,7 @@ func verifyVerityHelper(t *testing.T, kernelArgsList []string, dataDevice string
 			assert.Regexp(t, ` rd.systemd.verity=1 `, kernelArgs)
 			assert.Regexp(t, fmt.Sprintf(` systemd.verity_usr_data=%s `, dataId), kernelArgs)
 			assert.Regexp(t, fmt.Sprintf(` systemd.verity_usr_hash=%s `, hashId), kernelArgs)
-			assert.Regexp(t, fmt.Sprintf(` systemd.verity_usr_options=%s`, regexp.QuoteMeta(corruptionOption)), kernelArgs)
+			assert.Regexp(t, fmt.Sprintf(` systemd.verity_usr_options=%s(,| |$)`, corruptionOption), kernelArgs)
 
 			hashRegexp = regexp.MustCompile(` usrhash=([a-fA-F0-9]*) `)
 


### PR DESCRIPTION
<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

## Summary
Fixed test assertion in `customizeverity_test.go` that was failing when `hashSignaturePath` is configured in verity setup.

Dev test: https://github.com/microsoft/azure-linux-image-tools/actions/runs/19221283745

---

### **Checklist**
- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
