### PR TITLE
azl4: Create Distro-Aware FindBootPartitionUuidFromEsp for output.artifacts API support

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput.go
@@ -57,7 +57,7 @@ var ukiRegex = regexp.MustCompile(`^vmlinuz-.*\.efi$`)
 
 func outputArtifacts(ctx context.Context, items []imagecustomizerapi.OutputArtifactsItemType,
 	outputDir string, buildDir string, buildImage string, verityMetadata []verityDeviceMetadata,
-	previewFeatures []imagecustomizerapi.PreviewFeature,
+	previewFeatures []imagecustomizerapi.PreviewFeature, distroHandler DistroHandler,
 ) error {
 	logger.Log.Infof("Outputting artifacts")
 
@@ -82,7 +82,7 @@ func outputArtifacts(ctx context.Context, items []imagecustomizerapi.OutputArtif
 		return err
 	}
 
-	bootPartition, err := findBootPartitionFromEsp(systemBootPartition, diskPartitions, buildDir)
+	bootPartition, err := findBootPartitionFromEsp(systemBootPartition, diskPartitions, buildDir, distroHandler)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler.go
@@ -55,6 +55,10 @@ type DistroHandler interface {
 	// For example: "boot/efi" for most distros, "boot" for ACL.
 	GetEspDir() string
 
+	// FindBootPartitionUuidFromEsp reads the distro's grub.cfg stub from the already-mounted ESP at espMountDir and
+	// returns the UUID of the partition that contains the grub.cfg.
+	FindBootPartitionUuidFromEsp(espMountDir string) (string, error)
+
 	// Reports whether SELinux configuration is supported by the tool for this distro.
 	SELinuxSupported() bool
 

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"io/fs"
+	"path/filepath"
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/imageconnection"
@@ -76,6 +77,10 @@ func (d *aclDistroHandler) DetectBootloaderType(imageChroot safechroot.ChrootInt
 
 func (d *aclDistroHandler) GetEspDir() string {
 	return "boot"
+}
+
+func (d *aclDistroHandler) FindBootPartitionUuidFromEsp(espMountDir string) (string, error) {
+	return readBootPartitionUuidFromGrubCfg(filepath.Join(espMountDir, espGrubCfgPathAzl3), bootPartitionRegexAzl3)
 }
 
 func (d *aclDistroHandler) SELinuxSupported() bool {

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux.go
@@ -6,6 +6,7 @@ package imagecustomizerlib
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/installutils"
@@ -97,6 +98,17 @@ func (d *azureLinuxDistroHandler) DetectBootloaderType(imageChroot safechroot.Ch
 
 func (d *azureLinuxDistroHandler) GetEspDir() string {
 	return "boot/efi"
+}
+
+func (d *azureLinuxDistroHandler) FindBootPartitionUuidFromEsp(espMountDir string) (string, error) {
+	espGrubCfgPath := espGrubCfgPathAzl3
+	bootPartitionRegex := bootPartitionRegexAzl3
+	if d.version == "4.0" {
+		espGrubCfgPath = espGrubCfgPathAzl4
+		bootPartitionRegex = bootPartitionRegexAzl4
+	}
+
+	return readBootPartitionUuidFromGrubCfg(filepath.Join(espMountDir, espGrubCfgPath), bootPartitionRegex)
 }
 
 func (d *azureLinuxDistroHandler) SELinuxSupported() bool {

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
@@ -93,6 +93,7 @@ func (d *fedoraDistroHandler) GetEspDir() string {
 }
 
 func (d *fedoraDistroHandler) FindBootPartitionUuidFromEsp(espMountDir string) (string, error) {
+	// Reading Fedora's grub.cfg stub is not supported, so for now just use Azure Linux 3.0's values.
 	return readBootPartitionUuidFromGrubCfg(filepath.Join(espMountDir, espGrubCfgPathAzl3), bootPartitionRegexAzl3)
 }
 

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
@@ -6,6 +6,7 @@ package imagecustomizerlib
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"slices"
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
@@ -89,6 +90,10 @@ func (d *fedoraDistroHandler) DetectBootloaderType(imageChroot safechroot.Chroot
 
 func (d *fedoraDistroHandler) GetEspDir() string {
 	return "boot/efi"
+}
+
+func (d *fedoraDistroHandler) FindBootPartitionUuidFromEsp(espMountDir string) (string, error) {
+	return readBootPartitionUuidFromGrubCfg(filepath.Join(espMountDir, espGrubCfgPathAzl3), bootPartitionRegexAzl3)
 }
 
 func (d *fedoraDistroHandler) SELinuxSupported() bool {

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_ubuntu.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_ubuntu.go
@@ -6,6 +6,7 @@ package imagecustomizerlib
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"slices"
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
@@ -110,6 +111,10 @@ func (d *ubuntuDistroHandler) DetectBootloaderType(imageChroot safechroot.Chroot
 
 func (d *ubuntuDistroHandler) GetEspDir() string {
 	return "boot/efi"
+}
+
+func (d *ubuntuDistroHandler) FindBootPartitionUuidFromEsp(espMountDir string) (string, error) {
+	return readBootPartitionUuidFromGrubCfg(filepath.Join(espMountDir, espGrubCfgPathAzl3), bootPartitionRegexAzl3)
 }
 
 func (d *ubuntuDistroHandler) SELinuxSupported() bool {

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_ubuntu.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_ubuntu.go
@@ -114,6 +114,7 @@ func (d *ubuntuDistroHandler) GetEspDir() string {
 }
 
 func (d *ubuntuDistroHandler) FindBootPartitionUuidFromEsp(espMountDir string) (string, error) {
+	// Reading Ubuntu's grub.cfg stub is not supported, so for now just use Azure Linux 3.0's values.
 	return readBootPartitionUuidFromGrubCfg(filepath.Join(espMountDir, espGrubCfgPathAzl3), bootPartitionRegexAzl3)
 }
 

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -271,7 +271,7 @@ func customizeImageOptionsHelper(ctx context.Context, baseConfigPath string, con
 		outputDir := file.GetAbsPathWithBase(baseConfigPath, rc.OutputArtifacts.Path)
 
 		err = outputArtifacts(ctx, rc.OutputArtifacts.Items, outputDir, rc.BuildDirAbs,
-			rc.RawImageFile, im.verityMetadata, rc.PreviewFeatures)
+			rc.RawImageFile, im.verityMetadata, rc.PreviewFeatures, im.distroHandler)
 		if err != nil {
 			return fmt.Errorf("%w:\n%w", ErrCustomizeOutputArtifacts, err)
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/diskutils"
-	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/installutils"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/file"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/grub"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/imageconnection"
@@ -32,10 +31,16 @@ import (
 )
 
 var (
-	bootPartitionRegex = regexp.MustCompile(`(?m)^search -n -u ([a-zA-Z0-9\-]+) -s$`)
+	bootPartitionRegexAzl3 = regexp.MustCompile(`(?m)^[\t ]*search\s+-n\s+-u\s+([a-zA-Z0-9\-]+)\s+-s\s*$`)
+	bootPartitionRegexAzl4 = regexp.MustCompile(`(?m)^[\t ]*search\s+--fs-uuid\s+--set=root\s+([a-zA-Z0-9\-]+)\s*$`)
 
 	// Extract the partition number from the loopback partition path.
 	partitionNumberRegex = regexp.MustCompile(`^/dev/loop\d+p(\d+)$`)
+)
+
+const (
+	espGrubCfgPathAzl3 = "boot/grub2/grub.cfg"
+	espGrubCfgPathAzl4 = "EFI/fedora/grub.cfg"
 )
 
 const (
@@ -76,7 +81,9 @@ func findSystemBootPartition(diskPartitions []diskutils.PartitionInfo) (*diskuti
 	return bootPartition, nil
 }
 
-func findBootPartitionFromEsp(efiSystemPartition *diskutils.PartitionInfo, diskPartitions []diskutils.PartitionInfo, buildDir string) (*diskutils.PartitionInfo, error) {
+func findBootPartitionFromEsp(efiSystemPartition *diskutils.PartitionInfo, diskPartitions []diskutils.PartitionInfo,
+	buildDir string, distroHandler DistroHandler,
+) (*diskutils.PartitionInfo, error) {
 	tmpDir := filepath.Join(buildDir, tmpEspPartitionDirName)
 
 	// Mount the EFI System Partition.
@@ -86,9 +93,7 @@ func findBootPartitionFromEsp(efiSystemPartition *diskutils.PartitionInfo, diskP
 	}
 	defer efiSystemPartitionMount.Close()
 
-	// Read the grub.cfg file.
-	grubConfigFilePath := filepath.Join(tmpDir, installutils.FedoraGrubCfgFile)
-	grubConfigFile, err := os.ReadFile(grubConfigFilePath)
+	bootPartitionUuid, err := distroHandler.FindBootPartitionUuidFromEsp(tmpDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read EFI system partition's grub.cfg file:\n%w", err)
 	}
@@ -98,14 +103,6 @@ func findBootPartitionFromEsp(efiSystemPartition *diskutils.PartitionInfo, diskP
 	if err != nil {
 		return nil, fmt.Errorf("failed to close EFI system partition mount:\n%w", err)
 	}
-
-	// Look for the bootloader partition declaration line in the grub.cfg file.
-	match := bootPartitionRegex.FindStringSubmatch(string(grubConfigFile))
-	if match == nil {
-		return nil, fmt.Errorf("failed to find boot partition in grub.cfg file")
-	}
-
-	bootPartitionUuid := match[1]
 
 	var bootPartition *diskutils.PartitionInfo
 	for i := range diskPartitions {
@@ -122,6 +119,23 @@ func findBootPartitionFromEsp(efiSystemPartition *diskutils.PartitionInfo, diskP
 	}
 
 	return bootPartition, nil
+}
+
+// readBootPartitionUuidFromGrubCfg reads the grub.cfg file at grubConfigFilePath and
+// returns the UUID captured by bootPartitionRegex's first capture group.
+func readBootPartitionUuidFromGrubCfg(grubConfigFilePath string, bootPartitionRegex *regexp.Regexp,
+) (string, error) {
+	grubConfigFile, err := os.ReadFile(grubConfigFilePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read EFI system partition's grub.cfg file (%s):\n%w", grubConfigFilePath, err)
+	}
+
+	match := bootPartitionRegex.FindStringSubmatch(string(grubConfigFile))
+	if match == nil {
+		return "", fmt.Errorf("failed to find boot partition in grub.cfg file (%s)", grubConfigFilePath)
+	}
+
+	return match[1], nil
 }
 
 // Searches for the partition that contains the /etc/fstab file.


### PR DESCRIPTION
The grub.cfg stubs on the EFI partitions are in a different location and require a different regular expression to grep for the boot partition UUID on AZL4, so this PR introduces DistroHandler.FindBootPartitionUuidFromEsp to handle that.

Example azl4 grub.cfg stub (from Alpha 2 release):

```
search --fs-uuid --set=root 3190eea2-a4b1-4399-9679-e0840cf8eb75
set prefix=($root)/boot/grub2
configfile ($root)/boot/grub2/grub.cfg
```