### PR TITLE
Carry over settings for reinit verity.

### DIFF
--- a/toolkit/tools/imagecustomizerapi/verity.go
+++ b/toolkit/tools/imagecustomizerapi/verity.go
@@ -19,6 +19,11 @@ const (
 
 	VerityRootDevicePath = DeviceMapperPath + "/" + VerityRootDeviceName
 	VerityUsrDevicePath  = DeviceMapperPath + "/" + VerityUsrDeviceName
+
+	// Default settings for verity format.
+	DefaultVerityHashAlgorithm = "sha256"
+	DefaultVerityDataBlockSize = 4096
+	DefaultVerityHashBlockSize = 4096
 )
 
 var (

--- a/toolkit/tools/internal/verityutils/superblock.go
+++ b/toolkit/tools/internal/verityutils/superblock.go
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package verityutils
+
+import (
+	"bytes"
+)
+
+// From: https://gitlab.com/cryptsetup/cryptsetup/-/wikis/DMVerity
+type VeritySuperBlock struct {
+	Signature     [8]uint8   // "verity\0\0"
+	Version       uint32     // Superblock version: 1
+	HashType      uint32     // 0: Chrome OS, 1: normal
+	Uuid          [16]uint8  // UUID of hash device
+	Algorithm     [32]uint8  // Hash algorithm name
+	DataBlockSize uint32     // Data block in bytes
+	HashBlockSize uint32     // Hash block in bytes
+	DataBlocks    uint64     // Number of data blocks
+	SaltSize      uint16     // Salt size
+	Pad1          [6]uint8   // Padding
+	Salt          [256]uint8 // Salt
+	Pad2          [168]uint8 // Padding
+}
+
+func (s *VeritySuperBlock) GetAlgorithm() string {
+	algorithmBytes, _, _ := bytes.Cut(s.Algorithm[:], []byte{0})
+	algorithm := string(algorithmBytes)
+	return algorithm
+}

--- a/toolkit/tools/internal/verityutils/verityutils.go
+++ b/toolkit/tools/internal/verityutils/verityutils.go
@@ -1,42 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-package imagecustomizerlib
+package verityutils
 
 import (
-	"bytes"
 	"encoding/binary"
 	"fmt"
 	"os"
 )
 
-// From: https://gitlab.com/cryptsetup/cryptsetup/-/wikis/DMVerity
-type veritySuperBlock struct {
-	Signature     [8]uint8   // "verity\0\0"
-	Version       uint32     // Superblock version: 1
-	HashType      uint32     // 0: Chrome OS, 1: normal
-	Uuid          [16]uint8  // UUID of hash device
-	Algorithm     [32]uint8  // Hash algorithm name
-	DataBlockSize uint32     // Data block in bytes
-	HashBlockSize uint32     // Hash block in bytes
-	DataBlocks    uint64     // Number of data blocks
-	SaltSize      uint16     // Salt size
-	Pad1          [6]uint8   // Padding
-	Salt          [256]uint8 // Salt
-	Pad2          [168]uint8 // Padding
-}
-
-func calculateHashFileSizeInBytes(hashPartitionPath string) (uint64, error) {
-	hashPartition, err := os.Open(hashPartitionPath)
+func CalculateHashFileSizeInBytes(hashPartitionPath string) (uint64, error) {
+	superblock, err := ReadVeritySuperblock(hashPartitionPath)
 	if err != nil {
-		return 0, fmt.Errorf("failed to open hash partition (%s) block device:\n%w", hashPartitionPath, err)
-	}
-	defer hashPartition.Close()
-
-	superblock := veritySuperBlock{}
-	err = binary.Read(hashPartition, binary.LittleEndian, &superblock)
-	if err != nil {
-		return 0, fmt.Errorf("failed to read hash partition's (%s) superblock:\n%w", hashPartitionPath, err)
+		return 0, err
 	}
 
 	sizeInBytes, err := calculateHashFileSizeInBytesFromSuperBlock(superblock)
@@ -47,7 +23,23 @@ func calculateHashFileSizeInBytes(hashPartitionPath string) (uint64, error) {
 	return sizeInBytes, nil
 }
 
-func calculateHashFileSizeInBytesFromSuperBlock(superblock veritySuperBlock) (uint64, error) {
+func ReadVeritySuperblock(hashPartitionPath string) (VeritySuperBlock, error) {
+	hashPartition, err := os.Open(hashPartitionPath)
+	if err != nil {
+		return VeritySuperBlock{}, fmt.Errorf("failed to open hash partition (%s) block device:\n%w", hashPartitionPath, err)
+	}
+	defer hashPartition.Close()
+
+	superblock := VeritySuperBlock{}
+	err = binary.Read(hashPartition, binary.LittleEndian, &superblock)
+	if err != nil {
+		return VeritySuperBlock{}, fmt.Errorf("failed to read hash partition's (%s) superblock:\n%w", hashPartitionPath, err)
+	}
+
+	return superblock, nil
+}
+
+func calculateHashFileSizeInBytesFromSuperBlock(superblock VeritySuperBlock) (uint64, error) {
 	var err error
 
 	if string(superblock.Signature[:]) != "verity\x00\x00" {
@@ -62,8 +54,7 @@ func calculateHashFileSizeInBytesFromSuperBlock(superblock veritySuperBlock) (ui
 		return 0, fmt.Errorf("unsupported hash type (%d)", superblock.HashType)
 	}
 
-	algorithmBytes, _, _ := bytes.Cut(superblock.Algorithm[:], []byte{0})
-	algorithm := string(algorithmBytes)
+	algorithm := superblock.GetAlgorithm()
 
 	hashSize := uint32(0)
 	switch algorithm {
@@ -134,12 +125,4 @@ func roundUpToPowerOf2(n uint32) uint32 {
 		res *= 2
 	}
 	return res
-}
-
-func getVerityNames(verity []verityDeviceMetadata) []string {
-	verityNames := make([]string, len(verity))
-	for i, v := range verity {
-		verityNames[i] = v.name
-	}
-	return verityNames
 }

--- a/toolkit/tools/internal/verityutils/verityutils.go
+++ b/toolkit/tools/internal/verityutils/verityutils.go
@@ -38,7 +38,7 @@ func ReadVeritySuperblock(hashPartitionPath string) (VeritySuperBlock, error) {
 
 	err = verifySuperblock(superblock)
 	if err != nil {
-		return VeritySuperBlock{}, nil
+		return VeritySuperBlock{}, err
 	}
 
 	return superblock, nil
@@ -97,7 +97,7 @@ func calculateHashFileSizeInBytesFromSuperBlock(superblock VeritySuperBlock) (ui
 		return 0, err
 	}
 
-	sizeInBytes, err := calculateHashFileSizeInBytesHelper(superblock.DataBlocks, superblock.DataBlockSize, hashSize)
+	sizeInBytes, err := calculateHashFileSizeInBytesHelper(superblock.DataBlocks, superblock.HashBlockSize, hashSize)
 	if err != nil {
 		return 0, err
 	}

--- a/toolkit/tools/internal/verityutils/verityutils.go
+++ b/toolkit/tools/internal/verityutils/verityutils.go
@@ -36,43 +36,68 @@ func ReadVeritySuperblock(hashPartitionPath string) (VeritySuperBlock, error) {
 		return VeritySuperBlock{}, fmt.Errorf("failed to read hash partition's (%s) superblock:\n%w", hashPartitionPath, err)
 	}
 
+	err = verifySuperblock(superblock)
+	if err != nil {
+		return VeritySuperBlock{}, nil
+	}
+
 	return superblock, nil
+}
+
+func verifySuperblock(superblock VeritySuperBlock) error {
+	if string(superblock.Signature[:]) != "verity\x00\x00" {
+		return fmt.Errorf("wrong superblock signature")
+	}
+
+	if superblock.Version != 1 {
+		return fmt.Errorf("unsupported version (%d)", superblock.Version)
+	}
+
+	if superblock.HashType != 1 {
+		return fmt.Errorf("unsupported hash type (%d)", superblock.HashType)
+	}
+
+	hashSize, err := getAlgorithmHashSize(superblock.GetAlgorithm())
+	if err != nil {
+		return err
+	}
+
+	if !isPowerOf2(superblock.DataBlockSize) {
+		return fmt.Errorf("invalid data block size (%d)", superblock.DataBlockSize)
+	}
+
+	if !isPowerOf2(superblock.HashBlockSize) || superblock.HashBlockSize < hashSize {
+		return fmt.Errorf("invalid hash block size (%d)", superblock.HashBlockSize)
+	}
+
+	return nil
+}
+
+func getAlgorithmHashSize(algorithm string) (uint32, error) {
+	switch algorithm {
+	case "sha256":
+		return 32, nil
+
+	case "sha384":
+		return 48, nil
+
+	case "sha512":
+		return 64, nil
+
+	default:
+		return 0, fmt.Errorf("unknown hash algorithm (%s)", algorithm)
+	}
 }
 
 func calculateHashFileSizeInBytesFromSuperBlock(superblock VeritySuperBlock) (uint64, error) {
 	var err error
 
-	if string(superblock.Signature[:]) != "verity\x00\x00" {
-		return 0, fmt.Errorf("wrong superblock signature")
+	hashSize, err := getAlgorithmHashSize(superblock.GetAlgorithm())
+	if err != nil {
+		return 0, err
 	}
 
-	if superblock.Version != 1 {
-		return 0, fmt.Errorf("unsupported version (%d)", superblock.Version)
-	}
-
-	if superblock.HashType != 1 {
-		return 0, fmt.Errorf("unsupported hash type (%d)", superblock.HashType)
-	}
-
-	algorithm := superblock.GetAlgorithm()
-
-	hashSize := uint32(0)
-	switch algorithm {
-	case "sha256":
-		hashSize = 32
-
-	case "sha384":
-		hashSize = 48
-
-	case "sha512":
-		hashSize = 64
-
-	default:
-		return 0, fmt.Errorf("unknown hash algorithm (%s)", algorithm)
-	}
-
-	sizeInBytes, err := calculateHashFileSizeInBytesHelper(superblock.DataBlocks, superblock.DataBlockSize,
-		superblock.HashBlockSize, hashSize)
+	sizeInBytes, err := calculateHashFileSizeInBytesHelper(superblock.DataBlocks, superblock.DataBlockSize, hashSize)
 	if err != nil {
 		return 0, err
 	}
@@ -80,17 +105,7 @@ func calculateHashFileSizeInBytesFromSuperBlock(superblock VeritySuperBlock) (ui
 	return sizeInBytes, nil
 }
 
-func calculateHashFileSizeInBytesHelper(dataBlocksCount uint64, dataBlockSize uint32, hashBlockSize uint32,
-	hashSize uint32,
-) (uint64, error) {
-	if !isPowerOf2(dataBlockSize) {
-		return 0, fmt.Errorf("invalid data block size (%d)", dataBlockSize)
-	}
-
-	if !isPowerOf2(hashBlockSize) || hashBlockSize < hashSize {
-		return 0, fmt.Errorf("invalid hash block size (%d)", hashBlockSize)
-	}
-
+func calculateHashFileSizeInBytesHelper(dataBlocksCount uint64, hashBlockSize uint32, hashSize uint32) (uint64, error) {
 	// dm-verity pads each hash to the nearest power-of-2 to make the math easier.
 	hashSizeFull := roundUpToPowerOf2(hashSize)
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
@@ -767,7 +767,7 @@ func verityFormat(diskDevicePath string, dataPartitionPath string, hashPartition
 		"format", dataPartitionPath, hashPartitionPath,
 		"--hash", formatSettings.hashAlgorithm,
 		"--data-block-size", fmt.Sprintf("%d", formatSettings.dataBlockSizeBytes),
-		"--data-block-size", fmt.Sprintf("%d", formatSettings.hashBlockSizeBytes),
+		"--hash-block-size", fmt.Sprintf("%d", formatSettings.hashBlockSizeBytes),
 	}
 
 	verityOutput, _, err := shell.NewExecBuilder("veritysetup", formatArgs...).

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
@@ -44,7 +44,6 @@ var (
 	ErrFindVerityDataPartition           = NewImageCustomizerError("Verity:FindDataPartition", "failed to find verity data partition")
 	ErrFindVerityHashPartition           = NewImageCustomizerError("Verity:FindHashPartition", "failed to find verity hash partition")
 	ErrCalculateRootHash                 = NewImageCustomizerError("Verity:CalculateRootHash", "failed to calculate root hash")
-	ErrUnalignedVerityDataSize           = NewImageCustomizerError("Verity:UnalignedDataSize", "data size is not a multiple of the data block size")
 	ErrCompileRootHashRegex              = NewImageCustomizerError("Verity:CompileRootHashRegex", "failed to compile root hash regex")
 	ErrParseRootHash                     = NewImageCustomizerError("Verity:ParseRootHash", "failed to parse root hash from veritysetup output")
 	ErrCalculateHashSize                 = NewImageCustomizerError("Verity:CalculateHashSize", "failed to calculate hash partition size")
@@ -797,7 +796,7 @@ func verityFormat(diskDevicePath string, dataPartitionPath string, hashPartition
 		return "", fmt.Errorf("%w (device='%s'):\n%w", ErrUpdateDisk, diskDevicePath, err)
 	}
 
-	// Calculate the size of the hash partition from it's superblock.
+	// Calculate the size of the hash partition from its superblock.
 	// In newer `veritysetup` versions, `veritysetup format` returns the size in its output. But that feature
 	// is too new for now.
 	hashPartitionSizeInBytes, err := verityutils.CalculateHashFileSizeInBytes(hashPartitionPath)

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
@@ -23,6 +23,7 @@ import (
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safemount"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/shell"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/sliceutils"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/verityutils"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -43,6 +44,7 @@ var (
 	ErrFindVerityDataPartition           = NewImageCustomizerError("Verity:FindDataPartition", "failed to find verity data partition")
 	ErrFindVerityHashPartition           = NewImageCustomizerError("Verity:FindHashPartition", "failed to find verity hash partition")
 	ErrCalculateRootHash                 = NewImageCustomizerError("Verity:CalculateRootHash", "failed to calculate root hash")
+	ErrUnalignedVerityDataSize           = NewImageCustomizerError("Verity:UnalignedDataSize", "data size is not a multiple of the data block size")
 	ErrCompileRootHashRegex              = NewImageCustomizerError("Verity:CompileRootHashRegex", "failed to compile root hash regex")
 	ErrParseRootHash                     = NewImageCustomizerError("Verity:ParseRootHash", "failed to parse root hash from veritysetup output")
 	ErrCalculateHashSize                 = NewImageCustomizerError("Verity:CalculateHashSize", "failed to calculate hash partition size")
@@ -620,7 +622,7 @@ func findIdentifiedPartition(partitions []diskutils.PartitionInfo, ref imagecust
 	return partition, nil
 }
 
-func customizeVerityImageHelper(ctx context.Context, buildDir string, rc *ResolvedConfig,
+func customizeVerityImage(ctx context.Context, buildDir string, rc *ResolvedConfig,
 	buildImageFile string, partIdToPartUuid map[string]string, shrinkHashPartition bool,
 	baseImageVerity []verityDeviceMetadata, readonlyPartUuids []string,
 	partitionsLayout []fstabEntryPartNum,
@@ -670,7 +672,7 @@ func customizeVerityImageHelper(ctx context.Context, buildDir string, rc *Resolv
 
 			// Format hash partition.
 			rootHash, err := verityFormat(loopback.DevicePath(), dataPartition.Path, hashPartition.Path,
-				shrinkHashPartition, sectorSize, metadata.name)
+				shrinkHashPartition, sectorSize, metadata.name, metadata.formatSettings)
 			if err != nil {
 				return nil, err
 			}
@@ -696,8 +698,14 @@ func customizeVerityImageHelper(ctx context.Context, buildDir string, rc *Resolv
 		}
 
 		// Format hash partition.
+		formatSettings := verityFormatSettings{
+			hashAlgorithm:      imagecustomizerapi.DefaultVerityHashAlgorithm,
+			dataBlockSizeBytes: imagecustomizerapi.DefaultVerityDataBlockSize,
+			hashBlockSizeBytes: imagecustomizerapi.DefaultVerityHashBlockSize,
+		}
+
 		rootHash, err := verityFormat(loopback.DevicePath(), dataPartition.Path, hashPartition.Path,
-			shrinkHashPartition, sectorSize, verityConfig.Name)
+			shrinkHashPartition, sectorSize, verityConfig.Name, formatSettings)
 		if err != nil {
 			return nil, err
 		}
@@ -711,6 +719,7 @@ func customizeVerityImageHelper(ctx context.Context, buildDir string, rc *Resolv
 			hashDeviceMountIdType: verityConfig.HashDeviceMountIdType,
 			corruptionOption:      verityConfig.CorruptionOption,
 			hashSignaturePath:     verityConfig.HashSignaturePath,
+			formatSettings:        formatSettings,
 		}
 		verityMetadata = append(verityMetadata, metadata)
 		verityUpdated = true
@@ -752,10 +761,17 @@ func customizeVerityImageHelper(ctx context.Context, buildDir string, rc *Resolv
 }
 
 func verityFormat(diskDevicePath string, dataPartitionPath string, hashPartitionPath string, shrinkHashPartition bool,
-	sectorSize uint64, name string,
+	sectorSize uint64, name string, formatSettings verityFormatSettings,
 ) (string, error) {
 	// Write hash partition.
-	verityOutput, _, err := shell.NewExecBuilder("veritysetup", "format", dataPartitionPath, hashPartitionPath).
+	formatArgs := []string{
+		"format", dataPartitionPath, hashPartitionPath,
+		"--hash", formatSettings.hashAlgorithm,
+		"--data-block-size", fmt.Sprintf("%d", formatSettings.dataBlockSizeBytes),
+		"--data-block-size", fmt.Sprintf("%d", formatSettings.hashBlockSizeBytes),
+	}
+
+	verityOutput, _, err := shell.NewExecBuilder("veritysetup", formatArgs...).
 		LogLevel(logrus.DebugLevel, logrus.DebugLevel).
 		ErrorStderrLines(1).
 		ExecuteCaptureOutput()
@@ -784,7 +800,7 @@ func verityFormat(diskDevicePath string, dataPartitionPath string, hashPartition
 	// Calculate the size of the hash partition from it's superblock.
 	// In newer `veritysetup` versions, `veritysetup format` returns the size in its output. But that feature
 	// is too new for now.
-	hashPartitionSizeInBytes, err := calculateHashFileSizeInBytes(hashPartitionPath)
+	hashPartitionSizeInBytes, err := verityutils.CalculateHashFileSizeInBytes(hashPartitionPath)
 	if err != nil {
 		return "", fmt.Errorf("%w (partition='%s'):\n%w", ErrCalculateHashSize, hashPartitionPath, err)
 	}
@@ -858,4 +874,12 @@ func updateKernelArgsForVerity(buildDir string, diskPartitions []diskutils.Parti
 	}
 
 	return nil
+}
+
+func getVerityNames(verity []verityDeviceMetadata) []string {
+	verityNames := make([]string, len(verity))
+	for i, v := range verity {
+		verityNames[i] = v.name
+	}
+	return verityNames
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -115,17 +115,6 @@ type imageMetadata struct {
 	partitionOriginalSizes map[string]uint64
 }
 
-type verityDeviceMetadata struct {
-	name                  string
-	rootHash              string
-	dataPartUuid          string
-	hashPartUuid          string
-	dataDeviceMountIdType imagecustomizerapi.MountIdentifierType
-	hashDeviceMountIdType imagecustomizerapi.MountIdentifierType
-	corruptionOption      imagecustomizerapi.CorruptionOption
-	hashSignaturePath     string
-}
-
 func CustomizeImageWithConfigFile(ctx context.Context, buildDir string, configFile string, inputImageFile string,
 	rpmsSources []string, outputImageFile string, outputImageFormat string,
 	useBaseImageRpmRepos bool, packageSnapshotTime string,
@@ -524,7 +513,7 @@ func customizeOSContents(ctx context.Context, rc *ResolvedConfig) (imageMetadata
 
 	if len(rc.Storage.Verity) > 0 || len(im.baseImageVerityMetadata) > 0 {
 		// Customize image for dm-verity, setting up verity metadata and security features.
-		verityMetadata, err := customizeVerityImageHelper(ctx, rc.BuildDirAbs, rc, rc.RawImageFile,
+		verityMetadata, err := customizeVerityImage(ctx, rc.BuildDirAbs, rc, rc.RawImageFile,
 			partIdToPartUuid, shrinkPartitions, im.baseImageVerityMetadata, readonlyPartUuids, partitionsLayout)
 		if err != nil {
 			return im, fmt.Errorf("%w:\n%w", ErrCustomizeProvisionVerity, err)

--- a/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
@@ -657,7 +657,7 @@ func findVerityPartitionsFromCmdline(partitions []diskutils.PartitionInfo, cmdli
 
 	veritySuperblock, err := verityutils.ReadVeritySuperblock(hashPartition.Path)
 	if err != nil {
-		err = fmt.Errorf("failed read verity superblock:\n%w", err)
+		err = fmt.Errorf("failed to read verity superblock:\n%w", err)
 		return diskutils.PartitionInfo{}, 0, verityDeviceMetadata{}, err
 	}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
@@ -26,6 +26,7 @@ import (
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safemount"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/shell"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/sliceutils"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/verityutils"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
@@ -654,6 +655,12 @@ func findVerityPartitionsFromCmdline(partitions []diskutils.PartitionInfo, cmdli
 		return diskutils.PartitionInfo{}, 0, verityDeviceMetadata{}, err
 	}
 
+	veritySuperblock, err := verityutils.ReadVeritySuperblock(hashPartition.Path)
+	if err != nil {
+		err = fmt.Errorf("failed read verity superblock:\n%w", err)
+		return diskutils.PartitionInfo{}, 0, verityDeviceMetadata{}, err
+	}
+
 	verityMetadata := verityDeviceMetadata{
 		name:                  name,
 		rootHash:              hash,
@@ -663,6 +670,11 @@ func findVerityPartitionsFromCmdline(partitions []diskutils.PartitionInfo, cmdli
 		hashDeviceMountIdType: hashIdType,
 		corruptionOption:      corruptionOption,
 		hashSignaturePath:     hashSigPath,
+		formatSettings: verityFormatSettings{
+			hashAlgorithm:      veritySuperblock.GetAlgorithm(),
+			dataBlockSizeBytes: veritySuperblock.DataBlockSize,
+			hashBlockSizeBytes: veritySuperblock.HashBlockSize,
+		},
 	}
 
 	return dataPartition, dataPartitionIndex, verityMetadata, nil

--- a/toolkit/tools/pkg/imagecustomizerlib/veritytypes.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/veritytypes.go
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerlib
+
+import (
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
+)
+
+type verityDeviceMetadata struct {
+	name                  string
+	rootHash              string
+	dataPartUuid          string
+	hashPartUuid          string
+	dataDeviceMountIdType imagecustomizerapi.MountIdentifierType
+	hashDeviceMountIdType imagecustomizerapi.MountIdentifierType
+	corruptionOption      imagecustomizerapi.CorruptionOption
+	hashSignaturePath     string
+	formatSettings        verityFormatSettings
+}
+
+type verityFormatSettings struct {
+	hashAlgorithm      string
+	dataBlockSizeBytes uint32
+	hashBlockSizeBytes uint32
+}


### PR DESCRIPTION
When reinitializing verity, carry over the original verity format settings. While Image Customizer doesn't provide the option to change the verity format settings yet, it is expected to customize images not built by itself.

Also, when calling `veritysetup format`, hardcode the defaults we want IC to use. This will ensure consistency even if the defaults inside `veritysetup` ever change.

Also, move the `verityutils.go` file into its own Go package. This preparing for a future change, where the `imagecustomizerapi` pacakge will need access to these functions.

This change is being done in preparation for a future change where support for inline verity will be added.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
