### PR TITLE
Run grub2-install inside the install chroot to use target image's modules

### DIFF
--- a/.github/workflows/tests-functional.yml
+++ b/.github/workflows/tests-functional.yml
@@ -53,20 +53,13 @@ jobs:
         # Install Image Customizer prerequisities.
         PACKAGES="qemu-img rpm coreutils util-linux systemd openssl \
             sed createrepo_c squashfs-tools cdrkit e2fsprogs dosfstools \
-            xfsprogs btrfs-progs zstd veritysetup grub2 binutils lsof \
+            xfsprogs btrfs-progs zstd veritysetup binutils lsof \
             git azure-cli systemd-ukify"
-
-        # grub2-pc is only available on x86.
-        if [[ "$HOST_ARCH" == "amd64" ]]; then
-            PACKAGES+=" grub2-pc"
-        fi
 
         sudo ./repo/.github/workflows/scripts/retry.sh 5 5 \
             tdnf install -y $PACKAGES
 
         sudo tdnf list installed
-      env:
-        HOST_ARCH: ${{ inputs.hostArch }}
 
     - name: Patch ukify (AZL3)
       if: inputs.hostDistro == 'azl3'
@@ -87,7 +80,7 @@ jobs:
 
         sudo apt -y install qemu-utils rpm coreutils util-linux mount fdisk udev openssl \
           sed createrepo-c squashfs-tools genisoimage e2fsprogs dosfstools \
-          xfsprogs btrfs-progs zstd cryptsetup-bin grub2-common binutils lsof systemd-ukify
+          xfsprogs btrfs-progs zstd cryptsetup-bin binutils lsof systemd-ukify
 
         curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 

--- a/docs/imagecustomizer/quick-start/quick-start-binary.md
+++ b/docs/imagecustomizer/quick-start/quick-start-binary.md
@@ -37,14 +37,14 @@ Note: Using the [Image Customizer container](../quick-start/quick-start.md) is t
    `udevadm`, `flock`, `blkid`, `openssl`, `sed`, `createrepo`, `mksquashfs`,
    `genisoimage`, `mkfs`, `mkfs.btrfs`, `mkfs.ext4`, `mkfs.vfat`, `mkfs.xfs`, `fsck`,
    `e2fsck`, `xfs_repair`, `resize2fs`, `tune2fs`, `xfs_admin`, `fatlabel`, `zstd`,
-   `veritysetup`, `grub2-install` (or `grub-install`), `ukify`, `objcopy`, `lsof`, `btrfs`.
+   `veritysetup`, `ukify`, `objcopy`, `lsof`, `btrfs`.
 
    - For Ubuntu 22.04 images, run:
 
      ```bash
      sudo apt -y install qemu-utils rpm coreutils util-linux mount fdisk udev openssl \
         sed createrepo-c squashfs-tools genisoimage e2fsprogs dosfstools \
-        xfsprogs btrfs-progs zstd cryptsetup-bin grub2-common binutils lsof
+        xfsprogs btrfs-progs zstd cryptsetup-bin binutils lsof
      ```
 
    - For Azure Linux (2.0 and 3.0, x86_64 and arm64), run:
@@ -52,17 +52,8 @@ Note: Using the [Image Customizer container](../quick-start/quick-start.md) is t
      ```bash
      sudo tdnf install -y qemu-img rpm coreutils util-linux systemd openssl \
        sed createrepo_c squashfs-tools cdrkit e2fsprogs dosfstools \
-       xfsprogs btrfs-progs zstd veritysetup grub2 binutils lsof systemd-ukify
+       xfsprogs btrfs-progs zstd veritysetup binutils lsof systemd-ukify
      ```
-
-     - On x86_64, to install libraries for BIOS booting, additionally run:
-
-       ```bash
-       sudo tdnf install -y grub2-pc
-       ```
-
-       Note: arm64 machines only support UEFI, so the `grub2-pc` package is only needed
-       when building x86_64 images.
 
 4. Add executable permissions using `chmod +x imagecustomizer`.
 

--- a/toolkit/tools/imagecustomizer/container/build-container.sh
+++ b/toolkit/tools/imagecustomizer/container/build-container.sh
@@ -96,12 +96,6 @@ cp "$entrypointScript" "${stagingLibDir}"
 
 cp "$telemetryRequirements" "${containerStagingFolder}"/telemetry-requirements.txt
 
