### PR TITLE
Update VMTest python dependencies.

### DIFF
--- a/test/vmtests/requirements.txt
+++ b/test/vmtests/requirements.txt
@@ -1,5 +1,5 @@
 docker == 7.1.0
-libvirt-python == 10.9.0
-paramiko == 3.5.0
-pytest == 8.3.3
-PyYAML == 6.0.2
+libvirt-python == 11.10.0
+paramiko == 3.5.1
+pytest == 8.4.2
+PyYAML == 6.0.3


### PR DESCRIPTION
A newer version of libvirt-python is needed to support v11.6 of libvirt, which is used in Fedora 43. (Note: libvirt-python can support older libvirt versions.)

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
