### PR TITLE
Add support for inline verity.

### DIFF
--- a/docs/imagecustomizer/api/configuration/verity.md
+++ b/docs/imagecustomizer/api/configuration/verity.md
@@ -190,6 +190,11 @@ partition.
 
 Must be used with `hashDeviceId`.
 
+If `dataDeviceId` and `hashDeviceId` are set to the same value, then the verity hash
+tree is placed at the end of partition behind the filesystem. The sizes of the
+filesystem and verity hash tree are automatically calculated to fill the entire
+partition.
+
 Added in v0.7.
 
 ## dataDeviceMountIdType [string]

--- a/toolkit/tools/imagecustomizerapi/disk.go
+++ b/toolkit/tools/imagecustomizerapi/disk.go
@@ -202,4 +202,6 @@ func partFillSizeAndEnd(p *Partition, end DiskSize) {
 		p.Size.Type = PartitionSizeTypeExplicit
 		p.Size.Size = end - *p.Start
 	}
+
+	p.filled = true
 }

--- a/toolkit/tools/imagecustomizerapi/disk.go
+++ b/toolkit/tools/imagecustomizerapi/disk.go
@@ -178,6 +178,9 @@ func roundDown(size uint64, alignment uint64) uint64 {
 	if mod == 0 {
 		return size
 	}
+	if div == 0 {
+		return 0
+	}
 	return (div - 1) * alignment
 }
 

