### PR TITLE
tests: Remove "systemd-boot not available on AZL3 ARM64 yet" skips

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput_test.go
@@ -37,10 +37,6 @@ func TestOutputAndInjectArtifacts(t *testing.T) {
 		t.Skip("The 'ukify' command is not available")
 	}
 
-	if runtime.GOARCH == "arm64" {
-		t.Skip("systemd-boot not available on AZL3 ARM64 yet")
-	}
-
 	testTempDir := filepath.Join(tmpDir, "TestOutputAndInjectArtifacts")
 	defer os.RemoveAll(testTempDir)
 
@@ -149,10 +145,6 @@ func TestOutputAndInjectArtifactsCosi(t *testing.T) {
 	assert.NoError(t, err)
 	if !ukifyExists {
 		t.Skip("The 'ukify' command is not available")
-	}
-
-	if runtime.GOARCH == "arm64" {
-		t.Skip("systemd-boot not available on AZL3 ARM64 yet")
 	}
 
 	testTempDir := filepath.Join(tmpDir, "TestOutputAndInjectArtifacts")

--- a/toolkit/tools/pkg/imagecustomizerlib/baseconfigs_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/baseconfigs_test.go
@@ -79,10 +79,6 @@ func TestBaseConfigsFullRun(t *testing.T) {
 		t.Skip("The 'ukify' command is not available")
 	}
 
-	if runtime.GOARCH == "arm64" {
-		t.Skip("systemd-boot not available on AZL3 ARM64 yet")
-	}
-
 	testTmpDir := filepath.Join(tmpDir, "TestBaseConfigsFullRun")
 	defer os.RemoveAll(testTmpDir)
 

--- a/toolkit/tools/pkg/imagecustomizerlib/convertimage_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/convertimage_test.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"testing"
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
@@ -107,10 +106,6 @@ func testConvertImageRawToCosi(t *testing.T, baseImageInfo testBaseImageInfo) {
 		t.Skip("The 'ukify' command is not available")
 	}
 
-	if runtime.GOARCH == "arm64" {
-		t.Skip("systemd-boot not available on AZL3 ARM64 yet")
-	}
-
 	testTempDir := filepath.Join(tmpDir, fmt.Sprintf("TestConvertImageRawToCosi_%s", baseImageInfo.Name))
 	defer os.RemoveAll(testTempDir)
 
@@ -186,10 +181,6 @@ func testConvertImageRawToCosiWithCompression(t *testing.T, baseImageInfo testBa
 	assert.NoError(t, err)
 	if !ukifyExists {
 		t.Skip("The 'ukify' command is not available")
-	}
-
-	if runtime.GOARCH == "arm64" {
-		t.Skip("systemd-boot not available on AZL3 ARM64 yet")
 	}
 
 	testTempDir := filepath.Join(tmpDir,

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
@@ -38,10 +38,6 @@ func testCustomizeImageVerityUsrUkiHelper(t *testing.T, baseImageInfo testBaseIm
 		t.Skip("The 'ukify' command is not available")
 	}
 
-	if runtime.GOARCH == "arm64" {
-		t.Skip("systemd-boot not available on AZL3 ARM64 yet")
-	}
-
 	testTempDir := filepath.Join(tmpDir, fmt.Sprintf("TestCustomizeImageUsrVerityUki_%s", baseImageInfo.Name))
 	defer os.RemoveAll(testTempDir)
 
@@ -93,10 +89,6 @@ func testCustomizeImageVerityUsrUkiRecustomizeHelper(t *testing.T, baseImageInfo
 	assert.NoError(t, err)
 	if !ukifyExists {
 		t.Skip("The 'ukify' command is not available")
-	}
-
-	if runtime.GOARCH == "arm64" {
-		t.Skip("systemd-boot not available on AZL3 ARM64 yet")
 	}
 
 	testTempDir := filepath.Join(tmpDir, fmt.Sprintf("TestCustomizeImageUsrVerityUkiRecustomize_%s", baseImageInfo.Name))
@@ -214,10 +206,6 @@ func testCustomizeImageVerityUsrUkiPassthroughHelper(t *testing.T, baseImageInfo
 		t.Skip("The 'ukify' command is not available")
 	}
 
-	if runtime.GOARCH == "arm64" {
-		t.Skip("systemd-boot not available on AZL3 ARM64 yet")
-	}
-
 	testTempDir := filepath.Join(tmpDir, fmt.Sprintf("TestCustomizeImageUsrVerityUkiPassthrough_%s", baseImageInfo.Name))
 	defer os.RemoveAll(testTempDir)
 
@@ -279,10 +267,6 @@ func testCustomizeImageVerityRootUkiHelper(t *testing.T, baseImageInfo testBaseI
 	assert.NoError(t, err)
 	if !ukifyExists {
 		t.Skip("The 'ukify' command is not available")
-	}
-
-	if runtime.GOARCH == "arm64" {
-		t.Skip("systemd-boot not available on AZL3 ARM64 yet")
 	}
 
 	testTempDir := filepath.Join(tmpDir, fmt.Sprintf("TestCustomizeImageRootVerityUki_%s", baseImageInfo.Name))


### PR DESCRIPTION
Validated with a full Build (dev) run.