### PR TITLE
Fix: SELinux mode incorrectly detected as disabled when no kernel args present

### DIFF
--- a/test/vmtests/vmtests/osmodifier/test_osmodifier.py
+++ b/test/vmtests/vmtests/osmodifier/test_osmodifier.py
@@ -315,11 +315,7 @@ def test_osmodifier_boot_config(
     assert "overlay" in grub_cfg
 
     sestatus_output = ssh_client.run("sudo sestatus").stdout
-    sestatus = dict(
-        line.split(":", 1)
-        for line in sestatus_output.splitlines()
-        if ":" in line
-    )
+    sestatus = dict(line.split(":", 1) for line in sestatus_output.splitlines() if ":" in line)
     sestatus = {k.strip(): v.strip() for k, v in sestatus.items()}
 
     assert sestatus.get("SELinux status") == "enabled", f"SELinux not enabled: {sestatus_output}"

--- a/test/vmtests/vmtests/osmodifier/test_osmodifier.py
+++ b/test/vmtests/vmtests/osmodifier/test_osmodifier.py
@@ -313,8 +313,17 @@ def test_osmodifier_boot_config(
     assert "console=ttyS0" in grub_cfg
     assert "verity" in grub_cfg
     assert "overlay" in grub_cfg
-    assert "selinux=1" in grub_cfg
-    assert "enforcing=0" in grub_cfg
+
+    sestatus_output = ssh_client.run("sudo sestatus").stdout
+    sestatus = dict(
+        line.split(":", 1)
+        for line in sestatus_output.splitlines()
+        if ":" in line
+    )
+    sestatus = {k.strip(): v.strip() for k, v in sestatus.items()}
+
+    assert sestatus.get("SELinux status") == "enabled", f"SELinux not enabled: {sestatus_output}"
+    assert sestatus.get("Current mode") == "permissive", f"Expected permissive mode: {sestatus_output}"
 
 
 def test_uki_selinux_config(

--- a/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer_test.go
@@ -53,7 +53,7 @@ func TestBootCustomizerSELinuxMode20(t *testing.T) {
 	selinuxMode, found, err := b.getSELinuxModeFromCmdline("", nil)
 	assert.NoError(t, err)
 	assert.True(t, found)
-	assert.Equal(t, imagecustomizerapi.SELinuxModeDisabled, selinuxMode)
+	assert.Equal(t, imagecustomizerapi.SELinuxModeDefault, selinuxMode)
 
 	err = b.UpdateSELinuxCommandLine(imagecustomizerapi.SELinuxModePermissive)
 	assert.NoError(t, err)
@@ -117,9 +117,9 @@ func TestBootCustomizerSELinuxMode30(t *testing.T) {
 	assert.Equal(t, imagecustomizerapi.SELinuxModeDefault, selinuxMode)
 
 	expectedDefaultGrubFileDiff := `5c5
-< GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity "
+< GRUB_CMDLINE_LINUX="   selinux=0  rd.auto=1 net.ifnames=0 lockdown=integrity "
 ---
-> GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity security=selinux selinux=1  "
+> GRUB_CMDLINE_LINUX="   security=selinux selinux=1  rd.auto=1 net.ifnames=0 lockdown=integrity "
 `
 	checkDiffs30(t, b, "", expectedDefaultGrubFileDiff)
 
@@ -132,9 +132,9 @@ func TestBootCustomizerSELinuxMode30(t *testing.T) {
 	assert.Equal(t, imagecustomizerapi.SELinuxModeForceEnforcing, selinuxMode)
 
 	expectedDefaultGrubFileDiff = `5c5
-< GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity "
+< GRUB_CMDLINE_LINUX="   selinux=0  rd.auto=1 net.ifnames=0 lockdown=integrity "
 ---
-> GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity  security=selinux selinux=1 enforcing=1  "
+> GRUB_CMDLINE_LINUX="    security=selinux selinux=1 enforcing=1  rd.auto=1 net.ifnames=0 lockdown=integrity "
 `
 	checkDiffs30(t, b, "", expectedDefaultGrubFileDiff)
 
@@ -147,9 +147,9 @@ func TestBootCustomizerSELinuxMode30(t *testing.T) {
 	assert.Equal(t, imagecustomizerapi.SELinuxModeDisabled, selinuxMode)
 
 	expectedDefaultGrubFileDiff = `5c5
-< GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity "
+< GRUB_CMDLINE_LINUX="   selinux=0  rd.auto=1 net.ifnames=0 lockdown=integrity "
 ---
-> GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity    selinux=0  "
+> GRUB_CMDLINE_LINUX="      selinux=0  rd.auto=1 net.ifnames=0 lockdown=integrity "
 `
 	checkDiffs30(t, b, "", expectedDefaultGrubFileDiff)
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
@@ -5,7 +5,9 @@ package imagecustomizerlib
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -763,6 +765,10 @@ func getSELinuxModeFromConfigFile(imageChroot safechroot.ChrootInterface) (image
 	// Read the SELinux config file.
 	selinuxConfig, err := file.Read(selinuxConfigFilePath)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// SELinux config file doesn't exist (e.g. when SELinux isn't installed). Treat as disabled.
+			return imagecustomizerapi.SELinuxModeDisabled, nil
+		}
 		return imagecustomizerapi.SELinuxModeDefault, fmt.Errorf("failed to read SELinux config file (%s):\n%w",
 			installutils.SELinuxConfigFile, err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
@@ -735,9 +735,15 @@ func getSELinuxModeFromLinuxArgs(args []grubConfigLinuxArg) (imagecustomizerapi.
 		return imagecustomizerapi.SELinuxModeDefault, err
 	}
 
-	// Check if SELinux is disabled.
-	if securityValue != "selinux" || selinuxValue != "1" {
+	// Check if SELinux is explicitly disabled (selinux=0) or not explicitly enabled.
+	if selinuxValue == "0" {
 		return imagecustomizerapi.SELinuxModeDisabled, nil
+	}
+
+	// If there are no SELinux kernel args at all, the mode is determined by /etc/selinux/config.
+	// Signal this by returning the default ("") value.
+	if securityValue != "selinux" || selinuxValue != "1" {
+		return imagecustomizerapi.SELinuxModeDefault, nil
 	}
 
 	// Check if SELinux is in forced enforcing mode.
@@ -745,7 +751,7 @@ func getSELinuxModeFromLinuxArgs(args []grubConfigLinuxArg) (imagecustomizerapi.
 		return imagecustomizerapi.SELinuxModeForceEnforcing, nil
 	}
 
-	// The SELinux mode has been left up to the /etc/selinux/config file.
+	// The SELinux mode has again been left up to the /etc/selinux/config file.
 	// Signal this by returning the default ("") value.
 	return imagecustomizerapi.SELinuxModeDefault, nil
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/bootcfgtests/3.0-default-grub
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/bootcfgtests/3.0-default-grub
@@ -2,7 +2,7 @@ GRUB_TIMEOUT=0
 GRUB_DISTRIBUTOR="AzureLinux"
 GRUB_DISABLE_SUBMENU=y
 GRUB_TERMINAL_OUTPUT="console"
-GRUB_CMDLINE_LINUX="      rd.auto=1 net.ifnames=0 lockdown=integrity "
+GRUB_CMDLINE_LINUX="   selinux=0  rd.auto=1 net.ifnames=0 lockdown=integrity "
 GRUB_CMDLINE_LINUX_DEFAULT=" $kernelopts"
     
 # =============================notice===============================


### PR DESCRIPTION
getSELinuxModeFromLinuxArgs() treats the absence of SELinux kernel command-line arguments (security=, selinux=, enforcing=) as Disabled. No args, however, means the mode is determined by /etc/selinux/config, and should return Default to trigger the fallback path in GetSELinuxMode().
    
This causes selinuxSetFiles() to skip setfiles relabeling on any image that relies on config without explicit kernel cmdline SELinux args. Files modified by imagecustomizer are left with unlabeled_t contexts. If SELinux is actually enforcing at boot (per the config file), services are denied access to these files, causing dbus-broker, systemd-logind, sshd, and login to fail.
    
The bug was masked on prior Azure Linux versions:
    
- AZL2: No SELinux at all (no config, no kernel args). The incorrect Disabled result happens to be harmless since there's nothing to relabel.
- AZL3: Explicitly sets selinux=0 on the kernel command line, so the function correctly returns Disabled via the explicit check.
- AZL4: First image that omits SELinux kernel args but has SELINUX=enforcing in config. The bug causes setfiles to be skipped, producing broken images.

This also updates 3.0-default-grub test file to include selinux=0, matching the actual file shipped by AZL3 (3.0.20260414)