### PR TITLE
azl3: Enable TestCustomizeImageOverlaysSELinux

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeoverlays_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeoverlays_test.go
@@ -91,10 +91,6 @@ func TestCustomizeImageOverlaysSELinux(t *testing.T) {
 }
 
 func testCustomizeImageOverlaysSELinuxHelper(t *testing.T, testName string, baseImageInfo testBaseImageInfo) {
-	if baseImageInfo.Version == baseImageVersionAzl3 {
-		t.Skip("Azure Linux 3.0 is missing policy.kern file")
-	}
-
 	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	testTempDir := filepath.Join(tmpDir, testName)


### PR DESCRIPTION
This distribution is no longer missing the policy.kern file.