### PR TITLE
Add JSON log output.

### DIFF
--- a/docs/imagecustomizer/api/cli/cli.md
+++ b/docs/imagecustomizer/api/cli/cli.md
@@ -70,6 +70,22 @@ The levels from lowest to highest level of verbosity are: `panic`, `fatal`, `err
 
 Added in v0.3.
 
+## --log-format=FORMAT
+
+Sets the format of the logs.
+
+Options:
+
+- `text`: Output the logs as a human readable text log.
+- `json`: Output the logs as a sequence of JSON objects.
+
+Default option: `text`
+
+Note: There are no backwards-compatibility guarantees for the contents of the log
+messages.
+
+Added in v1.3.
+
 ## --version
 
 Prints the version of the tool.

--- a/docs/imagecustomizer/api/cli/cli.md
+++ b/docs/imagecustomizer/api/cli/cli.md
@@ -81,8 +81,12 @@ Options:
 
 Default option: `text`
 
-Note: There are no backwards-compatibility guarantees for the contents of the log
-messages.
+There are no backwards compatibility guarantees for the `text` log format. Both the
+format of the logs and the contents of the logs can be changed between releases.
+
+For the `json` log format, the only guarantee is that the logs are outputted as a
+sequence of JSON objects. The actual contents of the log messages can change between
+releases.
 
 Added in v1.3.
 

--- a/test/vmtests/vmtests/imagecustomizer/test_logging.py
+++ b/test/vmtests/vmtests/imagecustomizer/test_logging.py
@@ -1,11 +1,11 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+import json
+from datetime import datetime
 from pathlib import Path
 from typing import List
 
-from datetime import datetime
-import json
 from docker import DockerClient
 
 from ..conftest import TEST_CONFIGS_DIR
@@ -49,7 +49,9 @@ def test_json_logs_nochange(
 
         assert isinstance(line_json, dict)
         assert line_json.get("level") in ["panic", "fatal", "error", "warn", "info", "debug", "trace"]
-        datetime.fromisoformat(line_json.get("time"))
+        timestamp = line_json.get("time")
+        assert isinstance(timestamp, str)
+        datetime.fromisoformat(timestamp)
         assert line_json.get("msg")
 
     assert json_lines[-1].get("msg") == "Success!"

--- a/test/vmtests/vmtests/imagecustomizer/test_logging.py
+++ b/test/vmtests/vmtests/imagecustomizer/test_logging.py
@@ -1,0 +1,55 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from pathlib import Path
+from typing import List
+
+from datetime import datetime
+import json
+from docker import DockerClient
+
+from ..conftest import TEST_CONFIGS_DIR
+from ..utils.closeable import Closeable
+from ..utils.imagecustomizer import run_image_customizer
+
+
+def test_json_logs_nochange(
+    docker_client: DockerClient,
+    image_customizer_container_url: str,
+    core_efi_azl3: Path,
+    test_temp_dir: Path,
+    test_instance_name: str,
+    logs_dir: Path,
+    close_list: List[Closeable],
+) -> None:
+    input_image = core_efi_azl3
+
+    output_format = "qcow2"
+    output_image_path = test_temp_dir.joinpath("image." + output_format)
+
+    config_path = TEST_CONFIGS_DIR.joinpath("nochange-config.yaml")
+
+    _, stderr_lines = run_image_customizer(
+        docker_client,
+        image_customizer_container_url,
+        "customize",
+        config_path,
+        output_format,
+        output_image_path,
+        image_file=input_image,
+        log_format="json",
+    )
+
+    json_lines = []
+
+    # Ensure all the stderr lines are valid JSON.
+    for line in stderr_lines:
+        line_json = json.loads(line)
+        json_lines.append(line_json)
+
+        assert isinstance(line_json, dict)
+        assert line_json.get("level") in ["panic", "fatal", "error", "warn", "info", "debug", "trace"]
+        datetime.fromisoformat(line_json.get("time"))
+        assert line_json.get("msg")
+
+    assert json_lines[-1].get("msg") == "Success!"

--- a/test/vmtests/vmtests/utils/docker_utils.py
+++ b/test/vmtests/vmtests/utils/docker_utils.py
@@ -2,11 +2,12 @@
 # Licensed under the MIT License.
 
 import logging
-from typing import Any
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, List, Tuple
 
-import docker
 from docker import DockerClient
 from docker.models.containers import Container
+from docker.types.daemon import CancellableStream
 
 
 # Can be used with a `with` statement for deleting a Docker container.
@@ -25,17 +26,20 @@ class ContainerRemove:
 
 
 # Run a container, log its stdout and stderr, and wait for it to complete.
-def container_run(docker_client: DockerClient, *args: Any, **kwargs: Any) -> "docker._types.WaitContainerResponse":
+def container_run(docker_client: DockerClient, *args: Any, **kwargs: Any) -> Tuple[List[str], List[str]]:
     with ContainerRemove(docker_client.containers.run(*args, **kwargs)) as container:
         return container_log_and_wait(container.container)
 
 
 # Waits for a docker container to exit, while logging stdout and stderr.
-def container_log_and_wait(container: Container) -> "docker._types.WaitContainerResponse":
+def container_log_and_wait(container: Container) -> Tuple[List[str], List[str]]:
     # Log stdout and stderr.
-    logs = container.logs(stdout=True, stderr=True, stream=True)
-    for log in logs:
-        logging.debug(log.decode("utf-8", errors="replace").rstrip())
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        stdout_work = executor.submit(_process_logs, container.logs(stdout=True, stream=True))
+        stderr_work = executor.submit(_process_logs, container.logs(stderr=True, stream=True))
+
+        stdout_lines = stdout_work.result()
+        stderr_lines = stderr_work.result()
 
     # Wait for the container to close.
     result = container.wait()
@@ -44,4 +48,15 @@ def container_log_and_wait(container: Container) -> "docker._types.WaitContainer
     if exit_code != 0:
         raise Exception(f"Container failed with {exit_code}")
 
-    return result
+    return (stdout_lines, stderr_lines)
+
+
+def _process_logs(logs: CancellableStream[bytes]) -> List[str]:
+    lines = []
+
+    for log in logs:
+        log_str = log.decode("utf-8", errors="replace")
+        lines.append(log_str)
+        logging.debug(log_str.rstrip())
+
+    return lines

--- a/test/vmtests/vmtests/utils/docker_utils.py
+++ b/test/vmtests/vmtests/utils/docker_utils.py
@@ -35,8 +35,8 @@ def container_run(docker_client: DockerClient, *args: Any, **kwargs: Any) -> Tup
 def container_log_and_wait(container: Container) -> Tuple[List[str], List[str]]:
     # Log stdout and stderr.
     with ThreadPoolExecutor(max_workers=2) as executor:
-        stdout_work = executor.submit(_process_logs, container.logs(stdout=True, stream=True))
-        stderr_work = executor.submit(_process_logs, container.logs(stderr=True, stream=True))
+        stdout_work = executor.submit(_process_logs, container.logs(stdout=True, stderr=False, stream=True))
+        stderr_work = executor.submit(_process_logs, container.logs(stdout=False, stderr=True, stream=True))
 
         stdout_lines = stdout_work.result()
         stderr_lines = stderr_work.result()

--- a/test/vmtests/vmtests/utils/imagecustomizer.py
+++ b/test/vmtests/vmtests/utils/imagecustomizer.py
@@ -5,7 +5,7 @@ import logging
 import tempfile
 from os import fdopen
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 import yaml
 from docker import DockerClient
@@ -31,7 +31,8 @@ def run_image_customizer(
     tools_file: Path | None = None,
     distro: str | None = None,
     distro_version: str | None = None,
-) -> None:
+    log_format: str | None = None,
+) -> Tuple[List[str], List[str]]:
     container_config_dir = Path("/container/config")
     container_output_image_dir = Path("/container/output_image")
     container_build_dir = Path("/container/build")
@@ -90,12 +91,15 @@ def run_image_customizer(
     if distro_version:
         args.extend(["--distro-version", distro_version])
 
+    if log_format:
+        args.extend(["--log-format", log_format])
+
     environment = {
         "ENABLE_TELEMETRY": "true",
         "AZURE_MONITOR_CONNECTION_STRING": AZURE_CONN_STR,
     }
 
-    container_run(
+    return container_run(
         docker_client,
         image_customizer_container_url,
         args,

--- a/toolkit/tools/internal/exekong/exekong.go
+++ b/toolkit/tools/internal/exekong/exekong.go
@@ -11,19 +11,22 @@ var (
 	KongVars = kong.Vars{
 		"logcolorvalues": strings.Join(logger.Colors(), ", ") + ",",
 		"loglevelvalues": strings.Join(logger.Levels(), ", ") + ",",
+		"formatvalues":   strings.Join(logger.Formats(), ", ") + ",",
 	}
 )
 
 type LogFlags struct {
-	LogColor string `name:"log-color" placeholder:"(always|auto|never)" help:"Color setting for log terminal output." enum:"${logcolorvalues}" default:""`
-	LogFile  string `name:"log-file" help:"Path to the log file."`
-	LogLevel string `name:"log-level" placeholder:"(panic|fatal|error|warn|info|debug|trace)" help:"The minimum log level." enum:"${loglevelvalues}" default:""`
+	LogColor  string `name:"log-color" placeholder:"(always|auto|never)" help:"Color setting for log terminal output." enum:"${logcolorvalues}" default:""`
+	LogFile   string `name:"log-file" help:"Path to the log file."`
+	LogLevel  string `name:"log-level" placeholder:"(panic|fatal|error|warn|info|debug|trace)" help:"The minimum log level." enum:"${loglevelvalues}" default:""`
+	LogFormat string `name:"log-format" placeholder:"(text|json)" help:"Output format for the log." enum:"${formatvalues}" default:""`
 }
 
 func (f LogFlags) AsLoggerFlags() logger.LogFlags {
 	return logger.LogFlags{
-		LogColor: f.LogColor,
-		LogFile:  f.LogFile,
-		LogLevel: f.LogLevel,
+		LogColor:  f.LogColor,
+		LogFile:   f.LogFile,
+		LogLevel:  f.LogLevel,
+		LogFormat: f.LogFormat,
 	}
 }

--- a/toolkit/tools/internal/logger/log.go
+++ b/toolkit/tools/internal/logger/log.go
@@ -7,6 +7,7 @@ package logger
 
 import (
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 
@@ -25,6 +26,9 @@ var (
 
 	// Valid log colors
 	colorsArray = []string{colorModeAlways, colorModeAuto, colorModeNever}
+
+	// Valid log formats
+	formatsArray = []string{formatText, formatJson}
 )
 
 const (
@@ -34,16 +38,20 @@ const (
 	colorModeAuto   = "auto"
 	colorModeAlways = "always"
 	colorModeNever  = "never"
+
+	formatText = "text"
+	formatJson = "json"
 )
 
 type LogFlags struct {
-	LogColor string
-	LogFile  string
-	LogLevel string
+	LogColor  string
+	LogFile   string
+	LogLevel  string
+	LogFormat string
 }
 
 // initLogFile initializes the common logger with a file
-func initLogFile(filePath string, color string) (err error) {
+func initLogFile(filePath string, color string, outputFormat string) (err error) {
 	useColors := false
 	if color == colorModeAlways {
 		useColors = true
@@ -59,7 +67,7 @@ func initLogFile(filePath string, color string) (err error) {
 		return
 	}
 
-	fileHook = newWriterHook(file, defaultLogFileLevel, useColors)
+	fileHook = newWriterHook(file, defaultLogFileLevel, useColors, outputFormat)
 	Log.Hooks.Add(fileHook)
 	Log.SetLevel(defaultLogFileLevel)
 
@@ -68,7 +76,7 @@ func initLogFile(filePath string, color string) (err error) {
 
 // InitStderrLog initializes the logger to print to stderr
 func InitStderrLog() {
-	initStderrLogInternal(colorModeAuto)
+	initStderrLogInternal(colorModeAuto, formatText)
 }
 
 // SetStderrLogLevel sets the lowest log level for stderr output
@@ -81,15 +89,20 @@ func InitBestEffort(lf LogFlags) {
 	level := lf.LogLevel
 	color := lf.LogColor
 	path := lf.LogFile
+	format := lf.LogFormat
 
 	if level == "" {
 		level = defaultStderrLogLevel.String()
 	}
 
-	initStderrLogInternal(color)
+	if format == formatJson && color == colorModeAlways {
+		log.Fatal("log-color cannot be set to 'always' when log-format is 'json'")
+	}
+
+	initStderrLogInternal(color, format)
 
 	if path != "" {
-		fatalOnError(initLogFile(path, color), "Failed while setting log file (%s).", path)
+		fatalOnError(initLogFile(path, color, format), "Failed while setting log file (%s).", path)
 	}
 
 	fatalOnError(SetStderrLogLevel(level), "Failed while setting log level.")
@@ -105,6 +118,11 @@ func Colors() []string {
 	return colorsArray
 }
 
+// Formats returns list of strings representing valid log formats.
+func Formats() []string {
+	return formatsArray
+}
+
 // fatalOnError logs a fatal error and any message strings, then exits (while
 // running any cleanup functions registered with the log package)
 func fatalOnError(err error, args ...interface{}) {
@@ -116,7 +134,7 @@ func fatalOnError(err error, args ...interface{}) {
 	}
 }
 
-func initStderrLogInternal(color string) {
+func initStderrLogInternal(color string, outputFormat string) {
 	useColors := true
 	if color == colorModeNever {
 		useColors = false
@@ -125,7 +143,7 @@ func initStderrLogInternal(color string) {
 	Log = logrus.New()
 
 	// By default send all log messages through stderrHook
-	stderrHook = newWriterHook(os.Stderr, defaultStderrLogLevel, useColors)
+	stderrHook = newWriterHook(os.Stderr, defaultStderrLogLevel, useColors, outputFormat)
 	Log.AddHook(stderrHook)
 	Log.SetLevel(defaultStderrLogLevel)
 	Log.SetOutput(io.Discard)

--- a/toolkit/tools/internal/logger/writerhook.go
+++ b/toolkit/tools/internal/logger/writerhook.go
@@ -27,9 +27,18 @@ var (
 )
 
 // newWriterHook returns new writerHook
-func newWriterHook(writer io.Writer, level logrus.Level, useColors bool) *writerHook {
-	formatter := &logrus.TextFormatter{
-		ForceColors: useColors,
+func newWriterHook(writer io.Writer, level logrus.Level, useColors bool, outputFormat string,
+) *writerHook {
+	var formatter logrus.Formatter
+	switch outputFormat {
+	case formatJson:
+		useColors = false
+		formatter = &logrus.JSONFormatter{}
+
+	default:
+		formatter = &logrus.TextFormatter{
+			ForceColors: useColors,
+		}
 	}
 
 	return &writerHook{


### PR DESCRIPTION
Add CLI option to change log output to output JSON objects instead of pure text. This will allow programmatic callers of Image Customizer to more easily parse and filter the logs.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
