### PR TITLE
Fix '.output.image' docs example.

### DIFF
--- a/docs/imagecustomizer/api/configuration/outputImage.md
+++ b/docs/imagecustomizer/api/configuration/outputImage.md
@@ -10,9 +10,10 @@ Specifies the configuration for the output image.
 Example:
 
 ```yaml
-image:
-  path: ./out/image.vhdx
-  format: vhdx
+output::
+  image:
+    path: ./out/image.vhdx
+    format: vhdx
 ```
 
 ## path [string]


### PR DESCRIPTION
Ensure example in doc shows full API, instead of just a snippet.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
