### PR TITLE
Add Azure Linux 4.0 target OS and filesystem options

### DIFF
--- a/docs/imagecustomizer/README.md
+++ b/docs/imagecustomizer/README.md
@@ -59,6 +59,7 @@ other Linux distributions as well.
 Image Customizer supports the following input image distributions:
 
 - Azure Linux 3.0
+- Azure Linux 4.0
 - Ubuntu 22.04
 - Ubuntu 24.04
 

--- a/toolkit/tools/imagegen/diskutils/filesystem.go
+++ b/toolkit/tools/imagegen/diskutils/filesystem.go
@@ -139,7 +139,9 @@ var (
 		},
 	}
 
-	// GRUB 2.06 doesn't support 'metadata_csum_seed'.
+	// GRUB 2.06 doesn't support 'metadata_csum_seed', we need a new set of ext4 options for the /boot partition.
+	// This is azl4Ext4Options without 'metadata_csum_seed'.
+	// This is needed because AZL4 images are built on AZL3 hosts.
 	azl4BootExt4Options = ext4Options{
 		BlockSize: 4096,
 		Features: []string{

--- a/toolkit/tools/imagegen/diskutils/filesystem.go
+++ b/toolkit/tools/imagegen/diskutils/filesystem.go
@@ -42,6 +42,8 @@ type fileSystemsOptions struct {
 	Btrfs btrfsOptions
 	// The ext4 options to use.
 	Ext4 ext4Options
+	// The ext4 options to use for the partition that contains the /boot directory.
+	BootExt4 ext4Options
 	// The xfs options to use.
 	Xfs xfsOptions
 	// The xfs options to use for the partition that contains the /boot directory.
@@ -64,6 +66,13 @@ var (
 	// The default btrfs options used by an Azure Linux 3.0 image (kernel v6.6).
 	// Same as AZL2 since nothing has changed since v5.15.
 	azl3BtrfsOptions = btrfsOptions{
+		Features: []string{"extref", "skinny-metadata", "no-holes", "free-space-tree"},
+		Checksum: "crc32c",
+	}
+
+	// The default btrfs options used by an Azure Linux 4.0 image (kernel v6.18).
+	// Same as AZL3 since nothing has changed since v5.15.
+	azl4BtrfsOptions = btrfsOptions{
 		Features: []string{"extref", "skinny-metadata", "no-holes", "free-space-tree"},
 		Checksum: "crc32c",
 	}
@@ -119,6 +128,27 @@ var (
 		},
 	}
 
+	// The default ext4 options used by an Azure Linux 4.0 image.
+	// See, the /etc/mke2fs.conf file in an Azure Linux 4.0 image.
+	azl4Ext4Options = ext4Options{
+		BlockSize: 4096,
+		Features: []string{
+			"sparse_super", "large_file", "filetype", "resize_inode", "dir_index", "ext_attr", "has_journal", "extent",
+			"huge_file", "flex_bg", "metadata_csum", "metadata_csum_seed", "64bit", "dir_nlink", "extra_isize",
+			"orphan_file",
+		},
+	}
+
+	// GRUB 2.06 doesn't support 'metadata_csum_seed'.
+	azl4BootExt4Options = ext4Options{
+		BlockSize: 4096,
+		Features: []string{
+			"sparse_super", "large_file", "filetype", "resize_inode", "dir_index", "ext_attr", "has_journal", "extent",
+			"huge_file", "flex_bg", "metadata_csum", "64bit", "dir_nlink", "extra_isize",
+			"orphan_file",
+		},
+	}
+
 	// The default ext4 options used by Fedora 42 (kernel v6.11+)
 	// Based on typical Fedora defaults with modern ext4 features
 	fedora42Ext4Options = ext4Options{
@@ -170,6 +200,17 @@ var (
 		Features: []string{"bigtime", "crc", "finobt", "inobtcount", "reflink", "rmapbt", "sparse"},
 	}
 
+	// The default xfs options used by an Azure Linux 4.0 image (kernel v6.18).
+	// See, the /usr/share/xfsprogs/mkfs/lts_6.12.conf file.
+	azl4XfsOptions = xfsOptions{
+		Features: []string{"bigtime", "crc", "finobt", "inobtcount", "reflink", "rmapbt", "sparse", "nrext64"},
+	}
+
+	// GRUB 2.12 supports 'nrext64'.
+	azl4BootXfsOptions = xfsOptions{
+		Features: []string{"bigtime", "crc", "finobt", "inobtcount", "reflink", "rmapbt", "sparse", "nrext64"},
+	}
+
 	// The default xfs options used by Fedora 42 (kernel v6.11+)
 	// Based on modern XFS features supported in recent kernels
 	fedora42XfsOptions = xfsOptions{
@@ -196,34 +237,46 @@ var (
 
 	targetOsFileSystemsOptions = map[targetos.TargetOs]fileSystemsOptions{
 		targetos.TargetOsAzureLinux2: {
-			Btrfs:   azl2BtrfsOptions,
-			Ext4:    azl2Ext4Options,
-			Xfs:     azl2XfsOptions,
-			BootXfs: azl2XfsOptions,
+			Btrfs:    azl2BtrfsOptions,
+			Ext4:     azl2Ext4Options,
+			BootExt4: azl2Ext4Options,
+			Xfs:      azl2XfsOptions,
+			BootXfs:  azl2XfsOptions,
 		},
 		targetos.TargetOsAzureLinux3: {
-			Btrfs:   azl3BtrfsOptions,
-			Ext4:    azl3Ext4Options,
-			Xfs:     azl3XfsOptions,
-			BootXfs: azl3BootXfsOptions,
+			Btrfs:    azl3BtrfsOptions,
+			Ext4:     azl3Ext4Options,
+			BootExt4: azl3Ext4Options,
+			Xfs:      azl3XfsOptions,
+			BootXfs:  azl3BootXfsOptions,
+		},
+		targetos.TargetOsAzureLinux4: {
+			Btrfs:    azl4BtrfsOptions,
+			Ext4:     azl4Ext4Options,
+			BootExt4: azl4BootExt4Options,
+			Xfs:      azl4XfsOptions,
+			BootXfs:  azl4BootXfsOptions,
 		},
 		targetos.TargetOsFedora42: {
-			Btrfs:   fedora42BtrfsOptions,
-			Ext4:    fedora42Ext4Options,
-			Xfs:     fedora42XfsOptions,
-			BootXfs: fedora42XfsOptions,
+			Btrfs:    fedora42BtrfsOptions,
+			Ext4:     fedora42Ext4Options,
+			BootExt4: fedora42Ext4Options,
+			Xfs:      fedora42XfsOptions,
+			BootXfs:  fedora42XfsOptions,
 		},
 		targetos.TargetOsUbuntu2204: {
-			Btrfs:   ubuntu2204BtrfsOptions,
-			Ext4:    ubuntu2204Ext4Options,
-			Xfs:     ubuntu2204XfsOptions,
-			BootXfs: ubuntu2204XfsOptions,
+			Btrfs:    ubuntu2204BtrfsOptions,
+			Ext4:     ubuntu2204Ext4Options,
+			BootExt4: ubuntu2204Ext4Options,
+			Xfs:      ubuntu2204XfsOptions,
+			BootXfs:  ubuntu2204XfsOptions,
 		},
 		targetos.TargetOsUbuntu2404: {
-			Btrfs:   ubuntu2404BtrfsOptions,
-			Ext4:    ubuntu2404Ext4Options,
-			Xfs:     ubuntu2404XfsOptions,
-			BootXfs: ubuntu2404XfsOptions,
+			Btrfs:    ubuntu2404BtrfsOptions,
+			Ext4:     ubuntu2404Ext4Options,
+			BootExt4: ubuntu2404Ext4Options,
+			Xfs:      ubuntu2404XfsOptions,
+			BootXfs:  ubuntu2404XfsOptions,
 		},
 	}
 
@@ -274,7 +327,8 @@ var (
 	//
 	// Ref: https://e2fsprogs.sourceforge.net/e2fsprogs-release.html
 	ext4FeaturesE2fsprogsSupport = map[string]version.Version{
-		"orphan_file": {1, 47, 0},
+		"orphan_file":        {1, 47, 0},
+		"metadata_csum_seed": {1, 47, 0},
 	}
 
 	// A list of XFS features and their minimum supported xfsprogs / kernel versions.
@@ -372,7 +426,7 @@ func getFileSystemOptions(targetOs targetos.TargetOs, filesystemType string, isB
 		return options, nil
 
 	case "ext4":
-		options, err := getExt4FileSystemOptions(hostKernelVersion, options, partDevPath, fsSizeMiB)
+		options, err := getExt4FileSystemOptions(hostKernelVersion, options, partDevPath, fsSizeMiB, isBootPartition)
 		if err != nil {
 			return nil, err
 		}
@@ -465,17 +519,22 @@ func getBtrfsFileSystemOptions(hostKernelVersion version.Version, options fileSy
 }
 
 func getExt4FileSystemOptions(hostKernelVersion version.Version, options fileSystemsOptions, partDevPath string,
-	fsSizeMiB uint64,
+	fsSizeMiB uint64, isBootPartition bool,
 ) ([]string, error) {
 	mke2fsVersion, err := getMke2fsVersion()
 	if err != nil {
 		return nil, err
 	}
 
+	ext4Options := options.Ext4
+	if isBootPartition {
+		ext4Options = options.BootExt4
+	}
+
 	// "none" requests no default options.
 	features := []string{"none"}
 
-	for _, feature := range options.Ext4.Features {
+	for _, feature := range ext4Options.Features {
 		requiredKernelVersion, hasRequiredKernelVersion := ext4FeaturesKernelSupport[feature]
 		if hasRequiredKernelVersion && requiredKernelVersion.Gt(hostKernelVersion) {
 			// Feature is not supported on build host kernel.
@@ -495,7 +554,7 @@ func getExt4FileSystemOptions(hostKernelVersion version.Version, options fileSys
 
 	featuresArg := strings.Join(features, ",")
 
-	args := []string{"mkfs.ext4", "-b", strconv.Itoa(options.Ext4.BlockSize), "-O", featuresArg, partDevPath}
+	args := []string{"mkfs.ext4", "-b", strconv.Itoa(ext4Options.BlockSize), "-O", featuresArg, partDevPath}
 
 	if fsSizeMiB != 0 {
 		args = append(args, fmt.Sprintf("%dm", fsSizeMiB))

--- a/toolkit/tools/internal/targetos/targetos.go
+++ b/toolkit/tools/internal/targetos/targetos.go
@@ -18,6 +18,7 @@ type TargetOs string
 const (
 	TargetOsAzureLinux2          TargetOs = "azl2"
 	TargetOsAzureLinux3          TargetOs = "azl3"
+	TargetOsAzureLinux4          TargetOs = "azl4"
 	TargetOsAzureContainerLinux3 TargetOs = "acl3"
 	TargetOsFedora42             TargetOs = "fedora42"
 	TargetOsUbuntu2204           TargetOs = "ubuntu2204"
@@ -67,6 +68,9 @@ func GetInstalledTargetOs(rootfs string) (TargetOs, error) {
 			switch versionId {
 			case "3.0":
 				return TargetOsAzureLinux3, nil
+
+			case "4.0":
+				return TargetOsAzureLinux4, nil
 
 			default:
 				return "", fmt.Errorf("unknown VERSION_ID (%s) for Azure Linux in os-release", versionId)

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler.go
@@ -83,6 +83,8 @@ func NewDistroHandlerFromTargetOs(targetOs targetos.TargetOs) DistroHandler {
 		return newAzureLinuxDistroHandler("2.0")
 	case targetos.TargetOsAzureLinux3:
 		return newAzureLinuxDistroHandler("3.0")
+	case targetos.TargetOsAzureLinux4:
+		return newAzureLinuxDistroHandler("4.0")
 	case targetos.TargetOsAzureContainerLinux3:
 		return newAclDistroHandler()
 	case targetos.TargetOsUbuntu2204:

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux.go
@@ -24,9 +24,16 @@ type azureLinuxDistroHandler struct {
 }
 
 func newAzureLinuxDistroHandler(version string) *azureLinuxDistroHandler {
+	var packageManager rpmPackageManagerHandler
+	if version == "4.0" {
+		packageManager = newDnfPackageManager(version)
+	} else {
+		packageManager = newTdnfPackageManager(version)
+	}
+
 	return &azureLinuxDistroHandler{
 		version:        version,
-		packageManager: newTdnfPackageManager(version),
+		packageManager: packageManager,
 	}
 }
 
@@ -36,6 +43,8 @@ func (d *azureLinuxDistroHandler) GetTargetOs() targetos.TargetOs {
 		return targetos.TargetOsAzureLinux2
 	case "3.0":
 		return targetos.TargetOsAzureLinux3
+	case "4.0":
+		return targetos.TargetOsAzureLinux4
 	default:
 		panic("unsupported Azure Linux version: " + d.version)
 	}
@@ -65,13 +74,25 @@ func (d *azureLinuxDistroHandler) GetAllPackagesFromChroot(imageChroot safechroo
 }
 
 func (d *azureLinuxDistroHandler) DetectBootloaderType(imageChroot safechroot.ChrootInterface) (BootloaderType, error) {
-	if d.IsPackageInstalled(imageChroot, "grub2-efi-binary") || d.IsPackageInstalled(imageChroot, "grub2-efi-binary-noprefix") {
-		return BootloaderTypeGrub, nil
+	grubPackages := []string{"grub2-efi-binary", "grub2-efi-binary-noprefix"}
+	if d.version == "4.0" {
+		grubPackages = []string{"grub2-efi-x64", "grub2-efi-aa64"}
 	}
-	if d.IsPackageInstalled(imageChroot, "systemd-boot") {
-		return BootloaderTypeSystemdBoot, nil
+	for _, pkg := range grubPackages {
+		if d.IsPackageInstalled(imageChroot, pkg) {
+			return BootloaderTypeGrub, nil
+		}
 	}
-	return "", fmt.Errorf("unknown bootloader: neither grub2-efi-binary, grub2-efi-binary-noprefix, nor systemd-boot found")
+	systemdBootPackages := []string{"systemd-boot"}
+	if d.version == "4.0" {
+		systemdBootPackages = []string{"systemd-boot", "systemd-boot-unsigned"}
+	}
+	for _, pkg := range systemdBootPackages {
+		if d.IsPackageInstalled(imageChroot, pkg) {
+			return BootloaderTypeSystemdBoot, nil
+		}
+	}
+	return "", fmt.Errorf("unknown bootloader: none of %v or %v found", grubPackages, systemdBootPackages)
 }
 
 func (d *azureLinuxDistroHandler) GetEspDir() string {


### PR DESCRIPTION
This PR adds the minimal foundation needed to recognize AzL4 as a target distro and configure its filesystems correctly.

Locally verified. Build (dev) run against PR branch to ensure no regressions.