### PR TITLE
Fix CodeQL SM03116

### DIFF
--- a/test/vmtests/vmtests/utils/ssh_client.py
+++ b/test/vmtests/vmtests/utils/ssh_client.py
@@ -186,6 +186,7 @@ class SshClient:
         self.ssh_client = SSHClient()
 
         # Handle known hosts.
+        # CodeQL [SM03116] Test code + VMs are dynamically generated
         self.ssh_client.set_missing_host_key_policy(AutoAddPolicy)
         if known_hosts_path:
             self.ssh_client.load_host_keys(str(known_hosts_path))


### PR DESCRIPTION
The VMTests test suite uses SSH to connect to the QEMU VMs to verify the OS image's contents. CodeQL is complaining that this code is accepting unknown host keys. However, the VMs are being generated on the fly. So, there is no way to pre-learn the SSH host keys. Also, this is test code. Also, the SSH connection is occuring in a private virtual network. Therefore, suppress the warning.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
