### PR TITLE
Fix VMTests type annotations.

### DIFF
--- a/test/vmtests/vmtests/utils/docker_utils.py
+++ b/test/vmtests/vmtests/utils/docker_utils.py
@@ -51,7 +51,7 @@ def container_log_and_wait(container: Container) -> Tuple[List[str], List[str]]:
     return (stdout_lines, stderr_lines)
 
 
-def _process_logs(logs: CancellableStream[bytes]) -> List[str]:
+def _process_logs(logs: "CancellableStream[bytes]") -> List[str]:
     lines = []
 
     for log in logs:


### PR DESCRIPTION
Python v3.12 doesn't support subscripts on user defined types. So, wrap the offending type declaration in a string.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
