### PR TITLE
azl4: Use Distro-Aware isPackageInstalled in LiveOS code and TestBaseConfigsFullRun

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/baseconfigs_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/baseconfigs_test.go
@@ -163,10 +163,15 @@ func TestBaseConfigsFullRun(t *testing.T) {
 	verifyFileContentsSame(t, plantsFileOrigPath, plantsFileNewPath)
 
 	// Verify packages
-	curlInstalled := isPackageInstalled(imageConnection.Chroot(), "curl")
+	distroHandler, err := NewDistroHandlerFromChroot(imageConnection.Chroot())
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	curlInstalled := distroHandler.IsPackageInstalled(imageConnection.Chroot(), "curl")
 	assert.True(t, curlInstalled)
 
-	nginxInstalled := isPackageInstalled(imageConnection.Chroot(), "nginx")
+	nginxInstalled := distroHandler.IsPackageInstalled(imageConnection.Chroot(), "nginx")
 	assert.True(t, nginxInstalled)
 
 	nginxVersionOutput, err := getPkgVersionFromChroot(imageConnection, "nginx")
@@ -176,7 +181,7 @@ func TestBaseConfigsFullRun(t *testing.T) {
 	assert.Containsf(t, nginxVersionOutput, nginxExpectedVersion,
 		"should install nginx version %s, but got: %s", nginxExpectedVersion, nginxVersionOutput)
 
-	sshdInstalled := isPackageInstalled(imageConnection.Chroot(), "openssh-server")
+	sshdInstalled := distroHandler.IsPackageInstalled(imageConnection.Chroot(), "openssh-server")
 	assert.True(t, sshdInstalled)
 
 	systemdBootVersionOutput, err := getPkgVersionFromChroot(imageConnection, "systemd-boot")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages.go
@@ -10,8 +10,6 @@ import (
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/file"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safechroot"
-	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/shell"
-	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
@@ -115,17 +113,6 @@ func startRefreshPackageMetadataSpan(ctx context.Context) (context.Context, trac
 // The caller must call span.End() (typically via defer) when the operation completes.
 func startCleanPackagesCacheSpan(ctx context.Context) (context.Context, trace.Span) {
 	return otel.GetTracerProvider().Tracer(OtelTracerName).Start(ctx, "clean_package_cache")
-}
-
-func isPackageInstalled(imageChroot safechroot.ChrootInterface, packageName string) bool {
-	err := shell.NewExecBuilder("tdnf", "info", packageName, "--repo", "@system").
-		LogLevel(logrus.TraceLevel, logrus.DebugLevel).
-		Chroot(imageChroot.ChrootDir()).
-		Execute()
-	if err != nil {
-		return false
-	}
-	return true
 }
 
 func needPackageSources(config *imagecustomizerapi.OS) bool {

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -615,7 +615,7 @@ func convertWriteableFormatToOutputImage(ctx context.Context, rc *ResolvedConfig
 		if rebuildFullOsImage {
 			requestedSELinuxMode := rc.SELinux.Mode
 			err := createLiveOSFromRaw(ctx, rc.BuildDirAbs, inputIsoArtifacts, requestedSELinuxMode, rc.Iso, rc.Pxe,
-				rc.RawImageFile, rc.OutputImageFormat, rc.OutputImageFile)
+				rc.RawImageFile, rc.OutputImageFormat, rc.OutputImageFile, im.distroHandler)
 			if err != nil {
 				return fmt.Errorf("%w:\n%w", ErrCreateLiveOSArtifacts, err)
 			}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -615,7 +615,7 @@ func convertWriteableFormatToOutputImage(ctx context.Context, rc *ResolvedConfig
 		if rebuildFullOsImage {
 			requestedSELinuxMode := rc.SELinux.Mode
 			err := createLiveOSFromRaw(ctx, rc.BuildDirAbs, inputIsoArtifacts, requestedSELinuxMode, rc.Iso, rc.Pxe,
-				rc.RawImageFile, rc.OutputImageFormat, rc.OutputImageFile, im.distroHandler)
+				rc.RawImageFile, rc.OutputImageFormat, rc.OutputImageFile)
 			if err != nil {
 				return fmt.Errorf("%w:\n%w", ErrCreateLiveOSArtifacts, err)
 			}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoartifactstore.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoartifactstore.go
@@ -403,7 +403,7 @@ func createIsoInfoStoreFromMountedImage(buildDir string, imageRootDir string, di
 	// Note the MIC allows the user to install other selinux policy packages.
 	// So, the absence of selinux-policy does not mean that there are no selinux
 	// policy packages.
-	if isPackageInstalled(chroot, "selinux-policy") {
+	if distroHandler.IsPackageInstalled(chroot, "selinux-policy") {
 		infoStore.selinuxPolicyPackageInfo, err = getPackageInformation(chroot, "selinux-policy")
 		if err != nil {
 			return nil, fmt.Errorf("failed to determine package information for selinux-policy under (%s):\n%w", imageRootDir, err)

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -129,7 +129,7 @@ func populateWriteableRootfsDir(sourceDir, writeableRootfsDir string) error {
 func createLiveOSFromRaw(ctx context.Context, buildDir string, inputArtifactsStore *IsoArtifactsStore,
 	requestedSelinuxMode imagecustomizerapi.SELinuxMode, resolvedIso imagecustomizerapi.Iso,
 	resolvedPxe imagecustomizerapi.Pxe, rawImageFile string, outputFormat imagecustomizerapi.ImageFormatType,
-	outputPath string,
+	outputPath string, distroHandler DistroHandler,
 ) (err error) {
 	logger.Log.Infof("Creating Live OS artifacts using customized full OS image")
 
@@ -138,7 +138,7 @@ func createLiveOSFromRaw(ctx context.Context, buildDir string, inputArtifactsSto
 		return fmt.Errorf("failed to build live OS configuration from input configuration:\n%w", err)
 	}
 
-	err = createLiveOSFromRawHelper(ctx, buildDir, inputArtifactsStore, requestedSelinuxMode, liveosConfig, rawImageFile, outputFormat, outputPath)
+	err = createLiveOSFromRawHelper(ctx, buildDir, inputArtifactsStore, requestedSelinuxMode, liveosConfig, rawImageFile, outputFormat, outputPath, distroHandler)
 	if err != nil {
 		return fmt.Errorf("failed to create live OS artifacts:\n%w", err)
 	}
@@ -181,7 +181,7 @@ func isIsoBootImageNeeded(outputFormat imagecustomizerapi.ImageFormatType, initr
 
 func createLiveOSFromRawHelper(ctx context.Context, buildDir string, inputArtifactsStore *IsoArtifactsStore, requestedSelinuxMode imagecustomizerapi.SELinuxMode,
 	liveosConfig LiveOSConfig, rawImageFile string, outputFormat imagecustomizerapi.ImageFormatType,
-	outputPath string,
+	outputPath string, distroHandler DistroHandler,
 ) (err error) {
 	isoBuildDir := filepath.Join(buildDir, "liveosbuild")
 	defer func() {
@@ -204,7 +204,7 @@ func createLiveOSFromRawHelper(ctx context.Context, buildDir string, inputArtifa
 	defer rawImageConnection.Close()
 
 	// Detect the distro handler for the image.
-	distroHandler, err := NewDistroHandlerFromChroot(rawImageConnection.Chroot())
+	distroHandler, err = NewDistroHandlerFromChroot(rawImageConnection.Chroot())
 	if err != nil {
 		return fmt.Errorf("failed to detect distribution:\n%w", err)
 	}
@@ -314,7 +314,8 @@ func createLiveOSFromRawHelper(ctx context.Context, buildDir string, inputArtifa
 	case imagecustomizerapi.InitramfsImageTypeBootstrap:
 		// Generate the initrd image(s)
 		for kernelVersion, kernelBootFiles := range artifactsStore.files.kernelBootFiles {
-			err = createBootstrapInitrdImage(writeableRootfsDir, kernelVersion, kernelBootFiles.initrdImagePath)
+			err = createBootstrapInitrdImage(writeableRootfsDir, kernelVersion, kernelBootFiles.initrdImagePath,
+				distroHandler)
 			if err != nil {
 				return fmt.Errorf("failed to create initrd image:\n%w", err)
 			}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -129,7 +129,7 @@ func populateWriteableRootfsDir(sourceDir, writeableRootfsDir string) error {
 func createLiveOSFromRaw(ctx context.Context, buildDir string, inputArtifactsStore *IsoArtifactsStore,
 	requestedSelinuxMode imagecustomizerapi.SELinuxMode, resolvedIso imagecustomizerapi.Iso,
 	resolvedPxe imagecustomizerapi.Pxe, rawImageFile string, outputFormat imagecustomizerapi.ImageFormatType,
-	outputPath string, distroHandler DistroHandler,
+	outputPath string,
 ) (err error) {
 	logger.Log.Infof("Creating Live OS artifacts using customized full OS image")
 
@@ -138,7 +138,7 @@ func createLiveOSFromRaw(ctx context.Context, buildDir string, inputArtifactsSto
 		return fmt.Errorf("failed to build live OS configuration from input configuration:\n%w", err)
 	}
 
-	err = createLiveOSFromRawHelper(ctx, buildDir, inputArtifactsStore, requestedSelinuxMode, liveosConfig, rawImageFile, outputFormat, outputPath, distroHandler)
+	err = createLiveOSFromRawHelper(ctx, buildDir, inputArtifactsStore, requestedSelinuxMode, liveosConfig, rawImageFile, outputFormat, outputPath)
 	if err != nil {
 		return fmt.Errorf("failed to create live OS artifacts:\n%w", err)
 	}
@@ -181,7 +181,7 @@ func isIsoBootImageNeeded(outputFormat imagecustomizerapi.ImageFormatType, initr
 
 func createLiveOSFromRawHelper(ctx context.Context, buildDir string, inputArtifactsStore *IsoArtifactsStore, requestedSelinuxMode imagecustomizerapi.SELinuxMode,
 	liveosConfig LiveOSConfig, rawImageFile string, outputFormat imagecustomizerapi.ImageFormatType,
-	outputPath string, distroHandler DistroHandler,
+	outputPath string,
 ) (err error) {
 	isoBuildDir := filepath.Join(buildDir, "liveosbuild")
 	defer func() {
@@ -204,7 +204,7 @@ func createLiveOSFromRawHelper(ctx context.Context, buildDir string, inputArtifa
 	defer rawImageConnection.Close()
 
 	// Detect the distro handler for the image.
-	distroHandler, err = NewDistroHandlerFromChroot(rawImageConnection.Chroot())
+	distroHandler, err := NewDistroHandlerFromChroot(rawImageConnection.Chroot())
 	if err != nil {
 		return fmt.Errorf("failed to detect distribution:\n%w", err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoimages.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoimages.go
@@ -142,7 +142,9 @@ func createFullOSInitrdImage(writeableRootfsDir string, kernelKdumpFiles *imagec
 	return nil
 }
 
-func createBootstrapInitrdImage(writeableRootfsDir, kernelVersion, outputInitrdPath string) error {
+func createBootstrapInitrdImage(writeableRootfsDir, kernelVersion, outputInitrdPath string,
+	distroHandler DistroHandler,
+) error {
 	logger.Log.Infof("Creating bootstrap initrd for %s", kernelVersion)
 
 	dracutConfigFile := filepath.Join(writeableRootfsDir, "/etc/dracut.conf.d/20-live-cd.conf")
@@ -166,7 +168,7 @@ func createBootstrapInitrdImage(writeableRootfsDir, kernelVersion, outputInitrdP
 	requiredRpms := []string{"squashfs-tools", "tar", "device-mapper", "curl"}
 	for _, requiredRpm := range requiredRpms {
 		logger.Log.Debugf("Checking if (%s) is installed", requiredRpm)
-		if !isPackageInstalled(chroot, requiredRpm) {
+		if !distroHandler.IsPackageInstalled(chroot, requiredRpm) {
 			return fmt.Errorf("package (%s) is not installed:\nthe following packages must be installed to generate an iso: %v", requiredRpm, requiredRpms)
 		}
 	}


### PR DESCRIPTION
Removes isPackageInstalled() which uses tdnf so we can execute these code paths for distros that don't use it.

This function is safe to remove. It's a duplicate of `func (pm *tdnfPackageManager) isPackageInstalled`