### PR TITLE
azl4: Disable iso/pxe-dir/pxe-tar output as not supported

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux.go
@@ -51,6 +51,13 @@ func (d *azureLinuxDistroHandler) GetTargetOs() targetos.TargetOs {
 }
 
 func (d *azureLinuxDistroHandler) ValidateConfig(rc *ResolvedConfig) error {
+	if d.version == "4.0" {
+		switch rc.OutputImageFormat {
+		case imagecustomizerapi.ImageFormatTypeIso, imagecustomizerapi.ImageFormatTypePxeDir, imagecustomizerapi.ImageFormatTypePxeTar:
+			return fmt.Errorf("ISO and PXE output formats are not supported for Azure Linux 4.0")
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
ISO, PXE-DIR, and PXE-TAR output will not be supported initially for Azure Linux 4.0, so add a guard in the distrohandler for it.