### PR TITLE
Fix Disk.IsValid() not populating End for last partition with explicit size

### DIFF
--- a/toolkit/tools/imagecustomizerapi/disk.go
+++ b/toolkit/tools/imagecustomizerapi/disk.go
@@ -154,9 +154,10 @@ func (d *Disk) IsValid() error {
 				// Explicitly set the size of the last partition.
 				// This allows us to control the alignment of the GPT footer instead of relying on the behavior of the
 				// partitioning tool (e.g. sfdisk).
-				lastPartitionEnd := *d.MaxSize - gptFooterSize
-				partFillSizeAndEnd(lastPartition, lastPartitionEnd)
+				lastPartitionEnd = *d.MaxSize - gptFooterSize
 			}
+
+			partFillSizeAndEnd(lastPartition, lastPartitionEnd)
 		}
 	}
 


### PR DESCRIPTION
Disk.IsValid() skips partFillSizeAndEnd() for the last partition when maxSize is set and the partition has explicit size but no end. This leaves partition.End nil, causing a nil pointer dereference panic in partitionToImager() at typeConversion.go:105. Fix: call partFillSizeAndEnd() unconditionally for the last partition in the default case, matching the behavior already used for non-last partitions.

<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

---

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [ ] Code conforms to style guidelines
