### PR TITLE
Reduce redundant partition discovery.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
@@ -8,7 +8,6 @@ import (
 	"time"
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
-	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/imageconnection"
 )
 
@@ -17,7 +16,7 @@ const (
 )
 
 func doOsCustomizations(ctx context.Context, rc *ResolvedConfig, imageConnection *imageconnection.ImageConnection,
-	partitionsCustomized bool, partUuidToFstabEntry map[string]diskutils.FstabEntry, distroHandler distroHandler,
+	partitionsCustomized bool, partitionsLayout []fstabEntryPartNum, distroHandler distroHandler,
 ) error {
 	var err error
 
@@ -102,7 +101,7 @@ func doOsCustomizations(ctx context.Context, rc *ResolvedConfig, imageConnection
 		}
 	}
 
-	err = handleBootLoader(ctx, rc, imageConnection, partUuidToFstabEntry, false)
+	err = handleBootLoader(ctx, rc, imageConnection, partitionsLayout, false)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
@@ -404,3 +404,25 @@ func TestCustomizeImageExtractEmptyPartition(t *testing.T) {
 	}
 	defer rootfsMount.Close()
 }
+
+// Ensure that Image Customizer doesn't fail if the user modifies the /etc/fstab in a postCustomization script.
+func TestCustomizeImageFstabDelete(t *testing.T) {
+	var err error
+
+	baseImage, _ := checkSkipForCustomizeDefaultImage(t)
+
+	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageFstabDelete")
+	defer os.RemoveAll(testTempDir)
+
+	buildDir := filepath.Join(testTempDir, "build")
+	configFile := filepath.Join(testDir, "fstab-delete.yaml")
+	outImageFilePath := filepath.Join(testTempDir, "image.cosi")
+
+	// Customize image.
+	// Ensure there is no error even though the /etc/fstab file was deleted.
+	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "cosi",
+		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	if !assert.NoError(t, err) {
+		return
+	}
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecreator.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecreator.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/installutils"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/imageconnection"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/logger"
@@ -18,7 +17,7 @@ import (
 
 func CustomizeImageHelperImageCreator(ctx context.Context, rc *ResolvedConfig, tarFile string,
 	distroHandler distroHandler,
-) (map[string]diskutils.FstabEntry, string, error) {
+) ([]fstabEntryPartNum, string, error) {
 	logger.Log.Debugf("Customizing OS image with config file %s", rc.BaseConfigPath)
 
 	toolsChrootDir := filepath.Join(rc.BuildDirAbs, toolsRoot)
@@ -29,7 +28,7 @@ func CustomizeImageHelperImageCreator(ctx context.Context, rc *ResolvedConfig, t
 	}
 	defer toolsChroot.Close(false)
 
-	imageConnection, partUuidToFstabEntry, _, _, err := connectToExistingImage(ctx, rc.RawImageFile, toolsChrootDir,
+	imageConnection, partitionsLayout, _, _, err := connectToExistingImage(ctx, rc.RawImageFile, toolsChrootDir,
 		toolsRootImageDir, true, false, false, false)
 	if err != nil {
 		return nil, "", err
@@ -37,7 +36,7 @@ func CustomizeImageHelperImageCreator(ctx context.Context, rc *ResolvedConfig, t
 	defer imageConnection.Close()
 
 	// Do the actual customizations.
-	err = doOsCustomizationsImageCreator(ctx, rc, imageConnection, toolsChroot, partUuidToFstabEntry, distroHandler)
+	err = doOsCustomizationsImageCreator(ctx, rc, imageConnection, toolsChroot, partitionsLayout, distroHandler)
 
 	// Out of disk space errors can be difficult to diagnose.
 	// So, warn about any partitions with low free space.
@@ -63,7 +62,7 @@ func CustomizeImageHelperImageCreator(ctx context.Context, rc *ResolvedConfig, t
 		return nil, "", err
 	}
 
-	return partUuidToFstabEntry, osRelease, nil
+	return partitionsLayout, osRelease, nil
 }
 
 func doOsCustomizationsImageCreator(
@@ -71,7 +70,7 @@ func doOsCustomizationsImageCreator(
 	rc *ResolvedConfig,
 	imageConnection *imageconnection.ImageConnection,
 	toolsChroot *safechroot.Chroot,
-	partUuidToFstabEntry map[string]diskutils.FstabEntry,
+	partitionsLayout []fstabEntryPartNum,
 	distroHandler distroHandler,
 ) error {
 	imageChroot := imageConnection.Chroot()
@@ -104,7 +103,7 @@ func doOsCustomizationsImageCreator(
 		return err
 	}
 
-	if err = handleBootLoader(ctx, rc, imageConnection, partUuidToFstabEntry, true); err != nil {
+	if err = handleBootLoader(ctx, rc, imageConnection, partitionsLayout, true); err != nil {
 		return err
 	}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/fstab-delete.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/fstab-delete.yaml
@@ -1,0 +1,22 @@
+previewFeatures:
+- output-artifacts
+
+os:
+
+scripts:
+  postCustomization:
+  - content: |
+      set -eux
+
+      # Remove the fstab file.
+      # This will make the OS image unbootable. So, this isn't something that
+      # is really supported per se. But this is the easiest way to ensure that
+      # Image Customizer doesn't fail if the user makes changes to the fstab
+      # file.
+      rm -rf /etc/fstab
+
+output:
+  artifacts:
+    path: ./out/artifacts
+    items:
+    - shim


### PR DESCRIPTION
Currently, we have a `connectToExistingImage` function that tries to discover the partition layout (by looking for the /etc/fstab file) and then mounting all the partitions. This logic makes sense when we are first connecting to a base image. But if we need to reconnect to the image later in the customization process (e.g. to collect COSI metadata), then we reuse the existing discovered partition layout instead of trying to rediscover it.

This is mainly being done to allow users to mess with the fstab file without it negatively affecting the customization process.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
