### PR TITLE
Harden arm64 VM tests: bump systemd device timeout to 600s

### DIFF
--- a/test/vmtests/vmtests/utils/imagecustomizer.py
+++ b/test/vmtests/vmtests/utils/imagecustomizer.py
@@ -2,6 +2,7 @@
 # Licensed under the MIT License.
 
 import logging
+import platform
 import tempfile
 from os import fdopen
 from pathlib import Path
@@ -110,9 +111,10 @@ def run_image_customizer(
     )
 
 
-# Modify an image customizer config file:
+# Modify an image customizer config file to prepare an image for VM testing:
 # - Install the SSH server package,
-# - Add a user with an SSH public key.
+# - Add a user with an SSH public key,
+# - Extend systemd's default device timeout (arm64 only)
 def add_ssh_to_config(config_path: Path, username: str, ssh_public_key: str, close_list: List[Closeable]) -> Path:
     config_str = config_path.read_text()
     config = yaml.safe_load(config_str)
@@ -150,6 +152,21 @@ def add_ssh_to_config(config_path: Path, username: str, ssh_public_key: str, clo
 
     additional_files = dict_get_or_set(os, "additionalFiles", [])
     additional_files.append(sudoers_add_file)
+
+    # On arm64 hosts, extend systemd's default device timeout for VM tests.
+    #
+    # The arm64 VM test runners boot the guest much more slowly than the x86_64 runners. Boot can wait a long time
+    # before udev creates the /dev/disk/by-uuid/<UUID> symlink for the ESP. systemd's default
+    # DefaultDeviceTimeoutSec=90s is then exceeded, which fails the device unit, which fails boot-efi.mount, which fails
+    # local-fs.target, which drops the system into emergency.target: sshd never starts and the test fails with
+    # "Unable to connect to port 22".
+    #
+    # x86_64 VM tests have not exhibited this flake, so we leave the default behaviour in place there and only bump the
+    # timeout on arm64.
+    if platform.machine() == "aarch64":
+        kernel_command_line = dict_get_or_set(os, "kernelCommandLine", {})
+        extra_command_line = dict_get_or_set(kernel_command_line, "extraCommandLine", [])
+        extra_command_line.append("systemd.default_device_timeout_sec=600")
 
     # Write out new config file to a temporary file.
     fd, modified_config_path = tempfile.mkstemp(prefix=config_path.name + "~", suffix=".tmp", dir=config_path.parent)


### PR DESCRIPTION
Fixes flaky failures across multiple arm64 VM test jobs that were hitting an ESP device timeout during guest boot and cascading into emergency mode. Reproductions seen on two consecutive release runs:

* osmodifier Ubuntu24.04 ARM64 (run 26543985458, job 78192335242)
  - all 6 osmodifier AZL4 tests failed with "Unable to connect to port 22" after the boot fell into emergency.target
* VMTests imagecustomizer Ubuntu24.04 ARM64 (run 26545094754, job 78195779954)
  - test_min_change_efi_azl4_qcow_output failed identically on the same ESP UUID (B3A5-CBA1) with the same boot-time cascade

Root cause
----------
arm64 VM tests run a guest qemu/libvirt VM on an arm64 Ubuntu 24.04 runner and boot the guest much more slowly than the x86_64 jobs. On a noisy or slow runner the AZL4 image can take well over 90 seconds before udev publishes the /dev/disk/by-uuid/<ESP-UUID> symlink (kernel time ~187s observed in the imagecustomizer failure).

systemd's default DefaultDeviceTimeoutSec=90s is too short for that. When it expires the failure cascades:

  dev-disk-by\x2duuid-...device  (timeout)
    -> boot-efi.mount             (dependency failed)
    -> local-fs.target            (failed; ESP fstab entry lacks nofail)
    -> emergency.target           (system drops to rescue shell)

systemd never reaches multi-user.target, sshd never starts, and the test's SSH retry loop (~360s) eventually gives up with "Unable to connect to port 22". AZL3 happens to win this race today because its boot is a bit faster, but it is on the same cliff edge.

Fix
---
On arm64 hosts only, inject `systemd.default_device_timeout_sec=600` into the test image's kernel cmdline via image-customizer's `os.kernelCommandLine.extraCommandLine`. The bump is gated on `platform.machine() == "aarch64"`, matching the existing convention in the VM-test helpers (see `libvirt_vm.py` and `libvirt_utils.py`).

This is applied centrally in `add_ssh_to_config`, which every VM test already calls to prepare its config, so the hardening covers all current and future arm64 VM tests built on the helper:

  * osmodifier VMTests (test/vmtests/vmtests/osmodifier/...)
  * imagecustomizer VMTests (test_create.py, test_min_change.py)

x86_64 VM tests have not exhibited this flake, so the default systemd behaviour is left in place there. This change only affects test images at test time; product image behaviour is unchanged.
