### PR TITLE
Use addonx64.efi.stub, not linuxx64.efi.stub, for UKI addons

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki.go
@@ -382,9 +382,10 @@ func createUkiDirectories(buildDir string, imageChroot *safechroot.Chroot) error
 func copyUkiFiles(buildDir string, kernelToInitramfs map[string]string, imageChroot *safechroot.Chroot,
 	bootConfig BootFilesArchConfig, uki *imagecustomizerapi.Uki,
 ) error {
-	// Both create and modify modes need the stub file
+	// Both create and modify modes need the stub files
 	filesToCopy := map[string]string{
-		filepath.Join(imageChroot.RootDir(), bootConfig.ukiEfiStubBinaryPath): filepath.Join(buildDir, UkiBuildDir, bootConfig.ukiEfiStubBinary),
+		filepath.Join(imageChroot.RootDir(), bootConfig.ukiEfiStubBinaryPath):   filepath.Join(buildDir, UkiBuildDir, bootConfig.ukiEfiStubBinary),
+		filepath.Join(imageChroot.RootDir(), bootConfig.ukiAddonStubBinaryPath): filepath.Join(buildDir, UkiBuildDir, bootConfig.ukiAddonStubBinary),
 	}
 
 	// Create mode needs additional files (os-release, kernels, initramfs)
@@ -505,7 +506,7 @@ func createUkiInModifyMode(ctx context.Context, rc *ResolvedConfig) error {
 		logger.Log.Debugf("UKI file [%d]: %s", i, ukiFile)
 	}
 
-	stubPath := filepath.Join(rc.BuildDirAbs, UkiBuildDir, bootConfig.ukiEfiStubBinary)
+	stubPath := filepath.Join(rc.BuildDirAbs, UkiBuildDir, bootConfig.ukiAddonStubBinary)
 
 	// Process each UKI file - regenerate its addon with updated cmdline
 	for _, ukiFile := range ukiFiles {
@@ -628,6 +629,7 @@ func createUki(ctx context.Context, rc *ResolvedConfig) error {
 	}
 
 	stubPath := filepath.Join(rc.BuildDirAbs, UkiBuildDir, bootConfig.ukiEfiStubBinary)
+	addonStubPath := filepath.Join(rc.BuildDirAbs, UkiBuildDir, bootConfig.ukiAddonStubBinary)
 	osSubreleaseFullPath := filepath.Join(rc.BuildDirAbs, UkiBuildDir, "os-release")
 	cmdlineFilePath := filepath.Join(rc.BuildDirAbs, UkiBuildDir, UkiKernelInfoJson)
 
@@ -638,7 +640,7 @@ func createUki(ctx context.Context, rc *ResolvedConfig) error {
 	}
 
 	for kernel, info := range kernelInfo {
-		err := buildUki(kernel, info.Initramfs, info.Cmdline, osSubreleaseFullPath, stubPath, rc.BuildDirAbs,
+		err := buildUki(kernel, info.Initramfs, info.Cmdline, osSubreleaseFullPath, stubPath, addonStubPath, rc.BuildDirAbs,
 			systemBootPartitionTmpDir,
 		)
 		if err != nil {
@@ -724,7 +726,7 @@ func extractKernelToArgsFromGrub(grubCfgPath string) (map[string]string, error) 
 }
 
 func buildUki(kernel string, initramfs string, kernelArgs string, osSubreleaseFullPath string,
-	stubPath string, buildDir string, systemBootPartitionTmpDir string,
+	stubPath string, addonStubPath string, buildDir string, systemBootPartitionTmpDir string,
 ) error {
 	kernelVersion, err := getKernelVersion(kernel)
 	if err != nil {
@@ -738,7 +740,7 @@ func buildUki(kernel string, initramfs string, kernelArgs string, osSubreleaseFu
 	}
 
 	// Build UKI addon
-	err = buildUkiAddon(kernel, kernelArgs, stubPath, systemBootPartitionTmpDir)
+	err = buildUkiAddon(kernel, kernelArgs, addonStubPath, systemBootPartitionTmpDir)
 	if err != nil {
 		return fmt.Errorf("failed to build UKI addon:\n%w", err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoutils.go
@@ -32,6 +32,9 @@ const (
 	ukiEfiStubx64Binary  = "linuxx64.efi.stub"
 	ukiEfiStubAA64Binary = "linuxaa64.efi.stub"
 
+	ukiAddonStubx64Binary  = "addonx64.efi.stub"
+	ukiAddonStubAA64Binary = "addonaa64.efi.stub"
+
 	grubCfgDir     = "/boot/grub2"
 	isoGrubCfg     = "grub.cfg"
 	isoGrubCfgPath = grubCfgDir + "/" + isoGrubCfg
@@ -83,40 +86,44 @@ type BootFilesArchConfig struct {
 	isoGrubBinaryPath           string
 	ukiEfiStubBinary            string
 	ukiEfiStubBinaryPath        string
+	ukiAddonStubBinary          string
+	ukiAddonStubBinaryPath      string
 }
 
-var (
-	bootloaderFilesConfig = map[string]BootFilesArchConfig{
-		"amd64": {
-			bootBinary:                  bootx64Binary,
-			grubBinary:                  grubx64Binary,
-			grubNoPrefixBinary:          grubx64NoPrefixBinary,
-			espBootBinaryPath:           espBootloaderDir + "/" + bootx64Binary,
-			espGrubBinaryPath:           espBootloaderDir + "/" + grubx64Binary,
-			osEspBootBinaryPath:         osEspBootloaderDir + "/" + bootx64Binary,
-			osEspGrubBinaryPath:         osEspBootloaderDir + "/" + grubx64Binary,
-			osEspGrubNoPrefixBinaryPath: osEspBootloaderDir + "/" + grubx64NoPrefixBinary,
-			isoBootBinaryPath:           isoBootloaderDir + "/" + bootx64Binary,
-			isoGrubBinaryPath:           isoBootloaderDir + "/" + grubx64Binary,
-			ukiEfiStubBinary:            ukiEfiStubx64Binary,
-			ukiEfiStubBinaryPath:        ukiEfiStubDir + "/" + ukiEfiStubx64Binary,
-		},
-		"arm64": {
-			bootBinary:                  bootAA64Binary,
-			grubBinary:                  grubAA64Binary,
-			grubNoPrefixBinary:          grubAA64NoPrefixBinary,
-			espBootBinaryPath:           espBootloaderDir + "/" + bootAA64Binary,
-			espGrubBinaryPath:           espBootloaderDir + "/" + grubAA64Binary,
-			osEspBootBinaryPath:         osEspBootloaderDir + "/" + bootAA64Binary,
-			osEspGrubBinaryPath:         osEspBootloaderDir + "/" + grubAA64Binary,
-			osEspGrubNoPrefixBinaryPath: osEspBootloaderDir + "/" + grubAA64NoPrefixBinary,
-			isoBootBinaryPath:           isoBootloaderDir + "/" + bootAA64Binary,
-			isoGrubBinaryPath:           isoBootloaderDir + "/" + grubAA64Binary,
-			ukiEfiStubBinary:            ukiEfiStubAA64Binary,
-			ukiEfiStubBinaryPath:        ukiEfiStubDir + "/" + ukiEfiStubAA64Binary,
-		},
-	}
-)
+var bootloaderFilesConfig = map[string]BootFilesArchConfig{
+	"amd64": {
+		bootBinary:                  bootx64Binary,
+		grubBinary:                  grubx64Binary,
+		grubNoPrefixBinary:          grubx64NoPrefixBinary,
+		espBootBinaryPath:           espBootloaderDir + "/" + bootx64Binary,
+		espGrubBinaryPath:           espBootloaderDir + "/" + grubx64Binary,
+		osEspBootBinaryPath:         osEspBootloaderDir + "/" + bootx64Binary,
+		osEspGrubBinaryPath:         osEspBootloaderDir + "/" + grubx64Binary,
+		osEspGrubNoPrefixBinaryPath: osEspBootloaderDir + "/" + grubx64NoPrefixBinary,
+		isoBootBinaryPath:           isoBootloaderDir + "/" + bootx64Binary,
+		isoGrubBinaryPath:           isoBootloaderDir + "/" + grubx64Binary,
+		ukiEfiStubBinary:            ukiEfiStubx64Binary,
+		ukiEfiStubBinaryPath:        ukiEfiStubDir + "/" + ukiEfiStubx64Binary,
+		ukiAddonStubBinary:          ukiAddonStubx64Binary,
+		ukiAddonStubBinaryPath:      ukiEfiStubDir + "/" + ukiAddonStubx64Binary,
+	},
+	"arm64": {
+		bootBinary:                  bootAA64Binary,
+		grubBinary:                  grubAA64Binary,
+		grubNoPrefixBinary:          grubAA64NoPrefixBinary,
+		espBootBinaryPath:           espBootloaderDir + "/" + bootAA64Binary,
+		espGrubBinaryPath:           espBootloaderDir + "/" + grubAA64Binary,
+		osEspBootBinaryPath:         osEspBootloaderDir + "/" + bootAA64Binary,
+		osEspGrubBinaryPath:         osEspBootloaderDir + "/" + grubAA64Binary,
+		osEspGrubNoPrefixBinaryPath: osEspBootloaderDir + "/" + grubAA64NoPrefixBinary,
+		isoBootBinaryPath:           isoBootloaderDir + "/" + bootAA64Binary,
+		isoGrubBinaryPath:           isoBootloaderDir + "/" + grubAA64Binary,
+		ukiEfiStubBinary:            ukiEfiStubAA64Binary,
+		ukiEfiStubBinaryPath:        ukiEfiStubDir + "/" + ukiEfiStubAA64Binary,
+		ukiAddonStubBinary:          ukiAddonStubAA64Binary,
+		ukiAddonStubBinaryPath:      ukiEfiStubDir + "/" + ukiAddonStubAA64Binary,
+	},
+}
 
 func getBootArchConfig() (string, BootFilesArchConfig, error) {
 	arch := runtime.GOARCH


### PR DESCRIPTION
UKI addons were being built using linuxx64.efi.stub, the full systemd-stub meant for main UKIs that embed kernel/initrd. This worked by coincidence on current systemd 255 builds, but is incorrect per upstream systemd design, and will fail with later versions of systemd that ship a larger linuxx64.efi.stuf, which leaves no room for the appended .cmdline section data (systemd 258 already triggers this).

Since systemd 254, ukify ships a dedicated, minimal addonx64.efi.stub, whose PE header reserves space for appended sections. When --linux is not specified, ukify auto-selects the addon stub by default. Our code overrides this with --stub=, so we need to pass the correct stub explicitly.

Using the linux stub for addons produces PE binaries where the appended .cmdline section data may land at or beyond EOF depending on stub size and alignment, causing `objcopy --dump-section .cmdline` to fail with "file truncated". The addon stub avoids this by design.

<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

---

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] Code conforms to style guidelines
