### PR TITLE
docs: add 'Edit this page on GitHub' link to Jekyll config

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -20,4 +20,4 @@ gh_edit_link_text: Edit this page on GitHub
 gh_edit_repository: "https://github.com/microsoft/azure-linux-image-tools"
 gh_edit_branch: main
 gh_edit_source: docs
-gh_edit_view_mode: tree
+gh_edit_view_mode: edit

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -14,3 +14,10 @@ kramdown:
 aux_links:
   "GitHub Repo":
     - "https://github.com/microsoft/azure-linux-image-tools"
+
+gh_edit_link: true
+gh_edit_link_text: Edit this page on GitHub
+gh_edit_repository: "https://github.com/microsoft/azure-linux-image-tools"
+gh_edit_branch: main
+gh_edit_source: docs
+gh_edit_view_mode: tree


### PR DESCRIPTION
Enable the Just-the-Docs 'Edit this page on GitHub' feature by configuring the gh_edit_link settings in docs/_config.yml. This adds a per-page edit link that points to the corresponding source file in the microsoft/azure-linux-image-tools repository's main branch, making it easier for readers to propose documentation improvements.