### PR TITLE
fix: reject duplicate title key in BLS entry parser

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/blsutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/blsutils.go
@@ -85,6 +85,7 @@ func readKernelCmdlinesFromBLSEntries(bootDir string) (map[string][]grubConfigLi
 
 		var linux string
 		var title string
+		var titleSeen bool
 		var args []grubConfigLinuxArg
 
 		for _, field := range bls.ParseFields(string(content)) {
@@ -98,6 +99,13 @@ func readKernelCmdlinesFromBLSEntries(bootDir string) (map[string][]grubConfigLi
 				}
 				linux = filepath.Base(field.Value)
 			case "title":
+				// Per BLS spec each non-options key may appear at most once. An empty title value
+				// is still a valid (normal) entry, so we cannot infer duplication from title != "";
+				// track it explicitly.
+				if titleSeen {
+					return nil, fmt.Errorf("duplicate key (%s) in BLS entry (%s)", field.Key, absPath)
+				}
+				titleSeen = true
 				title = field.Value
 			case "efi", "uki", "uki-url":
 				return nil, fmt.Errorf("BLS entry (%s) uses '%s' key, which is not supported", absPath, field.Key)

--- a/toolkit/tools/pkg/imagecustomizerlib/blsutils_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/blsutils_test.go
@@ -394,6 +394,26 @@ func TestReadKernelCmdlinesFromBLSEntries(t *testing.T) {
 			wantErrSubstr: "duplicate key (linux)",
 		},
 		{
+			name: "duplicate 'title' key in a single entry produces an error",
+			files: map[string]string{
+				"dup-title.conf": "title Azure Linux\n" +
+					"title Azure Linux Also\n" +
+					"linux /vmlinuz-6.6\n" +
+					"options root=/dev/sda1\n",
+			},
+			wantErrSubstr: "duplicate key (title)",
+		},
+		{
+			name: "duplicate empty 'title' key in a single entry produces an error",
+			files: map[string]string{
+				"dup-empty-title.conf": "title\n" +
+					"title\n" +
+					"linux /vmlinuz-6.6\n" +
+					"options root=/dev/sda1\n",
+			},
+			wantErrSubstr: "duplicate key (title)",
+		},
+		{
 			name: "empty 'linux' value produces an error",
 			files: map[string]string{
 				"empty-linux.conf": "title Azure Linux\n" +


### PR DESCRIPTION
Per the Boot Loader Specification, non-'options' keys may appear at most once per entry. readKernelCmdlinesFromBLSEntries already rejects a duplicate 'linux' key but silently kept the last value when 'title' appeared more than once, which could mask malformed entries.