-# azl doesn't support grub2-pc for arm64, hence remove it from dockerfile
-if [ "$ARCH" == "arm64" ]; then
-    echo "Removing grub2-pc from Dockerfile for arm64"
-    sed -i 's/\<grub2-pc\>//g' "$dockerFile"
-fi
-
 # list all staged files
 (
     cd "$containerStagingFolder"

--- a/toolkit/tools/imagecustomizer/container/imagecustomizer.Dockerfile
+++ b/toolkit/tools/imagecustomizer/container/imagecustomizer.Dockerfile
@@ -14,7 +14,7 @@ RUN tdnf update -y && \
    tdnf update -y && \
    tdnf install -y qemu-img rpm coreutils util-linux systemd openssl \
       sed createrepo_c squashfs-tools cdrkit parted e2fsprogs dosfstools \
-      xfsprogs btrfs-progs zstd veritysetup grub2 grub2-pc systemd-ukify binutils lsof \
+      xfsprogs btrfs-progs zstd veritysetup systemd-ukify binutils lsof \
       python3 python3-pip jq oras tar pigz && \
    tdnf clean all
 

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -957,11 +957,8 @@ func InstallBootloader(installChroot *safechroot.Chroot, encryptEnabled bool, bo
 func installLegacyBootloader(installChroot *safechroot.Chroot, bootDevPath string, encryptEnabled bool) (err error) {
 	const (
 		squashErrors     = false
-		bootDir          = "/boot"
-		bootDirArg       = "--boot-directory"
 		grub2BootDir     = "/boot/grub2"
 		grub2InstallName = "grub2-install"
-		grubInstallName  = "grub-install"
 	)
 
 	// Add grub cryptodisk settings
@@ -971,29 +968,10 @@ func installLegacyBootloader(installChroot *safechroot.Chroot, bootDevPath strin
 			return
 		}
 	}
-	installBootDir := filepath.Join(installChroot.RootDir(), bootDir)
-	grub2InstallBootDirArg := fmt.Sprintf("%s=%s", bootDirArg, installBootDir)
 
-	installName := grub2InstallName
-	grub2InstallExists, err := file.CommandExists(grub2InstallName)
-	if err != nil {
-		return
-	}
-
-	if !grub2InstallExists {
-		grubInstallExists, err := file.CommandExists(grubInstallName)
-		if err != nil {
-			return err
-		}
-
-		if !grubInstallExists {
-			return fmt.Errorf("neither 'grub2-install' command nor 'grub-install' command found")
-		}
-
-		installName = grubInstallName
-	}
-
-	err = shell.ExecuteLive(squashErrors, installName, "--target=i386-pc", grub2InstallBootDirArg, bootDevPath)
+	err = shell.NewExecBuilder(grub2InstallName, "--target=i386-pc", "--boot-directory=/boot", bootDevPath).
+		Chroot(installChroot.ChrootDir()).
+		Execute()
 	if err != nil {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/versionsOfToolDependencies.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/versionsOfToolDependencies.go
@@ -15,7 +15,7 @@ func LogVersionsOfToolDeps() {
 		"--version": {
 			"qemu-img", "rpm", "dd", "lsblk", "losetup", "sfdisk", "udevadm",
 			"flock", "blkid", "sed", "createrepo", "genisoimage", "mkfs",
-			"fsck", "fatlabel", "zstd", "veritysetup", "grub-install", "objcopy",
+			"fsck", "fatlabel", "zstd", "veritysetup", "objcopy",
 		},
 		"-version": {
 			"mksquashfs",


### PR DESCRIPTION
installLegacyBootloader was running grub2-install on the host with --boot-directory pointed at the chroot's /boot, so the modules copied into the target image's /boot/grub2/i386-pc/ came from the IC container's grub2-pc, not the target's. If the two grub2 ABIs differ, installation will fail. Example: AZL3 container building an AZL4 image silently drops BLS-related modules (blscfg.mod / increment.mod / bli.mod) and the resulting image fails at "insmod blscfg" on boot.

Now grub2-install runs in the chroot via the safechroot exec builder, matching CallGrubMkconfig.

Also drops the grub-install host fallback from #9978 / d80ba54c1, which existed because the host call needed to handle Ubuntu's grub-install naming. The host's PATH no longer matters, and Ubuntu targets currently bail out of this code path in ubuntuDistroHandler.ConfigureDiskBootLoader with ErrUbuntuBootLoaderHardReset, so the grub-install fallback is safe to drop.

Also drops grub2 / grub2-pc / grub2-common from the IC container Dockerfile, the CI prereqs (AZL3 and Ubuntu), the binary quick-start, and the host tool version log. The arm64 sed workaround in build-container.sh that stripped grub2-pc from the Dockerfile is no longer needed and is removed.