--- a/toolkit/tools/imagecustomizerapi/disk.go
+++ b/toolkit/tools/imagecustomizerapi/disk.go
@@ -66,8 +66,8 @@ func (d *Disk) IsValid() error {
 			if i == 0 {
 				partition.Start = ptrutils.PtrTo(DiskSize(DefaultPartitionAlignment))
 			} else {
-				prev := d.Partitions[i-1]
-				prevEnd, prevHasEnd := prev.GetEnd()
+				prev := &d.Partitions[i-1]
+				prevEnd, prevHasEnd := partGetEnd(prev)
 				if !prevHasEnd {
 					return fmt.Errorf("partition (%s) omitted start value but previous partition (%s) has no size or end value",
 						partition.Id, prev.Id)
@@ -85,15 +85,15 @@ func (d *Disk) IsValid() error {
 
 	// Confirm each partition ends before the next starts.
 	for i := 0; i < len(d.Partitions)-1; i++ {
-		a := d.Partitions[i]
-		b := d.Partitions[i+1]
+		a := &d.Partitions[i]
+		b := &d.Partitions[i+1]
 
-		aEnd, aHasEnd := a.GetEnd()
+		aEnd, aHasEnd := partGetEnd(a)
 		if !aHasEnd {
 			return fmt.Errorf("partition (%s) is not last partition but size is set to \"grow\"", a.Id)
 		}
 		if aEnd > *b.Start {
-			bEnd, bHasEnd := b.GetEnd()
+			bEnd, bHasEnd := partGetEnd(b)
 			bEndStr := ""
 			if bHasEnd {
 				bEndStr = bEnd.HumanReadable()
@@ -101,6 +101,9 @@ func (d *Disk) IsValid() error {
 			return fmt.Errorf("partition's (%s) range [%s, %s) overlaps partition's (%s) range [%s, %s)",
 				a.Id, a.Start.HumanReadable(), aEnd.HumanReadable(), b.Id, b.Start.HumanReadable(), bEndStr)
 		}
+
+		// Fill in the End and Size values to make life easier for downstream code.
+		partFillSizeAndEnd(a, aEnd)
 	}
 
 	if d.MaxSize == nil && len(d.Partitions) <= 0 {
@@ -117,7 +120,7 @@ func (d *Disk) IsValid() error {
 
 		// Verify MaxSize value.
 		lastPartition := &d.Partitions[len(d.Partitions)-1]
-		lastPartitionEnd, lastPartitionHasEnd := lastPartition.GetEnd()
+		lastPartitionEnd, lastPartitionHasEnd := partGetEnd(lastPartition)
 
 		switch {
 		case !lastPartitionHasEnd && d.MaxSize == nil:
@@ -128,6 +131,8 @@ func (d *Disk) IsValid() error {
 			// Fill in the disk's size.
 			diskSize := lastPartitionEnd + gptFooterSize
 			d.MaxSize = &diskSize
+
+			partFillSizeAndEnd(lastPartition, lastPartitionEnd)
 
 		default:
 			// Check that the disk is big enough for the partition layout.
@@ -150,7 +155,7 @@ func (d *Disk) IsValid() error {
 				// This allows us to control the alignment of the GPT footer instead of relying on the behavior of the
 				// partitioning tool (e.g. sfdisk).
 				lastPartitionEnd := *d.MaxSize - gptFooterSize
-				lastPartition.End = &lastPartitionEnd
+				partFillSizeAndEnd(lastPartition, lastPartitionEnd)
 			}
 		}
 	}
@@ -165,4 +170,36 @@ func roundUp(size uint64, alignment uint64) uint64 {
 		return size
 	}
 	return (div + 1) * alignment
+}
+
+func roundDown(size uint64, alignment uint64) uint64 {
+	div := size / alignment
+	mod := size % alignment
+	if mod == 0 {
+		return size
+	}
+	return (div - 1) * alignment
+}
+
+func partGetEnd(p *Partition) (DiskSize, bool) {
+	if p.End != nil {
+		return *p.End, true
+	}
+
+	if p.Size.Type == PartitionSizeTypeExplicit {
+		return *p.Start + p.Size.Size, true
+	}
+
+	return 0, false
+}
+
+func partFillSizeAndEnd(p *Partition, end DiskSize) {
+	if p.End == nil {
+		p.End = &end
+	}
+
+	if p.Size.Type != PartitionSizeTypeExplicit {
+		p.Size.Type = PartitionSizeTypeExplicit
+		p.Size.Size = end - *p.Start
+	}
 }

--- a/toolkit/tools/imagecustomizerapi/filesystem.go
+++ b/toolkit/tools/imagecustomizerapi/filesystem.go
@@ -22,6 +22,12 @@ type FileSystem struct {
 	// Otherwise, it is the same as 'DeviceId'.
 	// Value is filled in by Storage.IsValid().
 	PartitionId string `json:"-"`
+
+	// The size of the filesystem in bytes.
+	// Used to limit the size of the filesystem when inline verity is used.
+	// A value of 0 means the filesystem should fill the entire partition.
+	// Value is filled in by Storage.IsValid().
+	Size uint64 `json:"-"`
 }
 
 // IsValid returns an error if the MountPoint is not valid

--- a/toolkit/tools/imagecustomizerapi/partition.go
+++ b/toolkit/tools/imagecustomizerapi/partition.go
@@ -24,6 +24,7 @@ type Partition struct {
 	Type PartitionType `yaml:"type" json:"type,omitempty"`
 
 	// Note: Start, End, and Size are filled in by Disk.IsValid().
+	filled bool `json:"-"`
 }
 
 func (p *Partition) IsValid() error {
@@ -32,7 +33,7 @@ func (p *Partition) IsValid() error {
 		return err
 	}
 
-	if p.End != nil && p.Size.Type != PartitionSizeTypeUnset {
+	if !p.filled && p.End != nil && p.Size.Type != PartitionSizeTypeUnset {
 		return fmt.Errorf("cannot specify both end and size on partition (%s)", p.Id)
 	}
 

--- a/toolkit/tools/imagecustomizerapi/partition.go
+++ b/toolkit/tools/imagecustomizerapi/partition.go
@@ -22,6 +22,8 @@ type Partition struct {
 	Size PartitionSize `yaml:"size" json:"size,omitempty"`
 	// Type specifies the type of the partition.
 	Type PartitionType `yaml:"type" json:"type,omitempty"`
+
+	// Note: Start, End, and Size are filled in by Disk.IsValid().
 }
 
 func (p *Partition) IsValid() error {
@@ -44,18 +46,6 @@ func (p *Partition) IsValid() error {
 	}
 
 	return nil
-}
-
-func (p *Partition) GetEnd() (DiskSize, bool) {
-	if p.End != nil {
-		return *p.End, true
-	}
-
-	if p.Size.Type == PartitionSizeTypeExplicit {
-		return *p.Start + p.Size.Size, true
-	}
-
-	return 0, false
 }
 
 // isGPTNameValid checks if a GPT partition name is valid.

--- a/toolkit/tools/imagecustomizerapi/storage.go
+++ b/toolkit/tools/imagecustomizerapi/storage.go
@@ -232,8 +232,8 @@ func (s *Storage) IsValid() error {
 
 					dataSize, err = calculateInlineVerityDataSize(uint64(partition.Size.Size))
 					if err != nil {
-						return fmt.Errorf("failed to caclulate inline verity device's (%d) data size:\n%w", err,
-							filesystem.DeviceId)
+						return fmt.Errorf("failed to caclulate inline verity device's (%s) data size:\n%w",
+							filesystem.DeviceId, err)
 					}
 
 					filesystem.Size = dataSize

--- a/toolkit/tools/imagecustomizerapi/storage.go
+++ b/toolkit/tools/imagecustomizerapi/storage.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/logger"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/sliceutils"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/verityutils"
 )
 
 type VerityPartitionsType int
@@ -217,19 +218,33 @@ func (s *Storage) IsValid() error {
 
 	// Validate verity filesystem settings.
 	if s.VerityPartitionsType == VerityPartitionsUsesConfig {
-		verityDeviceMount := make(map[*Verity]*VerityMount)
-
 		for i := range s.Verity {
 			verity := &s.Verity[i]
 			verityDeviceMounts := []*VerityMount{}
 
 			filesystem, hasFileSystem := deviceParents[verity.Id].(*FileSystem)
 			if hasFileSystem {
+				dataSize := uint64(0)
+				if verity.InlineVerity() {
+					// Inline verity is being used.
+					// So, calculate and store the size of the data section.
+					partition := deviceMap[verity.DataDeviceId].(*Partition)
+
+					dataSize, err = calculateInlineVerityDataSize(uint64(partition.Size.Size))
+					if err != nil {
+						return fmt.Errorf("failed to caclulate inline verity device's (%d) data size:\n%w", err,
+							filesystem.DeviceId)
+					}
+
+					filesystem.Size = dataSize
+				}
+
 				if filesystem.MountPoint != nil {
 					verityMount := &VerityMount{
 						MountPath:     filesystem.MountPoint.Path,
 						MountOptions:  filesystem.MountPoint.Options,
 						SubvolumePath: "",
+						DataSize:      dataSize,
 					}
 					verityDeviceMounts = append(verityDeviceMounts, verityMount)
 				}
@@ -243,6 +258,7 @@ func (s *Storage) IsValid() error {
 								MountPath:     subvolume.MountPoint.Path,
 								MountOptions:  subvolume.MountPoint.Options,
 								SubvolumePath: subvolume.Path,
+								DataSize:      dataSize,
 							}
 							verityDeviceMounts = append(verityDeviceMounts, verityMount)
 						}
@@ -252,13 +268,13 @@ func (s *Storage) IsValid() error {
 
 			// The empty case is handled in ValidateVerityMounts() to consolidate error handling.
 			if len(verityDeviceMounts) == 1 {
-				verityDeviceMount[verity] = verityDeviceMounts[0]
+				verity.Mount = verityDeviceMounts[0]
 			} else if len(verityDeviceMounts) > 1 {
 				return fmt.Errorf("verity device (%s) has multiple mount points, which is not supported", verity.Id)
 			}
 		}
 
-		err := ValidateVerityMounts(s.Verity, verityDeviceMount)
+		err := ValidateVerityMounts(s.Verity)
 		if err != nil {
 			return err
 		}
@@ -267,16 +283,15 @@ func (s *Storage) IsValid() error {
 	return nil
 }
 
-func ValidateVerityMounts(verityDevices []Verity, verityDeviceMount map[*Verity]*VerityMount) error {
+func ValidateVerityMounts(verityDevices []Verity) error {
 	for i := range verityDevices {
 		verity := &verityDevices[i]
 
-		mount, hasMount := verityDeviceMount[verity]
-		if !hasMount || (mount.MountPath != "/" && mount.MountPath != "/usr") {
+		mount := verity.Mount
+
+		if verity.Mount == nil || (verity.Mount.MountPath != "/" && verity.Mount.MountPath != "/usr") {
 			return fmt.Errorf("mount path of verity device (%s) must be set to '/' or '/usr'", verity.Id)
 		}
-
-		verity.Mount = *mount
 
 		expectedVerityName, validMount := verityMountMap[mount.MountPath]
 		if !validMount || verity.Name != expectedVerityName {
@@ -366,7 +381,7 @@ func checkDeviceTreeVerityItem(verity *Verity, deviceMap map[string]any, deviceP
 		}
 	}
 
-	if verity.HashDeviceId != "" {
+	if verity.HashDeviceId != "" && !verity.InlineVerity() {
 		err := addVerityParentToDevice(verity.HashDeviceId, deviceMap, deviceParents, verity)
 		if err != nil {
 			return fmt.Errorf("invalid 'hashDeviceId':\n%w", err)
@@ -494,4 +509,39 @@ func addParentToDevice(deviceId string, deviceMap map[string]any, deviceParents 
 
 	deviceParents[deviceId] = parent
 	return device, nil
+}
+
+func calculateInlineVerityDataSize(partitionSize uint64) (uint64, error) {
+	dataBlockSize := uint32(DefaultVerityDataBlockSize)
+	verityBlockSize := uint32(DefaultVerityHashBlockSize)
+	hashAlgorithm := DefaultVerityHashAlgorithm
+
+	left := uint64(0)
+	right := partitionSize / uint64(dataBlockSize)
+
+	// Binary search for the size that perfectly balances the data and the hash sizes.
+	for left <= right {
+		dataBlocks := (left + right) / 2
+
+		verityBlocks, err := verityutils.CalculateHashSizeInBlocks(dataBlocks, verityBlockSize, hashAlgorithm)
+		if err != nil {
+			return 0, err
+		}
+
+		totalBytes := verityBlocks*uint64(verityBlockSize) + dataBlocks*uint64(dataBlockSize)
+		if totalBytes == partitionSize {
+			left = dataBlocks
+			break
+		} else if totalBytes > partitionSize {
+			right = dataBlocks
+		} else {
+			left = dataBlocks
+		}
+	}
+
+	// Note: 'left' is updated when the totalBytes <= partitionSize. So, even if we don't get a perfect match,
+	// the value of 'left' is always valid to use.
+	dataSizeBytes := left * uint64(dataBlockSize)
+	dataSizeBytes = roundDown(dataSizeBytes, DefaultPartitionAlignment)
+	return dataSizeBytes, nil
 }

--- a/toolkit/tools/imagecustomizerapi/storage.go
+++ b/toolkit/tools/imagecustomizerapi/storage.go
@@ -520,7 +520,7 @@ func calculateInlineVerityDataSize(partitionSize uint64) (uint64, error) {
 	right := partitionSize / uint64(dataBlockSize)
 
 	// Binary search for the size that perfectly balances the data and the hash sizes.
-	for left <= right {
+	for left < right {
 		dataBlocks := (left + right) / 2
 
 		verityBlocks, err := verityutils.CalculateHashSizeInBlocks(dataBlocks, verityBlockSize, hashAlgorithm)
@@ -543,5 +543,8 @@ func calculateInlineVerityDataSize(partitionSize uint64) (uint64, error) {
 	// the value of 'left' is always valid to use.
 	dataSizeBytes := left * uint64(dataBlockSize)
 	dataSizeBytes = roundDown(dataSizeBytes, DefaultPartitionAlignment)
+	if dataSizeBytes == 0 {
+		return 0, fmt.Errorf("partition is too small for inline verity")
+	}
 	return dataSizeBytes, nil
 }

--- a/toolkit/tools/imagecustomizerapi/storage.go
+++ b/toolkit/tools/imagecustomizerapi/storage.go
@@ -542,8 +542,6 @@ func calculateInlineVerityDataSize(partitionSize uint64) (uint64, error) {
 		}
 	}
 
-	// Note: 'left' is updated when the totalBytes <= partitionSize. So, even if we don't get a perfect match,
-	// the value of 'left' is always valid to use.
 	dataSizeBytes := answer * uint64(dataBlockSize)
 	dataSizeBytes = roundDown(dataSizeBytes, DefaultPartitionAlignment)
 	if dataSizeBytes == 0 {

--- a/toolkit/tools/imagecustomizerapi/storage.go
+++ b/toolkit/tools/imagecustomizerapi/storage.go
@@ -518,10 +518,11 @@ func calculateInlineVerityDataSize(partitionSize uint64) (uint64, error) {
 
 	left := uint64(0)
 	right := partitionSize / uint64(dataBlockSize)
+	answer := uint64(0)
 
 	// Binary search for the size that perfectly balances the data and the hash sizes.
-	for left < right {
-		dataBlocks := (left + right) / 2
+	for left <= right {
+		dataBlocks := left + (right-left)/2
 
 		verityBlocks, err := verityutils.CalculateHashSizeInBlocks(dataBlocks, verityBlockSize, hashAlgorithm)
 		if err != nil {
@@ -529,19 +530,21 @@ func calculateInlineVerityDataSize(partitionSize uint64) (uint64, error) {
 		}
 
 		totalBytes := verityBlocks*uint64(verityBlockSize) + dataBlocks*uint64(dataBlockSize)
-		if totalBytes == partitionSize {
-			left = dataBlocks
-			break
-		} else if totalBytes > partitionSize {
-			right = dataBlocks
+		if totalBytes <= partitionSize {
+			answer = dataBlocks
+			left = dataBlocks + 1
 		} else {
-			left = dataBlocks
+			if dataBlocks == 0 {
+				// Avoid integer underflow.
+				break
+			}
+			right = dataBlocks - 1
 		}
 	}
 
 	// Note: 'left' is updated when the totalBytes <= partitionSize. So, even if we don't get a perfect match,
 	// the value of 'left' is always valid to use.
-	dataSizeBytes := left * uint64(dataBlockSize)
+	dataSizeBytes := answer * uint64(dataBlockSize)
 	dataSizeBytes = roundDown(dataSizeBytes, DefaultPartitionAlignment)
 	if dataSizeBytes == 0 {
 		return 0, fmt.Errorf("partition is too small for inline verity")

--- a/toolkit/tools/imagecustomizerapi/storage_test.go
+++ b/toolkit/tools/imagecustomizerapi/storage_test.go
@@ -3126,3 +3126,19 @@ func TestStorageIsValid_BtrfsSubvolumeMountPointIdTypePartLabel_Pass(t *testing.
 	err := value.IsValid()
 	assert.NoError(t, err)
 }
+
+func TestCalculateInlineVerityDataSizeZero(t *testing.T) {
+	_, err := calculateInlineVerityDataSize(0)
+	assert.ErrorContains(t, err, "partition is too small for inline verity")
+}
+
+func TestCalculateInlineVerityDataSize1MiB(t *testing.T) {
+	_, err := calculateInlineVerityDataSize(1 * diskutils.MiB)
+	assert.ErrorContains(t, err, "partition is too small for inline verity")
+}
+
+func TestCalculateInlineVerityDataSize100MiB(t *testing.T) {
+	fsSize, err := calculateInlineVerityDataSize(100 * diskutils.MiB)
+	assert.NoError(t, err)
+	assert.Equal(t, uint64(98*diskutils.MiB), fsSize)
+}

--- a/toolkit/tools/imagecustomizerapi/verity.go
+++ b/toolkit/tools/imagecustomizerapi/verity.go
@@ -62,8 +62,9 @@ type Verity struct {
 	HashSignaturePath string `yaml:"hashSignaturePath" json:"hashSignaturePath,omitempty"`
 
 	// Mount information of the verity device.
-	// Value is filled in by ValidateVerityMounts() (via Storage.IsValid() or validateVerityMountPaths()).
-	Mount VerityMount `json:"-"`
+	// Value is filled in by Storage.IsValid() or validateVerityMountPaths().
+	// See also: ValidateVerityMounts().
+	Mount *VerityMount `json:"-"`
 }
 
 // VerityMount contains mount point information for a verity device.
@@ -74,6 +75,8 @@ type VerityMount struct {
 	MountOptions string
 	// SubvolumePath is the BTRFS subvolume path (if applicable).
 	SubvolumePath string
+	// When inline verity is used, the size of data section.
+	DataSize uint64
 }
 
 func (v *Verity) IsValid() error {
@@ -132,4 +135,8 @@ func (v *Verity) IsValid() error {
 	}
 
 	return nil
+}
+
+func (v *Verity) InlineVerity() bool {
+	return v.DataDeviceId != "" && v.DataDeviceId == v.HashDeviceId
 }

--- a/toolkit/tools/imagegen/configuration/partition.go
+++ b/toolkit/tools/imagegen/configuration/partition.go
@@ -30,6 +30,10 @@ type Partition struct {
 	Artifacts []Artifact      `json:"Artifacts"`
 	// If the partition will contain pre-kernel/initramfs boot resources (e.g. /boot partition).
 	IsBootPartition bool `json:"IsBootPartition"`
+	// Limits the size of the filesystem in the partition.
+	// A value of 0 means the filesystem fills the entire partition.
+	// This field is useful when implementing inline verity.
+	FsSize uint64 `json:"FsSize"`
 }
 
 // HasFlag returns true if a given partition has a specific flag set.

--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -716,16 +716,15 @@ func formatSinglePartition(targetOs targetos.TargetOs, diskDevPath string, partD
 			fsType = "vfat"
 		}
 
-		mkfsOptions, err := getFileSystemOptions(targetOs, fsType, isBootPartition)
+		mkfsOptions, err := getFileSystemOptions(targetOs, fsType, isBootPartition, partDevPath, partition.FsSize)
 		if err != nil {
 			err = fmt.Errorf("failed to get mkfs args for filesystem type (%s) and target os (%s):\n%w", fsType,
 				targetOs, err)
 			return fsType, err
 		}
 
-		mkfsArgs := []string{"--timeout", "5", diskDevPath, "mkfs", "-t", fsType}
+		mkfsArgs := []string{"--timeout", "5", diskDevPath}
 		mkfsArgs = append(mkfsArgs, mkfsOptions...)
-		mkfsArgs = append(mkfsArgs, partDevPath)
 
 		err = retry.Run(func() error {
 			_, stderr, err := shell.Execute("flock", mkfsArgs...)

--- a/toolkit/tools/imagegen/diskutils/filesystem.go
+++ b/toolkit/tools/imagegen/diskutils/filesystem.go
@@ -344,7 +344,9 @@ var (
 // - targetOs: The OS the filesystem is being created for.
 // - filesystemType: The requested filesystem type.
 // - isBootPartition: Will the partition contain the /boot directory?
-func getFileSystemOptions(targetOs targetos.TargetOs, filesystemType string, isBootPartition bool) ([]string, error) {
+func getFileSystemOptions(targetOs targetos.TargetOs, filesystemType string, isBootPartition bool, partDevPath string,
+	fsSizeMiB uint64,
+) ([]string, error) {
 	hostKernelVersion, err := kernelversion.GetBuildHostKernelVersion()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get host kernel version:\n%w", err)
@@ -361,7 +363,7 @@ func getFileSystemOptions(targetOs targetos.TargetOs, filesystemType string, isB
 
 	switch filesystemType {
 	case "btrfs":
-		options, err := getBtrfsFileSystemOptions(hostKernelVersion, options)
+		options, err := getBtrfsFileSystemOptions(hostKernelVersion, options, partDevPath, fsSizeMiB)
 		if err != nil {
 			return nil, err
 		}
@@ -369,7 +371,7 @@ func getFileSystemOptions(targetOs targetos.TargetOs, filesystemType string, isB
 		return options, nil
 
 	case "ext4":
-		options, err := getExt4FileSystemOptions(hostKernelVersion, options)
+		options, err := getExt4FileSystemOptions(hostKernelVersion, options, partDevPath, fsSizeMiB)
 		if err != nil {
 			return nil, err
 		}
@@ -377,7 +379,7 @@ func getFileSystemOptions(targetOs targetos.TargetOs, filesystemType string, isB
 		return options, nil
 
 	case "xfs":
-		options, err := getXfsFileSystemOptions(hostKernelVersion, options, isBootPartition)
+		options, err := getXfsFileSystemOptions(hostKernelVersion, options, isBootPartition, partDevPath, fsSizeMiB)
 		if err != nil {
 			return nil, err
 		}
@@ -385,11 +387,14 @@ func getFileSystemOptions(targetOs targetos.TargetOs, filesystemType string, isB
 		return options, nil
 
 	default:
-		return []string(nil), nil
+		args := []string{fmt.Sprintf("mkfs.%s", filesystemType), partDevPath}
+		return args, nil
 	}
 }
 
-func getBtrfsFileSystemOptions(hostKernelVersion version.Version, options fileSystemsOptions) ([]string, error) {
+func getBtrfsFileSystemOptions(hostKernelVersion version.Version, options fileSystemsOptions, partDevPath string,
+	fsSizeMiB uint64,
+) ([]string, error) {
 	mkfsBtrfsVersion, err := getMkfsBtrfsVersion()
 	if err != nil {
 		return nil, err
@@ -438,7 +443,7 @@ func getBtrfsFileSystemOptions(hostKernelVersion version.Version, options fileSy
 
 	allFeatures := append(enableFeatures, disableFeatures...)
 
-	args := []string{}
+	args := []string{"mkfs.btrfs"}
 
 	if len(allFeatures) > 0 {
 		featuresArg := strings.Join(allFeatures, ",")
@@ -449,10 +454,18 @@ func getBtrfsFileSystemOptions(hostKernelVersion version.Version, options fileSy
 		args = append(args, "--csum", options.Btrfs.Checksum)
 	}
 
+	if fsSizeMiB != 0 {
+		args = append(args, "--byte-count", fmt.Sprintf("%d", fsSizeMiB*MiB))
+	}
+
+	args = append(args, partDevPath)
+
 	return args, nil
 }
 
-func getExt4FileSystemOptions(hostKernelVersion version.Version, options fileSystemsOptions) ([]string, error) {
+func getExt4FileSystemOptions(hostKernelVersion version.Version, options fileSystemsOptions, partDevPath string,
+	fsSizeMiB uint64,
+) ([]string, error) {
 	mke2fsVersion, err := getMke2fsVersion()
 	if err != nil {
 		return nil, err
@@ -481,11 +494,17 @@ func getExt4FileSystemOptions(hostKernelVersion version.Version, options fileSys
 
 	featuresArg := strings.Join(features, ",")
 
-	args := []string{"-b", strconv.Itoa(options.Ext4.BlockSize), "-O", featuresArg}
+	args := []string{"mkfs.ext4", "-b", strconv.Itoa(options.Ext4.BlockSize), "-O", featuresArg, partDevPath}
+
+	if fsSizeMiB != 0 {
+		args = append(args, fmt.Sprintf("%dm", fsSizeMiB))
+	}
+
 	return args, nil
 }
 
 func getXfsFileSystemOptions(hostKernelVersion version.Version, options fileSystemsOptions, isBootPartition bool,
+	partDevPath string, fsSizeMiB uint64,
 ) ([]string, error) {
 	mkfsXfsVersion, err := getMkfsXfsVersion()
 	if err != nil {
@@ -554,7 +573,13 @@ func getXfsFileSystemOptions(hostKernelVersion version.Version, options fileSyst
 	inodeArgValue := strings.Join(inodeArgs, ",")
 	namingArgValue := strings.Join(namingArgs, ",")
 
-	args := []string{"-m", metadataArgValue, "-i", inodeArgValue, "-n", namingArgValue}
+	args := []string{"mkfs.xfs", "-m", metadataArgValue, "-i", inodeArgValue, "-n", namingArgValue}
+
+	if fsSizeMiB != 0 {
+		args = append(args, "-d", fmt.Sprintf("size=%dm", fsSizeMiB))
+	}
+
+	args = append(args, partDevPath)
 	return args, nil
 }
 

--- a/toolkit/tools/internal/verityutils/verityutils.go
+++ b/toolkit/tools/internal/verityutils/verityutils.go
@@ -6,29 +6,38 @@ package verityutils
 import (
 	"encoding/binary"
 	"fmt"
+	"io"
 	"os"
 )
 
-func CalculateHashFileSizeInBytes(hashPartitionPath string) (uint64, error) {
-	superblock, err := ReadVeritySuperblock(hashPartitionPath)
+func CalculateHashFileSizeInBytes(hashPartitionPath string, hashOffsetBytes uint64) (uint64, error) {
+	superblock, err := ReadVeritySuperblock(hashPartitionPath, hashOffsetBytes)
 	if err != nil {
 		return 0, err
 	}
 
-	sizeInBytes, err := calculateHashFileSizeInBytesFromSuperBlock(superblock)
+	sizeInBytes, err := CalculateHashSizeInBytes(superblock.DataBlocks, superblock.HashBlockSize,
+		superblock.GetAlgorithm())
 	if err != nil {
-		return 0, fmt.Errorf("hash partition's (%s) superblock is invalid:\n%w", hashPartitionPath, err)
+		return 0, err
 	}
 
 	return sizeInBytes, nil
 }
 
-func ReadVeritySuperblock(hashPartitionPath string) (VeritySuperBlock, error) {
+func ReadVeritySuperblock(hashPartitionPath string, hashOffsetBytes uint64) (VeritySuperBlock, error) {
 	hashPartition, err := os.Open(hashPartitionPath)
 	if err != nil {
 		return VeritySuperBlock{}, fmt.Errorf("failed to open hash partition (%s) block device:\n%w", hashPartitionPath, err)
 	}
 	defer hashPartition.Close()
+
+	if hashOffsetBytes != 0 {
+		_, err := hashPartition.Seek(int64(hashOffsetBytes), io.SeekStart)
+		if err != nil {
+			return VeritySuperBlock{}, fmt.Errorf("failed to seek to hash partition's (%s) superblock:\n%w", hashPartitionPath, err)
+		}
+	}
 
 	superblock := VeritySuperBlock{}
 	err = binary.Read(hashPartition, binary.LittleEndian, &superblock)
@@ -57,20 +66,29 @@ func verifySuperblock(superblock VeritySuperBlock) error {
 		return fmt.Errorf("unsupported hash type (%d)", superblock.HashType)
 	}
 
-	hashSize, err := getAlgorithmHashSize(superblock.GetAlgorithm())
-	if err != nil {
-		return err
-	}
-
 	if !isPowerOf2(superblock.DataBlockSize) {
 		return fmt.Errorf("invalid data block size (%d)", superblock.DataBlockSize)
 	}
 
-	if !isPowerOf2(superblock.HashBlockSize) || superblock.HashBlockSize < hashSize {
-		return fmt.Errorf("invalid hash block size (%d)", superblock.HashBlockSize)
+	_, err := verifyHashAlgorithmAndBlockSize(superblock.GetAlgorithm(), superblock.HashBlockSize)
+	if err != nil {
+		return err
 	}
 
 	return nil
+}
+
+func verifyHashAlgorithmAndBlockSize(algorithm string, hashBlockSize uint32) (uint32, error) {
+	hashSize, err := getAlgorithmHashSize(algorithm)
+	if err != nil {
+		return 0, err
+	}
+
+	if !isPowerOf2(hashBlockSize) || hashBlockSize < hashSize {
+		return 0, fmt.Errorf("invalid hash block size (%d)", hashBlockSize)
+	}
+
+	return hashSize, nil
 }
 
 func getAlgorithmHashSize(algorithm string) (uint32, error) {
@@ -89,23 +107,22 @@ func getAlgorithmHashSize(algorithm string) (uint32, error) {
 	}
 }
 
-func calculateHashFileSizeInBytesFromSuperBlock(superblock VeritySuperBlock) (uint64, error) {
-	var err error
-
-	hashSize, err := getAlgorithmHashSize(superblock.GetAlgorithm())
+func CalculateHashSizeInBytes(dataBlocksCount uint64, hashBlockSize uint32, algorithm string) (uint64, error) {
+	totalBlocks, err := CalculateHashSizeInBlocks(dataBlocksCount, hashBlockSize, algorithm)
 	if err != nil {
 		return 0, err
 	}
 
-	sizeInBytes, err := calculateHashFileSizeInBytesHelper(superblock.DataBlocks, superblock.HashBlockSize, hashSize)
-	if err != nil {
-		return 0, err
-	}
-
-	return sizeInBytes, nil
+	totalBytes := totalBlocks * uint64(hashBlockSize)
+	return totalBytes, nil
 }
 
-func calculateHashFileSizeInBytesHelper(dataBlocksCount uint64, hashBlockSize uint32, hashSize uint32) (uint64, error) {
+func CalculateHashSizeInBlocks(dataBlocksCount uint64, hashBlockSize uint32, algorithm string) (uint64, error) {
+	hashSize, err := verifyHashAlgorithmAndBlockSize(algorithm, hashBlockSize)
+	if err != nil {
+		return 0, err
+	}
+
 	// dm-verity pads each hash to the nearest power-of-2 to make the math easier.
 	hashSizeFull := roundUpToPowerOf2(hashSize)
 
@@ -126,8 +143,7 @@ func calculateHashFileSizeInBytesHelper(dataBlocksCount uint64, hashBlockSize ui
 	}
 
 	totalBlocks := totalTreeBlocks + 1 // add superblock
-	totalBytes := totalBlocks * uint64(hashBlockSize)
-	return totalBytes, nil
+	return totalBlocks, nil
 }
 
 func isPowerOf2(n uint32) bool {

--- a/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput_test.go
@@ -216,7 +216,7 @@ func TestOutputAndInjectArtifactsCosi(t *testing.T) {
 	}
 
 	// Connect to image.
-	if !extractCosiAndVerifyMetadata(t, cosiFilePath, testTempDir, expectedCosiMetadata) {
+	if _, ok := extractCosiAndVerifyMetadata(t, cosiFilePath, testTempDir, expectedCosiMetadata); !ok {
 		return
 	}
 
@@ -281,7 +281,7 @@ func TestOutputAndInjectArtifactsCosi(t *testing.T) {
 
 	verifyInjectedFiles(t, espMountPath, espFiles)
 	verifyVerityUki(t, espMountPath, rootPartitionPath, rootHashPartitionPath, "UUID="+rootUuid, "UUID="+rootHashUuid,
-		"root", buildDir, "", "restart-on-corruption")
+		"root", buildDir, "", "restart-on-corruption", false /*inlineVerity*/)
 }
 
 func verifyAndSignOutputtedArtifacts(t *testing.T, outputArtifactsDir string, expectVerityHash bool) []string {

--- a/toolkit/tools/pkg/imagecustomizerlib/convertimage.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/convertimage.go
@@ -135,7 +135,8 @@ func convertRawImageToOutputFormat(ctx context.Context, buildDirAbs string, rawI
 
 		// For convert subcommand, we're dealing with arbitrary external images.
 		// Only shrink filesystems that completely cover their partition.
-		partitionOriginalSizes, err := shrinkFilesystemsHelper(ctx, rawImageFile, readonlyPartUuids, true /*isExternalImage*/)
+		partitionOriginalSizes, err := shrinkFilesystemsHelper(ctx, rawImageFile, readonlyPartUuids, nil,
+			true /*isExternalImage*/)
 		if err != nil {
 			return fmt.Errorf("%w:\n%w", ErrShrinkFilesystems, err)
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/cosicommon.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/cosicommon.go
@@ -17,6 +17,7 @@ import (
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/file"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/imageconnection"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/logger"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/ptrutils"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/randomization"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safeloopback"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/sliceutils"
@@ -127,6 +128,11 @@ func buildCosiFile(sourceDir string, outputFile string, partitions []outputParti
 	// Pre-compute a set of verity hash UUIDs for quick lookup
 	verityHashUuids := make(map[string]struct{})
 	for _, verity := range verityMetadata {
+		if verity.hashPartUuid == verity.dataPartUuid {
+			// Inline verity.
+			continue
+		}
+
 		verityHashUuids[verity.hashPartUuid] = struct{}{}
 	}
 
@@ -188,10 +194,16 @@ func buildCosiFile(sourceDir string, outputFile string, partitions []outputParti
 					return fmt.Errorf("missing metadata for hash partition UUID:\n%s", verity.hashPartUuid)
 				}
 
+				hashOffset := (*uint64)(nil)
+				if verity.formatSettings.hashOffsetBytes != 0 {
+					hashOffset = ptrutils.PtrTo(verity.formatSettings.hashOffsetBytes)
+				}
+
 				hashPartition := partitions[hashPartitionIndex]
 				metadataImage.Verity = &VerityConfig{
-					Roothash: verity.rootHash,
-					Image:    partitionImageFiles[hashPartition.PartitionNum],
+					Roothash:   verity.rootHash,
+					Image:      partitionImageFiles[hashPartition.PartitionNum],
+					HashOffset: hashOffset,
 				}
 
 				veritySourcePath := path.Join(sourceDir, hashPartition.PartitionFilename)

--- a/toolkit/tools/pkg/imagecustomizerlib/cosimetadata.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/cosimetadata.go
@@ -83,8 +83,9 @@ type FileSystem struct {
 }
 
 type VerityConfig struct {
-	Image    ImageFile `json:"image"`
-	Roothash string    `json:"roothash"`
+	Image      ImageFile `json:"image"`
+	Roothash   string    `json:"roothash"`
+	HashOffset *uint64   `json:"hashOffset,omitempty"`
 }
 
 type ImageFile struct {

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
@@ -851,7 +851,7 @@ func testCustomizeImageAzureDataDiskHelper(t *testing.T, testName string,
 		}
 	}
 
-	if !extractCosiAndVerifyMetadata(t, outImageCosiFilePath, testTmpDir, expectedCosiMetadata) {
+	if _, ok := extractCosiAndVerifyMetadata(t, outImageCosiFilePath, testTmpDir, expectedCosiMetadata); !ok {
 		return
 	}
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
@@ -320,7 +320,7 @@ func verifyUsrVerity(t *testing.T, buildDir string, imagePath string,
 	usrDevice := testutils.PartitionDevPath(imageConnection, 3)
 	usrHashDevice := testutils.PartitionDevPath(imageConnection, 4)
 	verifyVerityUki(t, espPath, usrDevice, usrHashDevice, "PARTUUID="+partitions[3].PartUuid,
-		"PARTUUID="+partitions[4].PartUuid, "usr", buildDir, "rd.info", "panic-on-corruption")
+		"PARTUUID="+partitions[4].PartUuid, "usr", buildDir, "rd.info", "panic-on-corruption", false /*inlineVerity*/)
 
 	// Verify fstab entries
 	expectedFstabEntries := []diskutils.FstabEntry{
@@ -460,7 +460,7 @@ func verifyRootVerityUki(t *testing.T, buildDir string, imagePath string, expect
 	rootDevice := testutils.PartitionDevPath(imageConnection, 3)
 	rootHashDevice := testutils.PartitionDevPath(imageConnection, 4)
 	verifyVerityUki(t, espPath, rootDevice, rootHashDevice, "PARTUUID="+partitions[3].PartUuid,
-		"PARTUUID="+partitions[4].PartUuid, "root", buildDir, "", "panic-on-corruption")
+		"PARTUUID="+partitions[4].PartUuid, "root", buildDir, "", "panic-on-corruption", false /*inlineVerity*/)
 
 	expectedFstabEntries := []diskutils.FstabEntry{
 		{

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
@@ -44,6 +45,7 @@ var (
 	ErrFindVerityDataPartition           = NewImageCustomizerError("Verity:FindDataPartition", "failed to find verity data partition")
 	ErrFindVerityHashPartition           = NewImageCustomizerError("Verity:FindHashPartition", "failed to find verity hash partition")
 	ErrCalculateRootHash                 = NewImageCustomizerError("Verity:CalculateRootHash", "failed to calculate root hash")
+	ErrUnalignedVerityDataSize           = NewImageCustomizerError("Verity:UnalignedDataSize", "data size is not a multiple of the data block size")
 	ErrCompileRootHashRegex              = NewImageCustomizerError("Verity:CompileRootHashRegex", "failed to compile root hash regex")
 	ErrParseRootHash                     = NewImageCustomizerError("Verity:ParseRootHash", "failed to parse root hash from veritysetup output")
 	ErrCalculateHashSize                 = NewImageCustomizerError("Verity:CalculateHashSize", "failed to calculate hash partition size")
@@ -333,6 +335,10 @@ func constructVerityKernelCmdlineArgs(verityMetadata []verityDeviceMetadata,
 			hasSignatureInjection = true
 		}
 
+		if metadata.formatSettings.hashOffsetBytes != 0 {
+			options += fmt.Sprintf(",hash-offset=%d", metadata.formatSettings.hashOffsetBytes)
+		}
+
 		newArgs = append(newArgs,
 			fmt.Sprintf("%s=%s", hashArg, metadata.rootHash),
 			fmt.Sprintf("%s=%s", dataArg, formattedDataPartition),
@@ -430,9 +436,12 @@ func SystemdFormatCorruptionOption(corruptionOption imagecustomizerapi.Corruptio
 	}
 }
 
-func parseSystemdVerityOptions(options string) (imagecustomizerapi.CorruptionOption, string, error) {
+func parseSystemdVerityOptions(options string) (imagecustomizerapi.CorruptionOption, string, uint64, error) {
+	var err error
+
 	corruptionOption := imagecustomizerapi.CorruptionOptionIoError
 	var hashSigPath string
+	var hashOffset uint64
 
 	optionValues := strings.Split(options, ",")
 	for _, option := range optionValues {
@@ -452,12 +461,20 @@ func parseSystemdVerityOptions(options string) (imagecustomizerapi.CorruptionOpt
 		case strings.HasPrefix(option, "root-hash-signature="):
 			hashSigPath = strings.TrimPrefix(option, "root-hash-signature=")
 
+		case strings.HasPrefix(option, "hash-offset="):
+			hashOffsetStr := strings.TrimPrefix(option, "hash-offset=")
+			hashOffset, err = strconv.ParseUint(hashOffsetStr, 10, 64)
+			if err != nil {
+				err = fmt.Errorf("failed to parse verity hash-offset value (%s):\n%w", hashOffsetStr, err)
+				return "", "", 0, err
+			}
+
 		default:
-			return "", "", fmt.Errorf("unknown verity option (%s)", option)
+			return "", "", 0, fmt.Errorf("unknown verity option (%s)", option)
 		}
 	}
 
-	return corruptionOption, hashSigPath, nil
+	return corruptionOption, hashSigPath, hashOffset, nil
 }
 
 func validateVerityDependencies(imageChroot *safechroot.Chroot, distroHandler DistroHandler) error {
@@ -510,7 +527,6 @@ func validateVerityMountPaths(imageConnection *imageconnection.ImageConnection, 
 		return err
 	}
 
-	verityDeviceMount := make(map[*imagecustomizerapi.Verity]*imagecustomizerapi.VerityMount)
 	for i := range storage.Verity {
 		verity := &storage.Verity[i]
 
@@ -557,10 +573,11 @@ func validateVerityMountPaths(imageConnection *imageconnection.ImageConnection, 
 			MountOptions:  dataEntry.FstabEntry.Options,
 			SubvolumePath: extractSubvolPath(dataEntry.FstabEntry.Options),
 		}
-		verityDeviceMount[verity] = verityMount
+
+		verity.Mount = verityMount
 	}
 
-	err = imagecustomizerapi.ValidateVerityMounts(storage.Verity, verityDeviceMount)
+	err = imagecustomizerapi.ValidateVerityMounts(storage.Verity)
 	if err != nil {
 		return err
 	}
@@ -621,38 +638,118 @@ func findIdentifiedPartition(partitions []diskutils.PartitionInfo, ref imagecust
 	return partition, nil
 }
 
-func customizeVerityImage(ctx context.Context, buildDir string, rc *ResolvedConfig,
-	buildImageFile string, partIdToPartUuid map[string]string, shrinkHashPartition bool,
-	baseImageVerity []verityDeviceMetadata, readonlyPartUuids []string,
-	partitionsLayout []fstabEntryPartNum,
+func collectVerityMetadataFromImage(verity []imagecustomizerapi.Verity, imageFile string,
+	partIdToPartUuid map[string]string,
 ) ([]verityDeviceMetadata, error) {
+	if len(verity) <= 0 {
+		return nil, nil
+	}
+
+	imageLoopback, err := safeloopback.NewLoopback(imageFile)
+	if err != nil {
+		return nil, err
+	}
+	defer imageLoopback.Close()
+
+	// Get partition info
+	diskPartitions, err := diskutils.GetDiskPartitions(imageLoopback.DevicePath())
+	if err != nil {
+		return nil, err
+	}
+
+	verityMetadata, err := collectVerityMetadata(verity, diskPartitions, partIdToPartUuid)
+	if err != nil {
+		return nil, err
+	}
+
+	err = imageLoopback.CleanClose()
+	if err != nil {
+		return nil, err
+	}
+
+	return verityMetadata, nil
+}
+
+func collectVerityMetadata(verity []imagecustomizerapi.Verity, diskPartitions []diskutils.PartitionInfo,
+	partIdToPartUuid map[string]string,
+) ([]verityDeviceMetadata, error) {
+	verityMetadata := []verityDeviceMetadata(nil)
+
+	for _, verityConfig := range verity {
+		// Extract the partition block device path.
+		dataPartition, err := verityIdToPartition(verityConfig.DataDeviceId, verityConfig.DataDevice, partIdToPartUuid,
+			diskPartitions)
+		if err != nil {
+			return nil, fmt.Errorf("%w (id='%s'):\n%w", ErrFindVerityDataPartition, verityConfig.Id, err)
+		}
+
+		var hashPartition diskutils.PartitionInfo
+		dataSize := uint64(0)
+
+		if verityConfig.InlineVerity() {
+			// Inline verity is being used.
+			hashPartition = dataPartition
+			dataSize = verityConfig.Mount.DataSize
+		} else {
+			hashPartition, err = verityIdToPartition(verityConfig.HashDeviceId, verityConfig.HashDevice, partIdToPartUuid,
+				diskPartitions)
+			if err != nil {
+				return nil, fmt.Errorf("%w (id='%s'):\n%w", ErrFindVerityHashPartition, verityConfig.Id, err)
+			}
+		}
+
+		metadata := verityDeviceMetadata{
+			name:                  verityConfig.Name,
+			dataPartUuid:          dataPartition.PartUuid,
+			hashPartUuid:          hashPartition.PartUuid,
+			dataDeviceMountIdType: verityConfig.DataDeviceMountIdType,
+			hashDeviceMountIdType: verityConfig.HashDeviceMountIdType,
+			corruptionOption:      verityConfig.CorruptionOption,
+			hashSignaturePath:     verityConfig.HashSignaturePath,
+			formatSettings: verityFormatSettings{
+				hashAlgorithm:      imagecustomizerapi.DefaultVerityHashAlgorithm,
+				dataBlockSizeBytes: imagecustomizerapi.DefaultVerityDataBlockSize,
+				hashBlockSizeBytes: imagecustomizerapi.DefaultVerityHashBlockSize,
+				dataSizeBytes:      dataSize,
+				hashOffsetBytes:    dataSize,
+			},
+		}
+		verityMetadata = append(verityMetadata, metadata)
+	}
+
+	return verityMetadata, nil
+}
+
+func customizeVerityImage(ctx context.Context, buildDir string, rc *ResolvedConfig,
+	buildImageFile string, shrinkHashPartition bool,
+	verityMetadata []verityDeviceMetadata, readonlyPartUuids []string,
+	partitionsLayout []fstabEntryPartNum,
+) error {
 	logger.Log.Infof("Provisioning verity")
 
 	_, span := otel.GetTracerProvider().Tracer(OtelTracerName).Start(ctx, "provision_verity")
 	defer span.End()
 
-	verityMetadata := []verityDeviceMetadata(nil)
-
 	loopback, err := safeloopback.NewLoopback(buildImageFile)
 	if err != nil {
-		return nil, fmt.Errorf("%w:\n%w", ErrVerityImageConnection, err)
+		return fmt.Errorf("%w:\n%w", ErrVerityImageConnection, err)
 	}
 	defer loopback.Close()
 
 	diskPartitions, err := diskutils.GetDiskPartitions(loopback.DevicePath())
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	sectorSize, _, err := diskutils.GetSectorSize(loopback.DevicePath())
 	if err != nil {
-		return nil, fmt.Errorf("%w (device='%s'):\n%w", ErrGetDiskSectorSize, loopback.DevicePath(), err)
+		return fmt.Errorf("%w (device='%s'):\n%w", ErrGetDiskSectorSize, loopback.DevicePath(), err)
 	}
 
 	verityUpdated := false
 
-	for _, metadata := range baseImageVerity {
-		newMetadata := metadata
+	for i := range verityMetadata {
+		metadata := &verityMetadata[i]
 
 		readonly := slices.Contains(readonlyPartUuids, metadata.dataPartUuid)
 		if !readonly {
@@ -660,80 +757,37 @@ func customizeVerityImage(ctx context.Context, buildDir string, rc *ResolvedConf
 			dataPartition, _, err := findPartitionHelper(imagecustomizerapi.MountIdentifierTypePartUuid,
 				metadata.dataPartUuid, diskPartitions)
 			if err != nil {
-				return nil, fmt.Errorf("%w (name='%s'):\n%w", ErrFindVerityDataPartition, metadata.name, err)
+				return fmt.Errorf("%w (name='%s'):\n%w", ErrFindVerityDataPartition, metadata.name, err)
 			}
 
 			hashPartition, _, err := findPartitionHelper(imagecustomizerapi.MountIdentifierTypePartUuid,
 				metadata.hashPartUuid, diskPartitions)
 			if err != nil {
-				return nil, fmt.Errorf("%w (name='%s'):\n%w", ErrFindVerityHashPartition, metadata.name, err)
+				return fmt.Errorf("%w (name='%s'):\n%w", ErrFindVerityHashPartition, metadata.name, err)
 			}
 
 			// Format hash partition.
 			rootHash, err := verityFormat(loopback.DevicePath(), dataPartition.Path, hashPartition.Path,
 				shrinkHashPartition, sectorSize, metadata.name, metadata.formatSettings)
 			if err != nil {
-				return nil, err
+				return err
 			}
 
-			newMetadata.rootHash = rootHash
+			metadata.rootHash = rootHash
 			verityUpdated = true
 		}
-
-		verityMetadata = append(verityMetadata, newMetadata)
-	}
-
-	for _, verityConfig := range rc.Storage.Verity {
-		// Extract the partition block device path.
-		dataPartition, err := verityIdToPartition(verityConfig.DataDeviceId, verityConfig.DataDevice, partIdToPartUuid,
-			diskPartitions)
-		if err != nil {
-			return nil, fmt.Errorf("%w (id='%s'):\n%w", ErrFindVerityDataPartition, verityConfig.Id, err)
-		}
-		hashPartition, err := verityIdToPartition(verityConfig.HashDeviceId, verityConfig.HashDevice, partIdToPartUuid,
-			diskPartitions)
-		if err != nil {
-			return nil, fmt.Errorf("%w (id='%s'):\n%w", ErrFindVerityHashPartition, verityConfig.Id, err)
-		}
-
-		// Format hash partition.
-		formatSettings := verityFormatSettings{
-			hashAlgorithm:      imagecustomizerapi.DefaultVerityHashAlgorithm,
-			dataBlockSizeBytes: imagecustomizerapi.DefaultVerityDataBlockSize,
-			hashBlockSizeBytes: imagecustomizerapi.DefaultVerityHashBlockSize,
-		}
-
-		rootHash, err := verityFormat(loopback.DevicePath(), dataPartition.Path, hashPartition.Path,
-			shrinkHashPartition, sectorSize, verityConfig.Name, formatSettings)
-		if err != nil {
-			return nil, err
-		}
-
-		metadata := verityDeviceMetadata{
-			name:                  verityConfig.Name,
-			rootHash:              rootHash,
-			dataPartUuid:          dataPartition.PartUuid,
-			hashPartUuid:          hashPartition.PartUuid,
-			dataDeviceMountIdType: verityConfig.DataDeviceMountIdType,
-			hashDeviceMountIdType: verityConfig.HashDeviceMountIdType,
-			corruptionOption:      verityConfig.CorruptionOption,
-			hashSignaturePath:     verityConfig.HashSignaturePath,
-			formatSettings:        formatSettings,
-		}
-		verityMetadata = append(verityMetadata, metadata)
-		verityUpdated = true
 	}
 
 	// Refresh disk partitions after running veritysetup so that the hash partition's UUID is correct.
 	err = diskutils.RefreshPartitions(loopback.DevicePath())
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	if verityUpdated {
 		diskPartitions, err = diskutils.GetDiskPartitions(loopback.DevicePath())
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		// Update kernel args.
@@ -741,13 +795,13 @@ func customizeVerityImage(ctx context.Context, buildDir string, rc *ResolvedConf
 		isUki := rc.Uki != nil && rc.Uki.Mode != imagecustomizerapi.UkiModePassthrough
 		err = updateKernelArgsForVerity(buildDir, diskPartitions, verityMetadata, isUki, partitionsLayout)
 		if err != nil {
-			return nil, err
+			return err
 		}
 	}
 
 	err = loopback.CleanClose()
 	if err != nil {
-		return nil, err
+		return err
 	}
 
 	deviceNamesJson := getVerityNames(verityMetadata)
@@ -756,7 +810,7 @@ func customizeVerityImage(ctx context.Context, buildDir string, rc *ResolvedConf
 		attribute.StringSlice("verity_device_name", deviceNamesJson),
 	)
 
-	return verityMetadata, nil
+	return nil
 }
 
 func verityFormat(diskDevicePath string, dataPartitionPath string, hashPartitionPath string, shrinkHashPartition bool,
@@ -768,6 +822,21 @@ func verityFormat(diskDevicePath string, dataPartitionPath string, hashPartition
 		"--hash", formatSettings.hashAlgorithm,
 		"--data-block-size", fmt.Sprintf("%d", formatSettings.dataBlockSizeBytes),
 		"--hash-block-size", fmt.Sprintf("%d", formatSettings.hashBlockSizeBytes),
+	}
+
+	if formatSettings.dataSizeBytes != 0 {
+		dataBlocks := formatSettings.dataSizeBytes / uint64(formatSettings.dataBlockSizeBytes)
+		if formatSettings.dataSizeBytes%uint64(formatSettings.dataBlockSizeBytes) != 0 {
+			return "", fmt.Errorf("%w (partition='%s')", ErrUnalignedVerityDataSize, dataPartitionPath)
+		}
+
+		formatArgs = append(formatArgs,
+			"--data-blocks", fmt.Sprintf("%d", dataBlocks))
+	}
+
+	if formatSettings.hashOffsetBytes != 0 {
+		formatArgs = append(formatArgs,
+			"--hash-offset", fmt.Sprintf("%d", formatSettings.hashOffsetBytes))
 	}
 
 	verityOutput, _, err := shell.NewExecBuilder("veritysetup", formatArgs...).
@@ -799,19 +868,21 @@ func verityFormat(diskDevicePath string, dataPartitionPath string, hashPartition
 	// Calculate the size of the hash partition from its superblock.
 	// In newer `veritysetup` versions, `veritysetup format` returns the size in its output. But that feature
 	// is too new for now.
-	hashPartitionSizeInBytes, err := verityutils.CalculateHashFileSizeInBytes(hashPartitionPath)
+	hashSizeInBytes, err := verityutils.CalculateHashFileSizeInBytes(hashPartitionPath,
+		formatSettings.hashOffsetBytes)
 	if err != nil {
 		return "", fmt.Errorf("%w (partition='%s'):\n%w", ErrCalculateHashSize, hashPartitionPath, err)
 	}
 
-	hashPartitionSizeInSectors := convertBytesToSectors(hashPartitionSizeInBytes, sectorSize)
+	logger.Log.Infof("Verity hash written (name=%s, size=%s)", name,
+		imagecustomizerapi.DiskSize(hashSizeInBytes).HumanReadable())
 
-	hashPartitionSizeInRoundedBytes := hashPartitionSizeInSectors * sectorSize
-	logger.Log.Infof("Verity hash partition formatted (name=%s, size=%s)", name,
-		imagecustomizerapi.DiskSize(hashPartitionSizeInRoundedBytes).HumanReadable())
+	// Note: When inline verity is used, the partition will have already been shrunk to the correct size during the
+	// partition shrinking phase.
+	if shrinkHashPartition && !formatSettings.IsInlineVerity() {
+		partitionSizeInSectors := convertBytesToSectors(hashSizeInBytes, sectorSize)
 
-	if shrinkHashPartition {
-		err = resizePartition(hashPartitionPath, diskDevicePath, hashPartitionSizeInSectors)
+		err = resizePartition(hashPartitionPath, diskDevicePath, partitionSizeInSectors)
 		if err != nil {
 			return "", fmt.Errorf("%w (device='%s'):\n%w", ErrShrinkHashPartition, diskDevicePath, err)
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safeloopback"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safemount"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/shell"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/sliceutils"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/testutils"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/unix"
@@ -102,7 +103,8 @@ func verifyRootVerity(t *testing.T, baseImageInfo testBaseImageInfo, buildDir st
 	rootDevice := testutils.PartitionDevPath(imageConnection, 3)
 	hashDevice := testutils.PartitionDevPath(imageConnection, 4)
 	verifyVerityGrub(t, bootPath, rootDevice, hashDevice, "PARTUUID="+partitions[3].PartUuid,
-		"PARTUUID="+partitions[4].PartUuid, "root", "rd.info", baseImageInfo, "panic-on-corruption")
+		"PARTUUID="+partitions[4].PartUuid, "root", "rd.info", baseImageInfo, "panic-on-corruption",
+		false /*inlineVerity*/)
 
 	err = imageConnection.CleanClose()
 	if !assert.NoError(t, err) {
@@ -128,12 +130,6 @@ func testCustomizeImageVerityCosiExtractHelper(t *testing.T, testName string, ba
 	outImageFilePath := filepath.Join(testTempDir, "image.cosi")
 	configFile := filepath.Join(testDir, "verity-partition-labels.yaml")
 
-	var config imagecustomizerapi.Config
-	err := imagecustomizerapi.UnmarshalAndValidateYamlFile(configFile, &config)
-	if !assert.NoError(t, err) {
-		return
-	}
-
 	espPartitionNum := 1
 	bootPartitionNum := 2
 	rootPartitionNum := 3
@@ -141,7 +137,7 @@ func testCustomizeImageVerityCosiExtractHelper(t *testing.T, testName string, ba
 	varPartitionNum := 5
 
 	// Customize image, shrink partitions, and split the partitions into individual files.
-	err = CustomizeImage(t.Context(), buildDir, testDir, &config, baseImage, nil, outImageFilePath, "cosi",
+	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "cosi",
 		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
 
 	if !assert.NoError(t, err) {
@@ -201,7 +197,7 @@ func testCustomizeImageVerityCosiExtractHelper(t *testing.T, testName string, ba
 	}
 
 	// Attach partition files.
-	if !extractCosiAndVerifyMetadata(t, outImageFilePath, testTempDir, expectedCosiMetadata) {
+	if _, ok := extractCosiAndVerifyMetadata(t, outImageFilePath, testTempDir, expectedCosiMetadata); !ok {
 		return
 	}
 
@@ -270,11 +266,12 @@ func testCustomizeImageVerityCosiExtractHelper(t *testing.T, testName string, ba
 
 	// Verify that verity is configured correctly.
 	verifyVerityGrub(t, bootMountPath, rootDevice.DevicePath(), hashDevice.DevicePath(), "PARTLABEL=root",
-		"PARTLABEL=roothash", "root", "rd.info", baseImageInfo, "panic-on-corruption")
+		"PARTLABEL=roothash", "root", "rd.info", baseImageInfo, "panic-on-corruption", false /*inlineVerity*/)
 }
 
 func verifyVerityGrub(t *testing.T, bootPath string, dataDevice string, hashDevice string, dataId string, hashId string,
 	verityType string, extraCommandLine string, baseImageInfo testBaseImageInfo, corruptionOption string,
+	inlineVerity bool,
 ) {
 	// Extract kernel command line args.
 	grubCfgPath := filepath.Join(bootPath, "/grub2/grub.cfg")
@@ -292,7 +289,8 @@ func verifyVerityGrub(t *testing.T, bootPath string, dataDevice string, hashDevi
 	}
 
 	// Verify verity.
-	verifyVerityHelper(t, kernelArgsList, dataDevice, hashDevice, dataId, hashId, verityType, corruptionOption)
+	verifyVerityHelper(t, kernelArgsList, dataDevice, hashDevice, dataId, hashId, verityType, corruptionOption,
+		inlineVerity)
 
 	// Verity extra command line args.
 	recoveryCount := 0
@@ -317,7 +315,7 @@ func verifyVerityGrub(t *testing.T, bootPath string, dataDevice string, hashDevi
 
 func verifyVerityUki(t *testing.T, espPath string, dataDevice string,
 	hashDevice string, dataId string, hashId string, verityType string, buildDir string, extraCommandLine string,
-	corruptionOption string,
+	corruptionOption string, inlineVerity bool,
 ) {
 	// Extract kernel command line args.
 	kernelToArgs, err := extractKernelCmdlineFromUkiEfis(espPath, buildDir)
@@ -332,7 +330,8 @@ func verifyVerityUki(t *testing.T, espPath string, dataDevice string,
 	}
 
 	// Verify verity
-	verifyVerityHelper(t, kernelArgsList, dataDevice, hashDevice, dataId, hashId, verityType, corruptionOption)
+	verifyVerityHelper(t, kernelArgsList, dataDevice, hashDevice, dataId, hashId, verityType, corruptionOption,
+		inlineVerity)
 
 	// Verify extra command line
 	if extraCommandLine != "" {
@@ -344,27 +343,30 @@ func verifyVerityUki(t *testing.T, espPath string, dataDevice string,
 
 func verifyVerityHelper(t *testing.T, kernelArgsList []string, dataDevice string,
 	hashDevice string, dataId string, hashId string, verityType string, corruptionOption string,
+	inlineVerity bool,
 ) {
 	assert.GreaterOrEqual(t, len(kernelArgsList), 1)
 
 	hash := ""
+	hashOffset := ""
 	for _, kernelArgs := range kernelArgsList {
 		var hashRegexp *regexp.Regexp
+		var optionsRegexp *regexp.Regexp
 		switch verityType {
 		case "root":
 			assert.Regexp(t, ` rd.systemd.verity=1 `, kernelArgs)
 			assert.Regexp(t, fmt.Sprintf(` systemd.verity_root_data=%s `, dataId), kernelArgs)
 			assert.Regexp(t, fmt.Sprintf(` systemd.verity_root_hash=%s `, hashId), kernelArgs)
-			assert.Regexp(t, fmt.Sprintf(` systemd.verity_root_options=%s(,| |$)`, corruptionOption), kernelArgs)
 
+			optionsRegexp = regexp.MustCompile(` systemd.verity_root_options=(\S*)( |$)`)
 			hashRegexp = regexp.MustCompile(` roothash=([a-fA-F0-9]*) `)
 
 		case "usr":
 			assert.Regexp(t, ` rd.systemd.verity=1 `, kernelArgs)
 			assert.Regexp(t, fmt.Sprintf(` systemd.verity_usr_data=%s `, dataId), kernelArgs)
 			assert.Regexp(t, fmt.Sprintf(` systemd.verity_usr_hash=%s `, hashId), kernelArgs)
-			assert.Regexp(t, fmt.Sprintf(` systemd.verity_usr_options=%s(,| |$)`, corruptionOption), kernelArgs)
 
+			optionsRegexp = regexp.MustCompile(` systemd.verity_usr_options=(\S*)( |$)`)
 			hashRegexp = regexp.MustCompile(` usrhash=([a-fA-F0-9]*) `)
 
 		default:
@@ -372,23 +374,45 @@ func verifyVerityHelper(t *testing.T, kernelArgsList []string, dataDevice string
 			continue
 		}
 
-		hashMatches := hashRegexp.FindStringSubmatch(kernelArgs)
-		if !assert.Equal(t, 2, len(hashMatches)) {
-			continue
+		optionsMatch := optionsRegexp.FindStringSubmatch(kernelArgs)
+		if assert.Equal(t, 3, len(optionsMatch)) {
+			optionsStr := optionsMatch[1]
+			options := strings.Split(optionsStr, ",")
+
+			assert.Contains(t, options, corruptionOption)
+
+			if inlineVerity {
+				hashOffsetOption, hasHashOffset := sliceutils.FindValueFunc(options, func(option string) bool {
+					return strings.HasPrefix(option, "hash-offset=")
+				})
+				assert.True(t, hasHashOffset)
+				hashOffset = strings.TrimPrefix(hashOffsetOption, "hash-offset=")
+			}
 		}
 
-		kernelArgsHash := hashMatches[1]
-		if hash == "" {
-			hash = kernelArgsHash
-		} else {
-			// Ensure all the hashes are the same for all kernel versions.
-			assert.Equal(t, hash, kernelArgsHash)
+		hashMatches := hashRegexp.FindStringSubmatch(kernelArgs)
+		if assert.Equal(t, 2, len(hashMatches)) {
+			kernelArgsHash := hashMatches[1]
+			if hash == "" {
+				hash = kernelArgsHash
+			} else {
+				// Ensure all the hashes are the same for all kernel versions.
+				assert.Equal(t, hash, kernelArgsHash)
+			}
 		}
 	}
 
 	if assert.NotEqual(t, "", hash) {
 		// Verify verity hashes.
-		err := shell.ExecuteLive(false, "veritysetup", "verify", dataDevice, hashDevice, hash)
+		args := []string{"verify"}
+
+		if inlineVerity {
+			args = append(args, fmt.Sprintf("--hash-offset=%s", hashOffset))
+		}
+
+		args = append(args, dataDevice, hashDevice, hash)
+
+		err := shell.ExecuteLive(false, "veritysetup", args...)
 		assert.NoError(t, err)
 	}
 }
@@ -468,7 +492,7 @@ func verityUsrVerity(t *testing.T, baseImageInfo testBaseImageInfo, buildDir str
 	usrDevice := testutils.PartitionDevPath(imageConnection, 2)
 	hashDevice := testutils.PartitionDevPath(imageConnection, 3)
 	verifyVerityGrub(t, bootPath, usrDevice, hashDevice, "UUID="+partitions[2].Uuid,
-		"UUID="+partitions[3].Uuid, "usr", "rd.info", baseImageInfo, corruptionOption)
+		"UUID="+partitions[3].Uuid, "usr", "rd.info", baseImageInfo, corruptionOption, false /*inlineVerity*/)
 }
 
 func TestCustomizeImageVerityUsr2Stage(t *testing.T) {
@@ -798,7 +822,7 @@ func verifyBtrfsVerityRoot(t *testing.T, baseImageInfo testBaseImageInfo, outIma
 	defer bootMount.Close()
 
 	verifyVerityGrub(t, bootMountDir, rootPartitionPath, hashPartitionPath, "PARTUUID="+partitions[3].PartUuid,
-		"PARTUUID="+partitions[4].PartUuid, "root", "rd.info", baseImageInfo, "panic-on-corruption")
+		"PARTUUID="+partitions[4].PartUuid, "root", "rd.info", baseImageInfo, "panic-on-corruption", false)
 
 	err = bootMount.CleanClose()
 	if !assert.NoError(t, err) {
@@ -852,4 +876,346 @@ func findFstabEntryByTarget(entries []diskutils.FstabEntry, target string) *disk
 		}
 	}
 	return nil
+}
+
+func TestCustomizeImageVerityRootInline(t *testing.T) {
+	for _, baseImageInfo := range baseImageAzureLinuxAll {
+		t.Run(baseImageInfo.Name, func(t *testing.T) {
+			testCustomizeImageVerityRootInlineHelper(t, "TestCustomizeImageVerityRootInline"+baseImageInfo.Name, baseImageInfo)
+		})
+	}
+}
+
+func testCustomizeImageVerityRootInlineHelper(t *testing.T, testName string, baseImageInfo testBaseImageInfo) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
+
+	testTempDir := filepath.Join(tmpDir, testName)
+	defer os.RemoveAll(testTempDir)
+
+	buildDir := filepath.Join(testTempDir, "build")
+	outImageFilePath := filepath.Join(testTempDir, "image.raw")
+	configFile := filepath.Join(testDir, "verity-root-inline.yaml")
+
+	// Customize image.
+	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
+		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	verifyRootInlineVerity(t, baseImageInfo, buildDir, outImageFilePath)
+
+	// Recustomize the image.
+	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, nil, outImageFilePath, "raw",
+		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	verifyRootInlineVerity(t, baseImageInfo, buildDir, outImageFilePath)
+
+	// Reinit verity without customizing partitions.
+	configFile = filepath.Join(testDir, "verity-reinit.yaml")
+
+	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, nil, outImageFilePath, "raw",
+		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	verifyRootInlineVerity(t, baseImageInfo, buildDir, outImageFilePath)
+}
+
+func verifyRootInlineVerity(t *testing.T, baseImageInfo testBaseImageInfo, buildDir string,
+	outImageFilePath string,
+) {
+	// Connect to customized image.
+	mountPoints := []testutils.MountPoint{
+		{
+			PartitionNum:   3,
+			Path:           "/",
+			FileSystemType: "ext4",
+			Flags:          unix.MS_RDONLY,
+		},
+		{
+			PartitionNum:   2,
+			Path:           "/boot",
+			FileSystemType: "ext4",
+		},
+		{
+			PartitionNum:   1,
+			Path:           "/boot/efi",
+			FileSystemType: "vfat",
+		},
+		{
+			PartitionNum:   4,
+			Path:           "/var",
+			FileSystemType: "ext4",
+		},
+	}
+
+	imageConnection, err := testutils.ConnectToImage(buildDir, outImageFilePath, false /*includeDefaultMounts*/, mountPoints)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer imageConnection.Close()
+
+	partitions, err := getDiskPartitionsMap(imageConnection.Loopback().DevicePath())
+	assert.NoError(t, err, "get disk partitions")
+
+	// Verify that verity is configured correctly.
+	// This helps verify that verity-enabled images can be recustomized.
+	bootPath := filepath.Join(imageConnection.Chroot().RootDir(), "/boot")
+	rootDevice := testutils.PartitionDevPath(imageConnection, 3)
+	verifyVerityGrub(t, bootPath, rootDevice, rootDevice, "PARTUUID="+partitions[3].PartUuid,
+		"PARTUUID="+partitions[3].PartUuid, "root", "rd.info", baseImageInfo, "panic-on-corruption",
+		true /*inlineVerity*/)
+
+	err = imageConnection.CleanClose()
+	if !assert.NoError(t, err) {
+		return
+	}
+}
+
+func TestCustomizeImageVerityUsrInline(t *testing.T) {
+	for _, baseImageInfo := range baseImageAzureLinuxAll {
+		t.Run(baseImageInfo.Name, func(t *testing.T) {
+			testCustomizeImageVerityUsrInlineHelper(t, "TestCustomizeImageVerityUsrInline"+baseImageInfo.Name, baseImageInfo)
+		})
+	}
+}
+
+func testCustomizeImageVerityUsrInlineHelper(t *testing.T, testName string, baseImageInfo testBaseImageInfo) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
+
+	testTempDir := filepath.Join(tmpDir, testName)
+	defer os.RemoveAll(testTempDir)
+
+	buildDir := filepath.Join(testTempDir, "build")
+	outImageFilePath := filepath.Join(testTempDir, "image.raw")
+	configFile := filepath.Join(testDir, "verity-usr-inline.yaml")
+
+	// Customize image.
+	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
+		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	verifyUsrInlineVerity(t, baseImageInfo, buildDir, outImageFilePath)
+
+	// Recustomize the image.
+	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, nil, outImageFilePath, "raw",
+		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	verifyUsrInlineVerity(t, baseImageInfo, buildDir, outImageFilePath)
+
+	// Reinit verity without customizing partitions.
+	configFile = filepath.Join(testDir, "verity-reinit.yaml")
+
+	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, nil, outImageFilePath, "raw",
+		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	verifyUsrInlineVerity(t, baseImageInfo, buildDir, outImageFilePath)
+}
+
+func verifyUsrInlineVerity(t *testing.T, baseImageInfo testBaseImageInfo, buildDir string,
+	outImageFilePath string,
+) {
+	// Connect to customized image.
+	mountPoints := []testutils.MountPoint{
+		{
+			PartitionNum:   3,
+			Path:           "/",
+			FileSystemType: "ext4",
+		},
+		{
+			PartitionNum:   1,
+			Path:           "/boot/efi",
+			FileSystemType: "vfat",
+		},
+		{
+			PartitionNum:   2,
+			Path:           "/usr",
+			FileSystemType: "ext4",
+			Flags:          unix.MS_RDONLY,
+		},
+	}
+
+	imageConnection, err := testutils.ConnectToImage(buildDir, outImageFilePath, false /*includeDefaultMounts*/, mountPoints)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer imageConnection.Close()
+
+	partitions, err := getDiskPartitionsMap(imageConnection.Loopback().DevicePath())
+	assert.NoError(t, err, "get disk partitions")
+
+	// Verify that verity is configured correctly.
+	// This helps verify that verity-enabled images can be recustomized.
+	bootPath := filepath.Join(imageConnection.Chroot().RootDir(), "/boot")
+	usrDevice := testutils.PartitionDevPath(imageConnection, 2)
+	verifyVerityGrub(t, bootPath, usrDevice, usrDevice, "PARTUUID="+partitions[2].PartUuid,
+		"PARTUUID="+partitions[2].PartUuid, "usr", "rd.info", baseImageInfo, "ignore-corruption",
+		true /*inlineVerity*/)
+
+	err = imageConnection.CleanClose()
+	if !assert.NoError(t, err) {
+		return
+	}
+}
+
+func TestCustomizeImageVerityRootInlineCosi(t *testing.T) {
+	for _, baseImageInfo := range baseImageAzureLinuxAll {
+		t.Run(baseImageInfo.Name, func(t *testing.T) {
+			testCustomizeImageVerityRootInlineCosiHelper(t, "TestCustomizeImageVerityRootInlineCosi"+baseImageInfo.Name, baseImageInfo)
+		})
+	}
+}
+
+func testCustomizeImageVerityRootInlineCosiHelper(t *testing.T, testName string, baseImageInfo testBaseImageInfo) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
+
+	testTempDir := filepath.Join(tmpDir, testName)
+	defer os.RemoveAll(testTempDir)
+
+	buildDir := filepath.Join(testTempDir, "build")
+	outImageFilePath := filepath.Join(testTempDir, "image.cosi")
+	configFile := filepath.Join(testDir, "verity-root-inline-uki.yaml")
+
+	// Customize image, shrink partitions, and split the partitions into individual files.
+	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "cosi",
+		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	expectedCosiMetadata := MetadataJson{
+		Disk: Disk{
+			Size:       2550 * diskutils.MiB,
+			GptRegions: newTestCosiGptSections([]int{1, 2, 3, 4}),
+		},
+		Images: []FileSystem{
+			{
+				Image: ImageFile{
+					Path: "images/image_1.raw.zst",
+				},
+				MountPoint: "/boot/efi",
+				FsType:     "vfat",
+				PartType:   imagecustomizerapi.PartitionTypeToUuid[imagecustomizerapi.PartitionTypeESP],
+			},
+			{
+				Image: ImageFile{
+					Path: "images/image_2.raw.zst",
+				},
+				MountPoint: "/boot",
+				FsType:     "ext4",
+				PartType:   imagecustomizerapi.PartitionTypeToUuid[imagecustomizerapi.PartitionTypeLinuxGeneric],
+			},
+			{
+				Image: ImageFile{
+					Path: "images/image_3.raw.zst",
+				},
+				MountPoint: "/",
+				FsType:     "ext4",
+				PartType:   imagecustomizerapi.PartitionTypeToUuid[imagecustomizerapi.PartitionTypeLinuxGeneric],
+				Verity: &VerityConfig{
+					Image: ImageFile{
+						Path: "images/image_3.raw.zst",
+					},
+				},
+			},
+			{
+				Image: ImageFile{
+					Path: "images/image_4.raw.zst",
+				},
+				MountPoint: "/var",
+				FsType:     "ext4",
+				PartType:   imagecustomizerapi.PartitionTypeToUuid[imagecustomizerapi.PartitionTypeLinuxGeneric],
+			},
+		},
+		Bootloader: CosiBootloader{
+			Type: "systemd-boot",
+			SystemdBoot: &SystemDBoot{
+				Entries: []SystemDBootEntry{
+					{
+						Type: "uki-standalone",
+					},
+				},
+			},
+		},
+		Compression: Compression{
+			MaxWindowLog: imagecustomizerapi.DefaultCosiCompressionLong,
+		},
+	}
+
+	// Attach partition files.
+	metadata, metadataOk := extractCosiAndVerifyMetadata(t, outImageFilePath, testTempDir, expectedCosiMetadata)
+	if !metadataOk {
+		return
+	}
+
+	gptPath := filepath.Join(testTempDir, "image_gpt.raw")
+	espPartitionPath := filepath.Join(testTempDir, fmt.Sprintf("image_%d.raw", 1))
+	bootPartitionPath := filepath.Join(testTempDir, fmt.Sprintf("image_%d.raw", 2))
+	rootPartitionPath := filepath.Join(testTempDir, fmt.Sprintf("image_%d.raw", 3))
+	varPartitionPath := filepath.Join(testTempDir, fmt.Sprintf("image_%d.raw", 4))
+
+	gptStat, err := os.Stat(gptPath)
+	assert.NoError(t, err)
+
+	espStat, err := os.Stat(espPartitionPath)
+	assert.NoError(t, err)
+
+	bootStat, err := os.Stat(bootPartitionPath)
+	assert.NoError(t, err)
+
+	rootStat, err := os.Stat(rootPartitionPath)
+	assert.NoError(t, err)
+
+	varStat, err := os.Stat(varPartitionPath)
+	assert.NoError(t, err)
+
+	// Check partition sizes.
+	// Standard GPT size = MBR (512) + GPT Header (512) + Partition Entries (128 × 128 = 16384) = 17408 bytes
+	assert.Equal(t, int64(17408), gptStat.Size())
+	assert.Equal(t, int64(250*diskutils.MiB), espStat.Size())
+
+	// These partitions are shrunk. Their final size will vary based on base image version, package versions, filesystem
+	// implementation details, and randomness. So, just enforce that the final size is below an arbitary value. Values
+	// were picked by observing values seen during test and adding a good buffer.
+	assert.Greater(t, int64(100*diskutils.MiB), bootStat.Size())
+	assert.Greater(t, int64(500*diskutils.MiB), rootStat.Size())
+	assert.Greater(t, int64(150*diskutils.MiB), varStat.Size())
+
+	espDevice, err := safeloopback.NewLoopback(espPartitionPath)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer espDevice.Close()
+
+	rootDevice, err := safeloopback.NewLoopback(rootPartitionPath)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer rootDevice.Close()
+
+	espMountPath := filepath.Join(testTempDir, "esppartition")
+	espMount, err := safemount.NewMount(espDevice.DevicePath(), espMountPath, "vfat", 0, "", true)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer espMount.Close()
+
+	// Verify that verity is configured correctly.
+	verifyVerityUki(t, espMountPath, rootDevice.DevicePath(), rootDevice.DevicePath(),
+		"UUID="+metadata.Images[2].FsUuid, "UUID="+metadata.Images[2].FsUuid, "root", buildDir, "rd.info",
+		"panic-on-corruption", true /*inlineVerity*/)
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
@@ -225,10 +225,10 @@ func extractZstFile(zstFilePath string, outputFilePath string) error {
 
 func extractCosiAndVerifyMetadata(t *testing.T, cosiFilePath string, partitionsOutputDir string,
 	expectedMetadata MetadataJson,
-) bool {
+) (MetadataJson, bool) {
 	partitionsPaths, metadata, err := extractCosi(cosiFilePath, partitionsOutputDir)
 	if !assert.NoError(t, err) {
-		return false
+		return MetadataJson{}, false
 	}
 
 	assert.Equal(t, "1.2", metadata.Version)
@@ -264,6 +264,9 @@ func extractCosiAndVerifyMetadata(t *testing.T, cosiFilePath string, partitionsO
 			if expectedImage.Verity != nil && actualImage.Verity != nil {
 				verifyCosiImageFile(t, expectedImage.Verity.Image, actualImage.Verity.Image)
 				assert.Regexp(t, `^[0-9a-fA-F]{64}$`, actualImage.Verity.Roothash)
+
+				inlineVerity := expectedImage.Verity.Image.Path == expectedImage.Image.Path
+				assert.Equal(t, inlineVerity, actualImage.Verity.HashOffset != nil)
 			}
 		}
 	}
@@ -290,7 +293,7 @@ func extractCosiAndVerifyMetadata(t *testing.T, cosiFilePath string, partitionsO
 
 	assert.Equal(t, expectedMetadata.Compression, metadata.Compression)
 
-	return true
+	return metadata, true
 }
 
 func verifyCosiImageFile(t *testing.T, expected ImageFile, actual ImageFile) {
@@ -514,7 +517,7 @@ func TestCustomizeImageNopShrink(t *testing.T) {
 	}
 
 	// Attach partition files.
-	if !extractCosiAndVerifyMetadata(t, outImageFilePath, testTempDir, expectedCosiMetadataForAzlCoreEfi) {
+	if _, ok := extractCosiAndVerifyMetadata(t, outImageFilePath, testTempDir, expectedCosiMetadataForAzlCoreEfi); !ok {
 		return
 	}
 
@@ -638,7 +641,7 @@ func TestCustomizeImageExtractEmptyPartition(t *testing.T) {
 	}
 
 	// Attach partition files.
-	if !extractCosiAndVerifyMetadata(t, outImageFilePath, buildDir, expectedCosiMetadata) {
+	if _, ok := extractCosiAndVerifyMetadata(t, outImageFilePath, buildDir, expectedCosiMetadata); !ok {
 		return
 	}
 
@@ -699,7 +702,7 @@ func TestCustomizeImageFstabDelete(t *testing.T) {
 		return
 	}
 
-	if !extractCosiAndVerifyMetadata(t, outImageFilePath, buildDir, expectedCosiMetadataForAzlCoreEfi) {
+	if _, ok := extractCosiAndVerifyMetadata(t, outImageFilePath, buildDir, expectedCosiMetadataForAzlCoreEfi); !ok {
 		return
 	}
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -104,8 +104,7 @@ const (
 var ToolVersion = ""
 
 type imageMetadata struct {
-	baseImageVerityMetadata []verityDeviceMetadata
-	verityMetadata          []verityDeviceMetadata
+	verityMetadata []verityDeviceMetadata
 
 	partitionsLayout       []fstabEntryPartNum
 	osRelease              string
@@ -497,24 +496,31 @@ func customizeOSContents(ctx context.Context, rc *ResolvedConfig) (imageMetadata
 	}
 
 	im.partitionsLayout = partitionsLayout
-	im.baseImageVerityMetadata = baseImageVerityMetadata
 	im.osRelease = osRelease
+
+	configVerityMetadata, err := collectVerityMetadataFromImage(rc.Storage.Verity, rc.RawImageFile, partIdToPartUuid)
+	if err != nil {
+		return im, fmt.Errorf("%w:\n%w", ErrShrinkFilesystems, err)
+	}
+
+	verityMetadata := slices.Concat(baseImageVerityMetadata, configVerityMetadata)
 
 	// For COSI, always shrink the filesystems.
 	shrinkPartitions := rc.OutputImageFormat == imagecustomizerapi.ImageFormatTypeCosi || rc.OutputImageFormat == imagecustomizerapi.ImageFormatTypeBareMetalImage
 	if shrinkPartitions {
 		// For customize subcommand, we control the image creation, so filesystems always cover their partitions.
-		partitionOriginalSizes, err := shrinkFilesystemsHelper(ctx, rc.RawImageFile, readonlyPartUuids, false /*isExternalImage*/)
+		partitionOriginalSizes, err := shrinkFilesystemsHelper(ctx, rc.RawImageFile, readonlyPartUuids,
+			verityMetadata, false /*isExternalImage*/)
 		if err != nil {
 			return im, fmt.Errorf("%w:\n%w", ErrShrinkFilesystems, err)
 		}
 		im.partitionOriginalSizes = partitionOriginalSizes
 	}
 
-	if len(rc.Storage.Verity) > 0 || len(im.baseImageVerityMetadata) > 0 {
+	if len(verityMetadata) > 0 {
 		// Customize image for dm-verity, setting up verity metadata and security features.
-		verityMetadata, err := customizeVerityImage(ctx, rc.BuildDirAbs, rc, rc.RawImageFile,
-			partIdToPartUuid, shrinkPartitions, im.baseImageVerityMetadata, readonlyPartUuids, partitionsLayout)
+		err := customizeVerityImage(ctx, rc.BuildDirAbs, rc, rc.RawImageFile,
+			shrinkPartitions, verityMetadata, readonlyPartUuids, partitionsLayout)
 		if err != nil {
 			return im, fmt.Errorf("%w:\n%w", ErrCustomizeProvisionVerity, err)
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
@@ -649,13 +649,13 @@ func findVerityPartitionsFromCmdline(partitions []diskutils.PartitionInfo, cmdli
 		return diskutils.PartitionInfo{}, 0, verityDeviceMetadata{}, err
 	}
 
-	corruptionOption, hashSigPath, err := parseSystemdVerityOptions(options)
+	corruptionOption, hashSigPath, hashOffset, err := parseSystemdVerityOptions(options)
 	if err != nil {
 		err = fmt.Errorf("failed parse verity options (%s) kernel argument:\n%w", optionsArgName, err)
 		return diskutils.PartitionInfo{}, 0, verityDeviceMetadata{}, err
 	}
 
-	veritySuperblock, err := verityutils.ReadVeritySuperblock(hashPartition.Path)
+	veritySuperblock, err := verityutils.ReadVeritySuperblock(hashPartition.Path, hashOffset)
 	if err != nil {
 		err = fmt.Errorf("failed to read verity superblock:\n%w", err)
 		return diskutils.PartitionInfo{}, 0, verityDeviceMetadata{}, err
@@ -674,6 +674,8 @@ func findVerityPartitionsFromCmdline(partitions []diskutils.PartitionInfo, cmdli
 			hashAlgorithm:      veritySuperblock.GetAlgorithm(),
 			dataBlockSizeBytes: veritySuperblock.DataBlockSize,
 			hashBlockSizeBytes: veritySuperblock.HashBlockSize,
+			dataSizeBytes:      veritySuperblock.DataBlocks * uint64(veritySuperblock.DataBlockSize),
+			hashOffsetBytes:    hashOffset,
 		},
 	}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/shrinkfilesystems.go
@@ -12,6 +12,7 @@ import (
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/logger"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safeloopback"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/shell"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/verityutils"
 	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel"
 )
@@ -30,7 +31,9 @@ var (
 // (convert/inject-files subcommands), filesystems are only shrunk if they completely cover
 // their partition. When false (customize subcommand), filesystems are always shrunk since
 // IC controls the image creation.
-func shrinkFilesystemsHelper(ctx context.Context, buildImageFile string, readonlyPartUuids []string, isExternalImage bool) (map[string]uint64, error) {
+func shrinkFilesystemsHelper(ctx context.Context, buildImageFile string, readonlyPartUuids []string,
+	verityMetadata []verityDeviceMetadata, isExternalImage bool,
+) (map[string]uint64, error) {
 	_, span := otel.GetTracerProvider().Tracer(OtelTracerName).Start(ctx, "shrink_filesystems")
 	defer span.End()
 
@@ -41,7 +44,8 @@ func shrinkFilesystemsHelper(ctx context.Context, buildImageFile string, readonl
 	defer imageLoopback.Close()
 
 	// Shrink the filesystems and capture original sizes.
-	partitionOriginalSizes, err := shrinkFilesystems(imageLoopback.DevicePath(), readonlyPartUuids, isExternalImage)
+	partitionOriginalSizes, err := shrinkFilesystems(imageLoopback.DevicePath(), readonlyPartUuids,
+		verityMetadata, isExternalImage)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +58,9 @@ func shrinkFilesystemsHelper(ctx context.Context, buildImageFile string, readonl
 	return partitionOriginalSizes, nil
 }
 
-func shrinkFilesystems(imageLoopDevice string, readonlyPartUuids []string, isExternalImage bool) (map[string]uint64, error) {
+func shrinkFilesystems(imageLoopDevice string, readonlyPartUuids []string, verityMetadata []verityDeviceMetadata,
+	isExternalImage bool,
+) (map[string]uint64, error) {
 	logger.Log.Infof("Shrinking filesystems")
 
 	// Get partition info
@@ -127,7 +133,12 @@ func shrinkFilesystems(imageLoopDevice string, readonlyPartUuids []string, isExt
 			continue
 		}
 
-		fileSystemSizeInSectors := convertBytesToSectors(fileSystemSizeInBytes, sectorSize)
+		totalSizeInBytes, err := addVeritySuffixSize(fileSystemSizeInBytes, verityMetadata, diskPartition)
+		if err != nil {
+			return nil, err
+		}
+
+		fileSystemSizeInSectors := convertBytesToSectors(totalSizeInBytes, sectorSize)
 
 		err = resizePartition(partitionLoopDevice, imageLoopDevice, fileSystemSizeInSectors)
 		if err != nil {
@@ -290,4 +301,47 @@ func getExtFilesystemSize(partitionDevice string) (uint64, error) {
 
 	filesystemSizeInBytes := blockCount * blockSize
 	return filesystemSizeInBytes, nil
+}
+
+// Returns the size of the partition, including the size of the inline verity footer if applicable.
+func addVeritySuffixSize(fileSystemSizeInBytes uint64, verityMetadata []verityDeviceMetadata,
+	diskPartition diskutils.PartitionInfo,
+) (uint64, error) {
+	verityIndex := slices.IndexFunc(verityMetadata,
+		func(metadata verityDeviceMetadata) bool {
+			return metadata.dataPartUuid == diskPartition.PartUuid
+		})
+	if verityIndex < 0 {
+		// Partition is not a verity data partition.
+		return fileSystemSizeInBytes, nil
+	}
+
+	metadata := &verityMetadata[verityIndex]
+	if !metadata.formatSettings.IsInlineVerity() {
+		// Verity is not inline.
+		return fileSystemSizeInBytes, nil
+	}
+
+	// Calculate the size of the verity footer.
+
+	dataBlocks := fileSystemSizeInBytes / uint64(metadata.formatSettings.dataBlockSizeBytes)
+	if fileSystemSizeInBytes%uint64(metadata.formatSettings.dataBlockSizeBytes) != 0 {
+		// Round up data size to nearest verity data block.
+		dataBlocks += 1
+	}
+
+	veritySizeInBytes, err := verityutils.CalculateHashSizeInBytes(dataBlocks,
+		uint32(metadata.formatSettings.hashBlockSizeBytes), metadata.formatSettings.hashAlgorithm)
+	if err != nil {
+		return 0, fmt.Errorf("failed to calculate verity hash size:\n%w", err)
+	}
+
+	dataSizeInBytes := dataBlocks * uint64(metadata.formatSettings.dataBlockSizeBytes)
+	totalSizeInBytes := dataSizeInBytes + veritySizeInBytes
+
+	// Store the calculated sizes for when `veritysetup format` is called.
+	metadata.formatSettings.dataSizeBytes = dataSizeInBytes
+	metadata.formatSettings.hashOffsetBytes = dataSizeInBytes
+
+	return totalSizeInBytes, nil
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-root-inline-uki.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-root-inline-uki.yaml
@@ -1,0 +1,102 @@
+previewFeatures:
+- uki
+
+storage:
+  bootType: efi
+  disks:
+  - partitionTableType: gpt
+    partitions:
+    - id: esp
+      type: esp
+      size: 250M
+
+    - id: boot
+      size: 250M
+
+    - id: root
+      size: 1G
+
+    - id: var
+      size: 1G
+
+  verity:
+  - id: verityroot
+    name: root
+    dataDeviceId: root
+    hashDeviceId: root
+    dataDeviceMountIdType: uuid
+    hashDeviceMountIdType: uuid
+    corruptionOption: panic
+
+  filesystems:
+  - deviceId: esp
+    type: fat32
+    mountPoint:
+      path: /boot/efi
+      options: umask=0077
+
+  - deviceId: boot
+    type: ext4
+    mountPoint:
+      path: /boot
+
+  - deviceId: verityroot
+    type: ext4
+    mountPoint:
+      path: /
+      options: ro
+
+  - deviceId: var
+    type: ext4
+    mountPoint:
+      path: /var
+
+os:
+  bootloader:
+    resetType: hard-reset
+
+  uki:
+    mode: create
+
+  selinux:
+    mode: disabled
+
+  kernelCommandLine:
+    extraCommandLine:
+    - "rd.info"
+
+  packages:
+    remove:
+    - grub2-efi-binary
+
+    install:
+    - openssh-server
+    - veritysetup
+    - vim
+    - device-mapper
+    - systemd-boot
+
+  additionalFiles:
+    # Change the directory that the sshd-keygen service writes the SSH host keys to.
+  - source: files/sshd-keygen.service
+    destination: /usr/lib/systemd/system/sshd-keygen.service
+
+    # Enable DHCP client on all of the physical NICs.
+  - source: files/89-ethernet.network
+    destination: /etc/systemd/network/89-ethernet.network
+
+  services:
+    enable:
+    - sshd
+    
+  users:
+  - name: test
+    sshPublicKeys:
+      # Your SSH public key here.
+    secondaryGroups:
+    - sudo
+
+scripts:
+  postCustomization:
+    # Move the SSH host keys off of the read-only /etc directory, so that sshd can run.
+  - path: scripts/ssh-move-host-keys.sh

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-root-inline.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-root-inline.yaml
@@ -1,0 +1,90 @@
+storage:
+  bootType: efi
+  disks:
+  - partitionTableType: gpt
+    partitions:
+    - id: esp
+      type: esp
+      size: 8M
+
+    - id: boot
+      size: 1G
+
+    - id: root
+      size: 2G
+
+    - id: var
+      size: 2G
+
+  verity:
+  - id: verityroot
+    name: root
+    dataDeviceId: root
+    hashDeviceId: root
+    corruptionOption: panic
+
+  filesystems:
+  - deviceId: esp
+    type: fat32
+    mountPoint:
+      path: /boot/efi
+      options: umask=0077
+
+  - deviceId: boot
+    type: ext4
+    mountPoint:
+      path: /boot
+
+  - deviceId: verityroot
+    type: ext4
+    mountPoint:
+      path: /
+      options: ro
+
+  - deviceId: var
+    type: ext4
+    mountPoint:
+      path: /var
+
+os:
+  bootloader:
+    resetType: hard-reset
+
+  selinux:
+    mode: disabled
+
+  kernelCommandLine:
+    extraCommandLine:
+    - "rd.info"
+
+  packages:
+    install:
+    - openssh-server
+    - veritysetup
+    - vim
+    - device-mapper
+
+  additionalFiles:
+    # Change the directory that the sshd-keygen service writes the SSH host keys to.
+  - source: files/sshd-keygen.service
+    destination: /usr/lib/systemd/system/sshd-keygen.service
+
+    # Enable DHCP client on all of the physical NICs.
+  - source: files/89-ethernet.network
+    destination: /etc/systemd/network/89-ethernet.network
+
+  services:
+    enable:
+    - sshd
+    
+  users:
+  - name: test
+    sshPublicKeys:
+      # Your SSH public key here.
+    secondaryGroups:
+    - sudo
+
+scripts:
+  postCustomization:
+    # Move the SSH host keys off of the read-only /etc directory, so that sshd can run.
+  - path: scripts/ssh-move-host-keys.sh

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-inline.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-inline.yaml
@@ -1,0 +1,68 @@
+storage:
+  bootType: efi
+  disks:
+  - partitionTableType: gpt
+    partitions:
+    - id: esp
+      type: esp
+      size: 8M
+
+    - id: usr
+      size: 2G
+    
+    - id: root
+      size: 2G
+
+  verity:
+  - id: verityusr
+    name: usr
+    dataDeviceId: usr
+    hashDeviceId: usr
+    corruptionOption: ignore
+
+  filesystems:
+  - deviceId: esp
+    type: fat32
+    mountPoint:
+      path: /boot/efi
+      options: umask=0077
+
+  - deviceId: root
+    type: ext4
+    mountPoint:
+      path: /
+
+  - deviceId: verityusr
+    type: ext4
+    mountPoint:
+      path: /usr
+      options: ro
+
+os:
+  bootloader:
+    resetType: hard-reset
+
+  selinux:
+    mode: disabled
+
+  kernelCommandLine:
+    extraCommandLine:
+    - "rd.info"
+
+  packages:
+    install:
+    - openssh-server
+    - veritysetup
+    - vim
+    - device-mapper
+
+  services:
+    enable:
+    - sshd
+    
+  users:
+  - name: test
+    sshPublicKeys:
+      # Your SSH public key here.
+    secondaryGroups:
+    - sudo

--- a/toolkit/tools/pkg/imagecustomizerlib/typeConversion.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/typeConversion.go
@@ -20,6 +20,7 @@ var (
 	ErrPartitionTableTypeUnknown  = NewImageCustomizerError("TypeConversion:PartitionTableTypeUnknown", "unknown partition table type")
 	ErrPartitionStartInvalid      = NewImageCustomizerError("TypeConversion:PartitionStartInvalid", "partition start must be multiple of 1 MiB")
 	ErrPartitionEndInvalid        = NewImageCustomizerError("TypeConversion:PartitionEndInvalid", "partition end must be multiple of 1 MiB")
+	ErrFilesystemSizeInvalid      = NewImageCustomizerError("TypeConversion:FilesystemSizeInvalid", "filesystem size must be multiple of 1 MiB")
 	ErrMountIdentifierTypeUnknown = NewImageCustomizerError("TypeConversion:MountIdentifierTypeUnknown", "unknown MountIdentifierType value")
 	ErrSelinuxModeUnknown         = NewImageCustomizerError("TypeConversion:SelinuxModeUnknown", "unknown SELinuxMode value")
 )
@@ -101,10 +102,15 @@ func partitionToImager(partition imagecustomizerapi.Partition, fileSystems []ima
 		return configuration.Partition{}, fmt.Errorf("%w (start='%d')", ErrPartitionStartInvalid, *partition.Start)
 	}
 
-	end, _ := partition.GetEnd()
+	end := *partition.End
 	imagerEnd := end / diskutils.MiB
 	if end%diskutils.MiB != 0 {
 		return configuration.Partition{}, fmt.Errorf("%w (end='%d')", ErrPartitionEndInvalid, end)
+	}
+
+	imagerFsSize := fileSystem.Size / diskutils.MiB
+	if fileSystem.Size%diskutils.MiB != 0 {
+		return configuration.Partition{}, fmt.Errorf("%w (size='%d')", ErrFilesystemSizeInvalid, fileSystem.Size)
 	}
 
 	imagerFlags, typeUuid, err := toImagerPartitionFlags(partition.Type)
@@ -123,6 +129,7 @@ func partitionToImager(partition imagecustomizerapi.Partition, fileSystems []ima
 		Flags:           imagerFlags,
 		TypeUUID:        typeUuid,
 		IsBootPartition: isBootPartition,
+		FsSize:          imagerFsSize,
 	}
 	return imagerPartition, nil
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/veritytypes.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/veritytypes.go
@@ -23,4 +23,10 @@ type verityFormatSettings struct {
 	hashAlgorithm      string
 	dataBlockSizeBytes uint32
 	hashBlockSizeBytes uint32
+	dataSizeBytes      uint64
+	hashOffsetBytes    uint64
+}
+
+func (s *verityFormatSettings) IsInlineVerity() bool {
+	return s.hashOffsetBytes != 0
 }


### PR DESCRIPTION
Add support for verity where the data and hash tree are placed in the same partition, with the hash at the back.

Changes include:

- Populate the size and end of the partition type during validation, so that downstream code can easily use this data.

- The `mkfs` command doesn't have a common way to specify a filesystem size that doesn't fill the partition. So, switch to using the `mkfs.xxx` commands instead.

- The shrink partition logic needs to know the verity metadata since it needs to be able to shrink inline verity partitions correctly. Hence, the verity metadata collection was moved to be prior to the shrink partitions operation.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
