### PR TITLE
Fix sparse vmlinuz boot failure on XFS by changing cp --sparse to auto

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
@@ -68,7 +68,7 @@ func copyPartitionFilesWithOptions(sourceRoot, targetRoot string, noClobber bool
 	// `-a` ensures unix permissions, extended attributes (including SELinux), and sub-directories (-r) are copied.
 	// `--no-dereference` ensures that symlinks are copied as symlinks.
 	copyArgs := []string{
-		"--verbose", "-a", "--no-dereference", "--sparse", "always",
+		"--verbose", "-a", "--no-dereference", "--sparse", "auto",
 		sourceRoot, targetRoot,
 	}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
@@ -68,7 +68,7 @@ func copyPartitionFilesWithOptions(sourceRoot, targetRoot string, noClobber bool
 	// `-a` ensures unix permissions, extended attributes (including SELinux), and sub-directories (-r) are copied.
 	// `--no-dereference` ensures that symlinks are copied as symlinks.
 	copyArgs := []string{
-		"--verbose", "-a", "--no-dereference", "--sparse", "auto",
+		"--verbose", "-a", "--no-dereference",
 		sourceRoot, targetRoot,
 	}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
@@ -239,7 +239,7 @@ func testCustomizeImageVerityCosiExtractHelper(t *testing.T, testName string, ba
 	// implementation details, and randomness. So, just enforce that the final size is below an arbitary value. Values
 	// were picked by observing values seen during test and adding a good buffer.
 	assert.Greater(t, int64(150*diskutils.MiB), bootStat.Size())
-	assert.Greater(t, int64(675*diskutils.MiB), rootStat.Size())
+	assert.Greater(t, int64(750*diskutils.MiB), rootStat.Size())
 	assert.Greater(t, int64(10*diskutils.MiB), hashStat.Size())
 	assert.Greater(t, int64(150*diskutils.MiB), varStat.Size())
 


### PR DESCRIPTION
<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

Fix boot failure caused by sparse vmlinuz kernel files on XFS partitions.

When Image Customizer repartitions an image (via `storage:` config), it copies
all files from the old image to the new one using `cp --sparse always`. This
flag aggressively scans file content for zero-byte runs and converts them into
filesystem holes.

The AZL 3.0 vmlinuz kernel binary contains a legitimate run of zero bytes.
`cp --sparse always` turns this into a sparse hole in the destination file.
GRUB cannot read sparse files on XFS, causing a boot failure.

---

## Verification
Reproduced and verified with Azure Linux 3.0 core-efi image
(core-3.0.20260401.vhdx) using the `partitions-xfs-boot.yaml` test config.

**Before fix** (`--sparse always`):
```
filefrag -v /mnt/boot/vmlinuz-6.6.130.1-3.azl3
 ext:     logical_offset:        physical_offset: length:   expected: flags:
   0:        0..    3566:      34935..     38501:   3567:
   1:     3568..    3702:      38503..     38637:    135:             last,eof
```
Logical block 3567 is a sparse hole.

**After fix** (`--sparse auto`):
```
filefrag -v /mnt/boot/vmlinuz-6.6.130.1-3.azl3
 ext:     logical_offset:        physical_offset: length:   expected: flags:
   0:        0..    3702:      31809..     35511:   3703:             last,eof
```
Single contiguous extent, no holes.