### PR TITLE
fix: Ensure skip_if_unavailable=False for dnf/tdnf

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_rpm.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_rpm.go
@@ -275,7 +275,15 @@ func refreshRpmPackageMetadata(ctx context.Context, imageChroot *safechroot.Chro
 	_, span := startRefreshPackageMetadataSpan(ctx)
 	defer span.End()
 
-	args := []string{pmHandler.getVerbosityOption(), "check-update", "--refresh", "--assumeyes"}
+	// --setopt=skip_if_unavailable=False ensures failures to fetch repo metadata are fatal. TDNF already does this by
+	// default, but DNF on some distros (e.g. Azure Linux 4.0) defaults to skip_if_unavailable=True, so we set it
+	// explicitly for both. It's important to ensure repo metadata is refreshed successfully to ensure correct package
+	// versions are installed as intended by the user's repo configuration. It also has the benefit of failing slightly
+	// faster when repos are misconfigured.
+	args := []string{
+		pmHandler.getVerbosityOption(), "check-update", "--refresh", "--assumeyes",
+		"--setopt=skip_if_unavailable=False",
+	}
 
 	args = append(args, "--setopt=reposdir="+rpmsMountParentDirInChroot)
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_rpm.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_rpm.go
@@ -277,9 +277,9 @@ func refreshRpmPackageMetadata(ctx context.Context, imageChroot *safechroot.Chro
 
 	// --setopt=skip_if_unavailable=False ensures failures to fetch repo metadata are fatal. TDNF already does this by
 	// default, but DNF on some distros (e.g. Azure Linux 4.0) defaults to skip_if_unavailable=True, so we set it
-	// explicitly for both. It's important to ensure repo metadata is refreshed successfully to ensure correct package
-	// versions are installed as intended by the user's repo configuration. It also has the benefit of failing slightly
-	// faster when repos are misconfigured.
+	// explicitly for both. It is important to ensure metadata is refreshed successfully to ensure correctness of
+	// package install operations and to catch any typos in user-provided repository configuration. Otherwise, the wrong
+	// package versions might be silently installed.
 	args := []string{
 		pmHandler.getVerbosityOption(), "check-update", "--refresh", "--assumeyes",
 		"--setopt=skip_if_unavailable=False",


### PR DESCRIPTION
Azure Linux 4.0 defaults to skip_if_unavailable=True, a change in behavior from Azure Linux 3.0 and likely an inheritance from Fedora upstream. It is important to ensure metadata is refreshed successfully to ensure correctness of package install operations and to catch any typos in user-provided repository configuration. Otherwise, the wrong package versions might be silently installed.