### PR TITLE
fix: osmodifier: error when 'root=' is missing from non-recovery boot entry

### DIFF
--- a/toolkit/tools/pkg/osmodifierlib/modifydefaultgrub.go
+++ b/toolkit/tools/pkg/osmodifierlib/modifydefaultgrub.go
@@ -77,6 +77,9 @@ func extractValuesFromGrubConfig(imageChroot safechroot.ChrootInterface, distroH
 	}
 
 	rootDevice := argMap["root"]
+	if rootDevice == "" {
+		return nil, "", fmt.Errorf("failed to find 'root=' kernel argument in non-recovery boot entry")
+	}
 
 	// Iterate grubArgs (not argMap) to preserve a deterministic order.
 	var values []string


### PR DESCRIPTION
In modifydefaultgrub.go, extractValuesFromGrubConfig previously returned an empty rootDevice when the non-recovery boot entry's kernel command line did not contain a 'root=' argument. SetRootDevice would then silently set GRUB_DEVICE with an empty value into /etc/default/grub, producing an unbootable default grub config.

Return an explicit error so the failure surfaces immediately to the caller instead of being papered over.
