### PR TITLE
Support EFI/azurelinux ESP layout for Azure Linux 4.0 images

### DIFF
--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -123,6 +123,15 @@ var (
 	}
 
 	GrubStubDirsAzl4 = []string{
+		"EFI/azurelinux",
+		"EFI/fedora",
+		"EFI/BOOT",
+	}
+
+	// GrubStubDirsFedora lists the ESP-relative directories where the grub stub
+	// grub.cfg is written for Fedora images. Unlike AZL4, Fedora does not use the
+	// EFI/azurelinux location.
+	GrubStubDirsFedora = []string{
 		"EFI/fedora",
 		"EFI/BOOT",
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux4.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux4.go
@@ -5,7 +5,9 @@ package imagecustomizerlib
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"runtime"
 
@@ -104,7 +106,28 @@ func (d *azureLinux4DistroHandler) GetEspDir() string {
 }
 
 func (d *azureLinux4DistroHandler) FindBootPartitionUuidFromEsp(espMountDir string) (string, error) {
-	return readBootPartitionUuidFromGrubCfg(filepath.Join(espMountDir, espGrubCfgPathAzl4), bootPartitionRegexAzl4)
+	// Azure Linux 4.0 base images may place the ESP grub.cfg under either
+	// EFI/azurelinux (preferred, going forward) or EFI/fedora (legacy). Probe in
+	// preference order and use the first one that exists.
+	var firstErr error
+	for _, relPath := range espGrubCfgPathsAzl4 {
+		grubCfgPath := filepath.Join(espMountDir, relPath)
+		if _, err := os.Stat(grubCfgPath); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			if firstErr == nil {
+				firstErr = fmt.Errorf("failed to stat EFI system partition's grub.cfg file (%s):\n%w", grubCfgPath, err)
+			}
+			continue
+		}
+		return readBootPartitionUuidFromGrubCfg(grubCfgPath, bootPartitionRegexAzl4)
+	}
+	if firstErr != nil {
+		return "", firstErr
+	}
+	return "", fmt.Errorf("failed to find EFI system partition's grub.cfg file under %s (looked for %v)",
+		espMountDir, espGrubCfgPathsAzl4)
 }
 
 func (d *azureLinux4DistroHandler) GetSELinuxConfigFile() string {

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
@@ -176,7 +176,7 @@ func (d *fedoraDistroHandler) ConfigureDiskBootLoader(imageConnection *imageconn
 ) error {
 	return configureDiskBootLoader(imageConnection, rootMountIdType, bootType, selinuxConfig, kernelCommandLine,
 		currentSELinuxMode, true /* forceGrubMkconfig */, d, resources.AssetsGrubDefFileAzl4,
-		installutils.FedoraGrubEnvRelPath, resources.AssetsGrubStubFileAzl4, installutils.GrubStubDirsAzl4)
+		installutils.FedoraGrubEnvRelPath, resources.AssetsGrubStubFileAzl4, installutils.GrubStubDirsFedora)
 }
 
 func (d *fedoraDistroHandler) ReadGrubConfigLinuxArgs(bootDir string) (map[string][]grubConfigLinuxArg, error) {

--- a/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
@@ -41,9 +41,18 @@ var (
 )
 
 const (
-	espGrubCfgPathAzl3 = "boot/grub2/grub.cfg"
-	espGrubCfgPathAzl4 = "EFI/fedora/grub.cfg"
+	espGrubCfgPathAzl3           = "boot/grub2/grub.cfg"
+	espGrubCfgPathAzl4Fedora     = "EFI/fedora/grub.cfg"
+	espGrubCfgPathAzl4AzureLinux = "EFI/azurelinux/grub.cfg"
 )
+
+// espGrubCfgPathsAzl4 lists the ESP-relative grub.cfg paths to probe for Azure Linux 4.0
+// images, in preference order. EFI/azurelinux is the preferred location; EFI/fedora is
+// kept for backwards compatibility with existing AZL4 base images.
+var espGrubCfgPathsAzl4 = []string{
+	espGrubCfgPathAzl4AzureLinux,
+	espGrubCfgPathAzl4Fedora,
+}
 
 const (
 	// BtrfsTopLevelSubvolumeId is the ID of the top-level subvolume in a BTRFS filesystem.


### PR DESCRIPTION
Azure Linux 4.0 base images are transitioning from the EFI/fedora ESP directory to EFI/azurelinux. Probe both locations when reading the boot partition UUID from the ESP grub.cfg (preferring EFI/azurelinux), and include EFI/azurelinux in the AZL4 grub stub directories so newly-installed stubs land in the new location alongside EFI/fedora and EFI/BOOT.