### PR TITLE
Run grub2-install inside the install chroot to use target image's modules

### DIFF
--- a/docs/imagecustomizer/api/configuration/storage.md
+++ b/docs/imagecustomizer/api/configuration/storage.md
@@ -54,7 +54,7 @@ Supported options:
 
   Install the following packages (using the `os.packages.install` API):
 
-  - Fedora, Azure Linux 4.0: `grub2-tools`, `grub-pc-modules`
+  - Fedora, Azure Linux 4.0: `grub2-tools`, `grub2-pc-modules`
   - Azure Linux 2.0, 3.0: `grub2`, `grub2-pc`
 
   For Azure Linux 2.0 and 3.0, if the `grub2-install` command is not available in the

--- a/docs/imagecustomizer/api/configuration/storage.md
+++ b/docs/imagecustomizer/api/configuration/storage.md
@@ -52,10 +52,10 @@ Supported options:
 
   The `grub2-install` command must be installed in the target image.
 
-  Install the following package (using the `os.packages.install` API):
+  Install the following packages (using the `os.packages.install` API):
 
-  - Fedora, Azure Linux: `grub2-pc`
-  - Ubuntu: `grub2-common`
+  - Fedora, Azure Linux 4.0: `grub2-tools`, `grub-pc-modules`
+  - Azure Linux 2.0, 3.0: `grub2`, `grub2-pc`
 
   For Azure Linux 2.0 and 3.0, if the `grub2-install` command is not available in the
   target OS, then the `grub2-install` command from the container (or build host) is

--- a/docs/imagecustomizer/api/configuration/storage.md
+++ b/docs/imagecustomizer/api/configuration/storage.md
@@ -50,6 +50,15 @@ Supported options:
 
 - `legacy`: Support booting from BIOS firmware.
 
+  The `grub2-install` command must be installed in the target image.
+
+  Install the following package (using the `os.packages.install` API):
+
+  - Fedora, Azure Linux: `grub2-pc`
+  - Ubuntu: `grub2-common`
+
+  For Azure Linux 2.0 and 3.0, if the `grub2-install` command is not available in the target OS, then the `grub2-install` command from the container (or build host) is used instead. However, this behavior is deprecated and will be removed in a future version.
+
   When this option is specified, the partition layout must contain a partition with the
   `bios-grub` flag.
 

--- a/docs/imagecustomizer/api/configuration/storage.md
+++ b/docs/imagecustomizer/api/configuration/storage.md
@@ -57,7 +57,10 @@ Supported options:
   - Fedora, Azure Linux: `grub2-pc`
   - Ubuntu: `grub2-common`
 
-  For Azure Linux 2.0 and 3.0, if the `grub2-install` command is not available in the target OS, then the `grub2-install` command from the container (or build host) is used instead. However, this behavior is deprecated and will be removed in a future version.
+  For Azure Linux 2.0 and 3.0, if the `grub2-install` command is not available in the
+  target OS, then the `grub2-install` command from the container (or build host) is
+  used instead. However, this behavior is deprecated and will be removed in a future
+  version.
 
   When this option is specified, the partition layout must contain a partition with the
   `bios-grub` flag.

--- a/test/vmtests/vmtests/imagecustomizer/test_min_change.py
+++ b/test/vmtests/vmtests/imagecustomizer/test_min_change.py
@@ -607,3 +607,163 @@ def test_min_change_legacy_azl4_iso_output(
         libvirt_conn,
         close_list,
     )
+
+
+@pytest.mark.skipif(platform.machine() != "x86_64", reason="no arm64 legacy boot input images are available")
+def test_legacy_bootloader_reset_azl2(
+    docker_client: DockerClient,
+    image_customizer_container_url: str,
+    core_legacy_azl2: Path,
+    ssh_key: Tuple[str, Path],
+    test_temp_dir: Path,
+    test_instance_name: str,
+    logs_dir: Path,
+    libvirt_conn: libvirt.virConnect,
+    close_list: List[Closeable],
+) -> None:
+    azl_release = 2
+    config_path = TEST_CONFIGS_DIR.joinpath("legacyboot-reset.yaml")
+    output_format = "qcow2"
+
+    run_min_change_test(
+        docker_client,
+        image_customizer_container_url,
+        core_legacy_azl2,
+        azl_release,
+        config_path,
+        output_format,
+        ssh_key,
+        test_temp_dir,
+        test_instance_name,
+        logs_dir,
+        libvirt_conn,
+        close_list,
+    )
+
+
+@pytest.mark.skipif(platform.machine() != "x86_64", reason="no arm64 legacy boot input images are available")
+def test_legacy_bootloader_reset_azl3(
+    docker_client: DockerClient,
+    image_customizer_container_url: str,
+    core_legacy_azl3: Path,
+    ssh_key: Tuple[str, Path],
+    test_temp_dir: Path,
+    test_instance_name: str,
+    logs_dir: Path,
+    libvirt_conn: libvirt.virConnect,
+    close_list: List[Closeable],
+) -> None:
+    azl_release = 3
+    config_path = TEST_CONFIGS_DIR.joinpath("legacyboot-reset.yaml")
+    output_format = "qcow2"
+
+    run_min_change_test(
+        docker_client,
+        image_customizer_container_url,
+        core_legacy_azl3,
+        azl_release,
+        config_path,
+        output_format,
+        ssh_key,
+        test_temp_dir,
+        test_instance_name,
+        logs_dir,
+        libvirt_conn,
+        close_list,
+    )
+
+
+@pytest.mark.skipif(platform.machine() != "x86_64", reason="no arm64 legacy boot input images are available")
+def test_legacy_bootloader_reset_azl4(
+    docker_client: DockerClient,
+    image_customizer_container_url: str,
+    core_legacy_azl4: Path,
+    ssh_key: Tuple[str, Path],
+    test_temp_dir: Path,
+    test_instance_name: str,
+    logs_dir: Path,
+    libvirt_conn: libvirt.virConnect,
+    close_list: List[Closeable],
+) -> None:
+    azl_release = 4
+    config_path = TEST_CONFIGS_DIR.joinpath("legacyboot-reset.yaml")
+    output_format = "qcow2"
+
+    run_min_change_test(
+        docker_client,
+        image_customizer_container_url,
+        core_legacy_azl4,
+        azl_release,
+        config_path,
+        output_format,
+        ssh_key,
+        test_temp_dir,
+        test_instance_name,
+        logs_dir,
+        libvirt_conn,
+        close_list,
+    )
+
+
+@pytest.mark.skipif(platform.machine() != "x86_64", reason="no arm64 legacy boot input images are available")
+def test_legacy_bootloader_reset_fallback_azl2(
+    docker_client: DockerClient,
+    image_customizer_container_url: str,
+    core_legacy_azl2: Path,
+    ssh_key: Tuple[str, Path],
+    test_temp_dir: Path,
+    test_instance_name: str,
+    logs_dir: Path,
+    libvirt_conn: libvirt.virConnect,
+    close_list: List[Closeable],
+) -> None:
+    azl_release = 2
+    config_path = TEST_CONFIGS_DIR.joinpath("legacyboot-reset-fallback.yaml")
+    output_format = "qcow2"
+
+    run_min_change_test(
+        docker_client,
+        image_customizer_container_url,
+        core_legacy_azl2,
+        azl_release,
+        config_path,
+        output_format,
+        ssh_key,
+        test_temp_dir,
+        test_instance_name,
+        logs_dir,
+        libvirt_conn,
+        close_list,
+    )
+
+
+@pytest.mark.skipif(platform.machine() != "x86_64", reason="no arm64 legacy boot input images are available")
+def test_legacy_bootloader_reset_fallback_azl3(
+    docker_client: DockerClient,
+    image_customizer_container_url: str,
+    core_legacy_azl3: Path,
+    ssh_key: Tuple[str, Path],
+    test_temp_dir: Path,
+    test_instance_name: str,
+    logs_dir: Path,
+    libvirt_conn: libvirt.virConnect,
+    close_list: List[Closeable],
+) -> None:
+    azl_release = 3
+    config_path = TEST_CONFIGS_DIR.joinpath("legacyboot-reset-fallback.yaml")
+    output_format = "qcow2"
+
+    run_min_change_test(
+        docker_client,
+        image_customizer_container_url,
+        core_legacy_azl3,
+        azl_release,
+        config_path,
+        output_format,
+        ssh_key,
+        test_temp_dir,
+        test_instance_name,
+        logs_dir,
+        libvirt_conn,
+        close_list,
+    )

--- a/toolkit/tools/imagecustomizer/container/imagecustomizer.Dockerfile
+++ b/toolkit/tools/imagecustomizer/container/imagecustomizer.Dockerfile
@@ -12,7 +12,7 @@ ENV AZURE_MONITOR_CONNECTION_STRING=${AZ_MON_CONN_STR}
 RUN tdnf update -y && \
    tdnf install -y azurelinux-repos-cloud-native && \
    tdnf update -y && \
-   tdnf install -y qemu-img rpm coreutils util-linux systemd openssl \
+   tdnf install -y qemu-img rpm coreutils util-linux systemd systemd-udev openssl \
       sed createrepo_c squashfs-tools cdrkit parted e2fsprogs dosfstools \
       xfsprogs btrfs-progs zstd veritysetup grub2 grub2-pc systemd-ukify binutils lsof \
       python3 python3-pip jq oras tar pigz && \

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -106,8 +106,12 @@ const (
 )
 
 const (
-	rootMountPoint = "/"
-	bootMountPoint = "/boot"
+	rootMountPoint   = "/"
+	bootMountPoint   = "/boot"
+	grub2BootDir     = "/boot/grub2"
+	grub2InstallName = "grub2-install"
+	grubInstallName  = "grub-install"
+	grubModulesDir   = "/usr/lib/grub/i386-pc"
 
 	// /boot directory should be only accesible by root. The directories need the execute bit as well.
 	bootDirectoryFileMode = 0400
@@ -403,7 +407,8 @@ func ConfigureDiskBootloaderWithRootMountIdType(bootType string, encryptionEnabl
 	rootMountIdentifier configuration.MountIdentifier, kernelCommandLine configuration.KernelCommandLine,
 	installChroot *safechroot.Chroot, diskDevPath string, mountPointMap map[string]string,
 	encryptedRoot diskutils.EncryptedRootDevice, enableGrubMkconfig bool, assetGrubDefFile,
-	grubEnvRelPath, assetGrubStubFile string, grubStubDirs []string,
+	grubEnvRelPath, assetGrubStubFile string, grubStubDirs []string, allowHostGrubInstallFallback bool,
+	grubInstallPackage string, grubModulesPackage string,
 ) (err error) {
 	// Add bootloader. Prefer a separate boot partition if one exists.
 	bootDevice, isBootPartitionSeparate := mountPointMap[bootMountPoint]
@@ -427,7 +432,7 @@ func ConfigureDiskBootloaderWithRootMountIdType(bootType string, encryptionEnabl
 	}
 
 	err = InstallBootloader(installChroot, encryptionEnable, bootType, bootUUID, bootPrefix, diskDevPath,
-		assetGrubStubFile, grubStubDirs)
+		assetGrubStubFile, grubStubDirs, allowHostGrubInstallFallback, grubInstallPackage, grubModulesPackage)
 	if err != nil {
 		err = fmt.Errorf("failed to install bootloader: %s", err)
 		return
@@ -920,7 +925,8 @@ func sed(find, replace, delimiter, file string) (err error) {
 // Note: this boot partition could be different than the boot partition specified in the main grub config.
 // This boot partition specifically indicates where to find the main grub cfg
 func InstallBootloader(installChroot *safechroot.Chroot, encryptEnabled bool, bootType, bootUUID, bootPrefix,
-	bootDevPath, grubAssetFileName string, grubFinalDirs []string,
+	bootDevPath, grubAssetFileName string, grubFinalDirs []string, allowHostGrubInstallFallback bool,
+	grubInstallPackage string, grubModulesPackage string,
 ) (err error) {
 	const (
 		efiMountPoint  = "/boot/efi"
@@ -933,7 +939,8 @@ func InstallBootloader(installChroot *safechroot.Chroot, encryptEnabled bool, bo
 
 	switch bootType {
 	case legacyBootType:
-		err = installLegacyBootloader(installChroot, bootDevPath, encryptEnabled)
+		err = installLegacyBootloader(installChroot, bootDevPath, encryptEnabled, allowHostGrubInstallFallback,
+			grubInstallPackage, grubModulesPackage)
 		if err != nil {
 			return
 		}
@@ -952,18 +959,17 @@ func InstallBootloader(installChroot *safechroot.Chroot, encryptEnabled bool, bo
 	return
 }
 
+// installLegacyBootloader installs the legacy grub2 bootloader to the target image by either using the target's own
+// grub2-install command and modules, or by falling back to using the build host's grub2-install if the target is
+// missing either of those and the fallback is allowed. Set allowHostGrubInstallFallback to true for scenarios in which
+// not falling back would cause a backwards compatibility issue for older distro versions, and set it to false for all
+// other scenarios to encourage using the correct path (grub2-install within the target image).
+//
 // Note: We assume that the /boot directory is present. Whether it is backed by an explicit "boot" partition or present
 // as part of a general "root" partition is assumed to have been done already.
-func installLegacyBootloader(installChroot *safechroot.Chroot, bootDevPath string, encryptEnabled bool) (err error) {
-	const (
-		squashErrors     = false
-		bootDir          = "/boot"
-		bootDirArg       = "--boot-directory"
-		grub2BootDir     = "/boot/grub2"
-		grub2InstallName = "grub2-install"
-		grubInstallName  = "grub-install"
-	)
-
+func installLegacyBootloader(installChroot *safechroot.Chroot, bootDevPath string, encryptEnabled bool,
+	allowHostGrubInstallFallback bool, grubInstallPackage string, grubModulesPackage string,
+) (err error) {
 	// Add grub cryptodisk settings
 	if encryptEnabled {
 		err = enableCryptoDisk()
@@ -971,9 +977,76 @@ func installLegacyBootloader(installChroot *safechroot.Chroot, bootDevPath strin
 			return
 		}
 	}
-	installBootDir := filepath.Join(installChroot.RootDir(), bootDir)
-	grub2InstallBootDirArg := fmt.Sprintf("%s=%s", bootDirArg, installBootDir)
 
+	// Installing the legacy bootloader from the target's own grub requires BOTH the grub2-install command and the
+	// i386-pc platform modules that it installs.
+	grubInstallExists := grubInstallCommandExistsInChroot(installChroot, grub2InstallName)
+	grubModulesExist, err := grubLegacyModulesExistInChroot(installChroot)
+	if err != nil {
+		return fmt.Errorf("failed to check for grub modules in chroot: %w", err)
+	}
+
+	missingPackages := []string{}
+	if !grubInstallExists {
+		missingPackages = append(missingPackages, grubInstallPackage)
+	}
+	if !grubModulesExist && grubModulesPackage != grubInstallPackage {
+		missingPackages = append(missingPackages, grubModulesPackage)
+	}
+
+	switch {
+	case grubInstallExists && grubModulesExist:
+		// Install the bootloader from inside the chroot using the target's own grub2-install.
+		err = shell.NewExecBuilder(grub2InstallName, "--target=i386-pc", "--boot-directory=/boot", bootDevPath).
+			Chroot(installChroot.ChrootDir()).
+			Execute()
+		if err != nil {
+			return
+		}
+	case allowHostGrubInstallFallback:
+		if err = installLegacyBootloaderFromHost(installChroot, bootDevPath, missingPackages); err != nil {
+			return
+		}
+	default:
+		package_s := "package"
+		if len(missingPackages) > 1 {
+			package_s = "packages"
+		}
+		return fmt.Errorf("the target image must have the following %s installed to build a legacy-boot image "+
+			"(they can be added to os.packages.install): '%s'", package_s, strings.Join(missingPackages, "', '"))
+	}
+
+	installGrub2BootDir := filepath.Join(installChroot.RootDir(), grub2BootDir)
+	err = shell.ExecuteLive(false /*squashErrors*/, "chmod", "-R", "go-rwx", installGrub2BootDir)
+	return
+}
+
+// grubLegacyModulesExistInChroot reports whether the target image contains the i386-pc grub modules that
+// grub2-install --target=i386-pc installs from.
+func grubLegacyModulesExistInChroot(installChroot *safechroot.Chroot) (bool, error) {
+	modulesDir := filepath.Join(installChroot.RootDir(), grubModulesDir)
+	entries, err := os.ReadDir(modulesDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".mod") {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// installLegacyBootloaderFromHost installs the legacy bootloader using the build host's grub2-install
+// (or grub-install), pointed at the target image's /boot. This is the historical behavior and should only be used as a
+// fallback for out-of-preview distro versions, and only when the target image does not ship the packages needed to
+// install the bootloader from the target itself. It risks introducing copmatibility issues between the host's grub
+// and the target image's grub configuration.
+func installLegacyBootloaderFromHost(installChroot *safechroot.Chroot, bootDevPath string, missingPackages []string,
+) (err error) {
 	installName := grub2InstallName
 	grub2InstallExists, err := file.CommandExists(grub2InstallName)
 	if err != nil {
@@ -987,20 +1060,33 @@ func installLegacyBootloader(installChroot *safechroot.Chroot, bootDevPath strin
 		}
 
 		if !grubInstallExists {
-			return fmt.Errorf("neither 'grub2-install' command nor 'grub-install' command found")
+			return fmt.Errorf("neither '%s' command nor '%s' command found on the build host", grub2InstallName,
+				grubInstallName)
 		}
 
 		installName = grubInstallName
 	}
 
-	err = shell.ExecuteLive(squashErrors, installName, "--target=i386-pc", grub2InstallBootDirArg, bootDevPath)
-	if err != nil {
-		return
+	package_s := "package"
+	if len(missingPackages) > 1 {
+		package_s = "packages"
 	}
+	logger.Log.Warnf("Installing the legacy bootloader using the build host's '%s' because the target image is "+
+		"missing the following %s: '%s'. The resulting image may fail to boot if the host's grub differs from the "+
+		"target's in a significant way. Add the %s to the image's package list (os.packages.install) to install the "+
+		"bootloader from the target itself.", installName, package_s, strings.Join(missingPackages, "', '"), package_s)
 
-	installGrub2BootDir := filepath.Join(installChroot.RootDir(), grub2BootDir)
-	err = shell.ExecuteLive(squashErrors, "chmod", "-R", "go-rwx", installGrub2BootDir)
-	return
+	installBootDir := filepath.Join(installChroot.RootDir(), "/boot")
+	bootDirArg := fmt.Sprintf("%s=%s", "--boot-directory", installBootDir)
+	return shell.ExecuteLive(false /*squashErrors*/, installName, "--target=i386-pc", bootDirArg, bootDevPath)
+}
+
+func grubInstallCommandExistsInChroot(installChroot *safechroot.Chroot, command string) bool {
+	err := shell.NewExecBuilder(command, "--version").
+		LogLevel(logrus.DebugLevel, logrus.DebugLevel).
+		Chroot(installChroot.ChrootDir()).
+		Execute()
+	return err == nil
 }
 
 // GetUUID queries the UUID of the given partition

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -1008,12 +1008,8 @@ func installLegacyBootloader(installChroot *safechroot.Chroot, bootDevPath strin
 			return
 		}
 	default:
-		package_s := "package"
-		if len(missingPackages) > 1 {
-			package_s = "packages"
-		}
-		return fmt.Errorf("the target image must have the following %s installed to build a legacy-boot image "+
-			"(they can be added to os.packages.install): '%s'", package_s, strings.Join(missingPackages, "', '"))
+		return fmt.Errorf("the target image must have the following package(s) installed to build a legacy-boot image "+
+			"(they can be added to os.packages.install): '%s'", strings.Join(missingPackages, "', '"))
 	}
 
 	installGrub2BootDir := filepath.Join(installChroot.RootDir(), grub2BootDir)
@@ -1067,14 +1063,10 @@ func installLegacyBootloaderFromHost(installChroot *safechroot.Chroot, bootDevPa
 		installName = grubInstallName
 	}
 
-	package_s := "package"
-	if len(missingPackages) > 1 {
-		package_s = "packages"
-	}
 	logger.Log.Warnf("Installing the legacy bootloader using the build host's '%s' because the target image is "+
-		"missing the following %s: '%s'. The resulting image may fail to boot if the host's grub differs from the "+
-		"target's in a significant way. Add the %s to the image's package list (os.packages.install) to install the "+
-		"bootloader from the target itself.", installName, package_s, strings.Join(missingPackages, "', '"), package_s)
+		"missing the following package(s): '%s'. The resulting image may fail to boot if the host's grub differs from "+
+		"the target's in a significant way. Add the package(s) to the image's package list (os.packages.install) to "+
+		"install the bootloader from the target itself.", installName, strings.Join(missingPackages, "', '"))
 
 	installBootDir := filepath.Join(installChroot.RootDir(), "/boot")
 	bootDirArg := fmt.Sprintf("%s=%s", "--boot-directory", installBootDir)

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -980,7 +980,8 @@ func installLegacyBootloader(installChroot *safechroot.Chroot, bootDevPath strin
 
 	// Installing the legacy bootloader from the target's own grub requires BOTH the grub2-install command and the
 	// i386-pc platform modules that it installs.
-	grubInstallExists := grubInstallCommandExistsInChroot(installChroot, grub2InstallName)
+	_, err = shell.LookPathChroot(grub2InstallName, installChroot.ChrootDir())
+	grubInstallExists := err == nil
 	grubModulesExist, err := grubLegacyModulesExistInChroot(installChroot)
 	if err != nil {
 		return fmt.Errorf("failed to check for grub modules in chroot: %w", err)
@@ -1071,14 +1072,6 @@ func installLegacyBootloaderFromHost(installChroot *safechroot.Chroot, bootDevPa
 	installBootDir := filepath.Join(installChroot.RootDir(), "/boot")
 	bootDirArg := fmt.Sprintf("%s=%s", "--boot-directory", installBootDir)
 	return shell.ExecuteLive(false /*squashErrors*/, installName, "--target=i386-pc", bootDirArg, bootDevPath)
-}
-
-func grubInstallCommandExistsInChroot(installChroot *safechroot.Chroot, command string) bool {
-	err := shell.NewExecBuilder(command, "--version").
-		LogLevel(logrus.DebugLevel, logrus.DebugLevel).
-		Chroot(installChroot.ChrootDir()).
-		Execute()
-	return err == nil
 }
 
 // GetUUID queries the UUID of the given partition

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -1040,7 +1040,7 @@ func grubLegacyModulesExistInChroot(installChroot *safechroot.Chroot) (bool, err
 // installLegacyBootloaderFromHost installs the legacy bootloader using the build host's grub2-install
 // (or grub-install), pointed at the target image's /boot. This is the historical behavior and should only be used as a
 // fallback for out-of-preview distro versions, and only when the target image does not ship the packages needed to
-// install the bootloader from the target itself. It risks introducing copmatibility issues between the host's grub
+// install the bootloader from the target itself. It risks introducing compatibility issues between the host's grub
 // and the target image's grub configuration.
 func installLegacyBootloaderFromHost(installChroot *safechroot.Chroot, bootDevPath string, missingPackages []string,
 ) (err error) {

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
@@ -12,14 +12,17 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/file"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/imageconnection"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/kernelversion"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/ptrutils"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safeloopback"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safemount"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/shell"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/testutils"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -218,6 +221,123 @@ func TestCustomizeImagePartitionsSizeOnly(t *testing.T) {
 	assert.Equal(t, uint64(2*diskutils.GiB), partitions[3].SizeInBytes)
 }
 
+func TestCustomizeImagePartitionsLegacy_TargetMissingPackages(t *testing.T) {
+	// Skip this test on arm64 because the legacy bootloader is not supported.
+	if runtime.GOARCH == "arm64" {
+		t.Skip("Skipping legacy test for arm64")
+	}
+
+	for _, baseImageInfo := range baseImageAzureLinuxAll {
+		// Azure Linux 4.0 is intentionally not covered here. Its grub2 packages (grub2-tools and grub2-pc-modules) are
+		// dnf-protected and/or required by other protected packages (e.g. shim -> grub2-efi-x64 -> grub2-tools), so the
+		// "target missing the legacy-boot packages" scenario cannot be set up via os.packages.remove without forcibly
+		// bypassing the package manager.
+		if baseImageInfo.Version == baseImageVersionAzl4 {
+			continue
+		}
+
+		t.Run(baseImageInfo.Name, func(t *testing.T) {
+			testCustomizeImagePartitionsLegacy_TargetMissingPackages(t,
+				"TestCustomizeImagePartitionsLegacy_TargetMissingPackages"+baseImageInfo.Name, baseImageInfo)
+		})
+	}
+}
+
+func testCustomizeImagePartitionsLegacy_TargetMissingPackages(t *testing.T, testName string, baseImageInfo testBaseImageInfo) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
+
+	testTmpDir := filepath.Join(tmpDir, testName)
+	defer os.RemoveAll(testTmpDir)
+
+	buildDir := filepath.Join(testTmpDir, "build")
+
+	config := imagecustomizerapi.Config{
+		Storage: imagecustomizerapi.Storage{
+			BootType: imagecustomizerapi.BootTypeLegacy,
+			Disks: []imagecustomizerapi.Disk{
+				{
+					PartitionTableType: imagecustomizerapi.PartitionTableTypeGpt,
+					MaxSize:            ptrutils.PtrTo(imagecustomizerapi.DiskSize(4 * diskutils.GiB)),
+					Partitions: []imagecustomizerapi.Partition{
+						{
+							Id:    "boot",
+							Type:  imagecustomizerapi.PartitionTypeBiosGrub,
+							Start: ptrutils.PtrTo(imagecustomizerapi.DiskSize(1 * diskutils.MiB)),
+							Size: imagecustomizerapi.PartitionSize{
+								Type: imagecustomizerapi.PartitionSizeTypeExplicit,
+								Size: 1023 * diskutils.MiB,
+							},
+						},
+						{
+							Id:    "rootfs",
+							Start: ptrutils.PtrTo(imagecustomizerapi.DiskSize(1 * diskutils.GiB)),
+							Size: imagecustomizerapi.PartitionSize{
+								Type: imagecustomizerapi.PartitionSizeTypeGrow,
+							},
+						},
+					},
+				},
+			},
+			FileSystems: []imagecustomizerapi.FileSystem{
+				{
+					DeviceId: "rootfs",
+					Type:     imagecustomizerapi.FileSystemTypeExt4,
+					MountPoint: &imagecustomizerapi.MountPoint{
+						Path: "/",
+					},
+				},
+			},
+		},
+		OS: &imagecustomizerapi.OS{
+			BootLoader: imagecustomizerapi.BootLoader{
+				ResetType: imagecustomizerapi.ResetBootLoaderTypeHard,
+			},
+		},
+	}
+
+	// Azure Linux 2.0/3.0 ship neither grub2-install nor the i386-pc modules, so they take the build host's grub
+	// fallback without any package removal.
+	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
+
+	// Capture log messages so the azl2/azl3 cases can assert that the host-grub fallback warning was emitted.
+	logSubHook := logMessagesHook.AddSubHook()
+	defer logSubHook.Close()
+
+	err := basicCustomizeImage(t.Context(), buildDir, testDir, &config, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
+
+	switch baseImageInfo.Version {
+	case baseImageVersionAzl2, baseImageVersionAzl3:
+		if !assert.NoError(t, err) {
+			return
+		}
+
+		warningSeen := false
+		expectedWarningPrefix := "Installing the legacy bootloader using the build host's"
+		for _, message := range logSubHook.ConsumeMessages() {
+			if message.Level != logrus.WarnLevel {
+				continue
+			}
+			if !strings.Contains(message.Message, expectedWarningPrefix) {
+				continue
+			}
+			assert.Contains(t, message.Message, "'grub2'", "warning doesn't mention grub2 package")
+			assert.Contains(t, message.Message, "'grub2-pc'", "warning doesn't mention grub2-pc package")
+			warningSeen = true
+			break
+		}
+
+		if !warningSeen {
+			assert.Failf(t, "missing host-grub fallback warning",
+				"expected a warning containing %q, but it was not logged", expectedWarningPrefix)
+		}
+
+		verifyLegacyBootImage(t, outImageFilePath, baseImageInfo, buildDir)
+	default:
+		assert.Failf(t, "unsupported Azure Linux version", "version %q", baseImageInfo.Version)
+	}
+}
+
 func TestCustomizeImagePartitionsLegacy(t *testing.T) {
 	// Skip this test on arm64 because the legacy bootloader is not supported.
 	if runtime.GOARCH == "arm64" {
@@ -239,6 +359,10 @@ func testCustomizeImagePartitionsLegacy(t *testing.T, testName string, baseImage
 
 	buildDir := filepath.Join(testTmpDir, "build")
 	legacybootConfigFile := filepath.Join(testDir, "legacyboot-config.yaml")
+	if baseImageInfo.Version == baseImageVersionAzl4 {
+		legacybootConfigFile = filepath.Join(testDir, "legacyboot-config-azl4.yaml")
+	}
+
 	efiConfigFile := filepath.Join(testDir, "partitions-config.yaml")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux.go
@@ -31,6 +31,8 @@ const (
 	shimPackageAzl3            = "shim"
 	grubEfiPackageAzl3         = "grub2-efi-binary"
 	grubEfiNoPrefixPackageAzl3 = "grub2-efi-binary-noprefix"
+	grubInstallPackageAzl3     = "grub2"
+	grubModulesPackageAzl3     = "grub2-pc"
 )
 
 var (
@@ -184,7 +186,8 @@ func (d *azureLinuxDistroHandler) ConfigureDiskBootLoader(imageConnection *image
 
 	return configureDiskBootLoader(imageConnection, rootMountIdType, bootType, selinuxConfig, kernelCommandLine,
 		currentSELinuxMode, forceGrubMkconfig, d, resources.AssetsGrubDefFileAzl3, installutils.FedoraGrubEnvRelPath,
-		resources.AssetsGrubStubFileAzl3, installutils.GrubStubDirsAzl3)
+		resources.AssetsGrubStubFileAzl3, installutils.GrubStubDirsAzl3, true, /*allowHostGrubInstallFallback*/
+		grubInstallPackageAzl3, grubModulesPackageAzl3)
 }
 
 func (d *azureLinuxDistroHandler) ReadGrubConfigLinuxArgs(bootDir string) (map[string][]grubConfigLinuxArg, error) {

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux4.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux4.go
@@ -207,7 +207,8 @@ func (d *azureLinux4DistroHandler) ConfigureDiskBootLoader(imageConnection *imag
 ) error {
 	return configureDiskBootLoader(imageConnection, rootMountIdType, bootType, selinuxConfig, kernelCommandLine,
 		currentSELinuxMode, true /*forceGrubMkconfig*/, d, resources.AssetsGrubDefFileAzl4,
-		installutils.FedoraGrubEnvRelPath, resources.AssetsGrubStubFileAzl4, installutils.GrubStubDirsAzl4)
+		installutils.FedoraGrubEnvRelPath, resources.AssetsGrubStubFileAzl4, installutils.GrubStubDirsAzl4,
+		false /*allowHostGrubInstallFallback*/, grubToolsPackageFedora, grubPcModulesPackageFedora)
 }
 
 func (d *azureLinux4DistroHandler) ReadGrubConfigLinuxArgs(bootDir string) (map[string][]grubConfigLinuxArg, error) {

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
@@ -29,10 +29,12 @@ type fedoraDistroHandler struct {
 }
 
 const (
-	grubEfiPackageFedoraAmd64 = "grub2-efi-x64"
-	grubEfiPackageFedoraArm64 = "grub2-efi-aa64"
-	shimPackageFedoraAmd64    = "shim-x64"
-	shimPackageFedoraArm64    = "shim-aa64"
+	grubEfiPackageFedoraAmd64  = "grub2-efi-x64"
+	grubEfiPackageFedoraArm64  = "grub2-efi-aa64"
+	shimPackageFedoraAmd64     = "shim-x64"
+	shimPackageFedoraArm64     = "shim-aa64"
+	grubToolsPackageFedora     = "grub2-tools"
+	grubPcModulesPackageFedora = "grub2-pc-modules"
 )
 
 func newFedoraDistroHandler(targetOs targetos.TargetOs) *fedoraDistroHandler {
@@ -178,7 +180,8 @@ func (d *fedoraDistroHandler) ConfigureDiskBootLoader(imageConnection *imageconn
 ) error {
 	return configureDiskBootLoader(imageConnection, rootMountIdType, bootType, selinuxConfig, kernelCommandLine,
 		currentSELinuxMode, true /* forceGrubMkconfig */, d, resources.AssetsGrubDefFileAzl4,
-		installutils.FedoraGrubEnvRelPath, resources.AssetsGrubStubFileAzl4, installutils.GrubStubDirsFedora)
+		installutils.FedoraGrubEnvRelPath, resources.AssetsGrubStubFileAzl4, installutils.GrubStubDirsFedora,
+		false /* allowHostGrubInstallFallback */, grubToolsPackageFedora, grubPcModulesPackageFedora)
 }
 
 func (d *fedoraDistroHandler) ReadGrubConfigLinuxArgs(bootDir string) (map[string][]grubConfigLinuxArg, error) {

--- a/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
@@ -253,6 +253,7 @@ func configureDiskBootLoader(imageConnection *imageconnection.ImageConnection,
 	selinuxConfig imagecustomizerapi.SELinux, kernelCommandLine imagecustomizerapi.KernelCommandLine,
 	currentSELinuxMode imagecustomizerapi.SELinuxMode, forceGrubMkconfig bool, distroHandler DistroHandler,
 	assetGrubDefFile string, grubEnvRelPath string, assetGrubStubFile string, grubStubDirs []string,
+	allowHostGrubInstallFallback bool, grubInstallPackage string, grubModulesPackage string,
 ) error {
 	imagerBootType, err := bootTypeToImager(bootType)
 	if err != nil {
@@ -293,7 +294,7 @@ func configureDiskBootLoader(imageConnection *imageconnection.ImageConnection,
 	err = installutils.ConfigureDiskBootloaderWithRootMountIdType(imagerBootType, false, imagerRootMountIdType,
 		imagerKernelCommandLine, imageConnection.Chroot(), imageConnection.Loopback().DevicePath(), mountPointMap,
 		diskutils.EncryptedRootDevice{}, useGrubMkconfig, assetGrubDefFile, grubEnvRelPath, assetGrubStubFile,
-		grubStubDirs)
+		grubStubDirs, allowHostGrubInstallFallback, grubInstallPackage, grubModulesPackage)
 	if err != nil {
 		return fmt.Errorf("failed to install bootloader:\n%w", err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/legacyboot-config-azl4.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/legacyboot-config-azl4.yaml
@@ -23,7 +23,3 @@ storage:
 os:
   bootloader:
     resetType: hard-reset
-
-  packages:
-    install:
-      - grub2-pc

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/legacyboot-reset-fallback.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/legacyboot-reset-fallback.yaml
@@ -1,0 +1,9 @@
+os:
+  bootloader:
+    resetType: hard-reset
+
+  additionalFiles:
+    # Enable DHCP client on all of the physical NICs, so the VM test can obtain
+    # an IP and connect over SSH.
+  - source: files/89-ethernet.network
+    destination: /etc/systemd/network/89-ethernet.network

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/legacyboot-reset.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/legacyboot-reset.yaml
@@ -1,0 +1,13 @@
+os:
+  bootloader:
+    resetType: hard-reset
+
+  packages:
+    install:
+      - grub2-pc
+
+  additionalFiles:
+    # Enable DHCP client on all of the physical NICs, so the VM test can obtain
+    # an IP and connect over SSH.
+  - source: files/89-ethernet.network
+    destination: /etc/systemd/network/89-ethernet.network


### PR DESCRIPTION
## Problem

Image Customizer installs the legacy (BIOS) bootloader by running `grub2-install` on the **build host**, which copies grub modules from the *host's* `grub2-pc` into the target image. When the host's grub significantly differs from the target's grub, the copied modules don't match the `grub.cfg` the target's own `grub2-mkconfig` produces, and the image fails to boot. Concretely, the AZL3-based IC container building an AZL4 image produces a disk whose `grub.cfg` does `insmod blscfg` while `/boot/grub2/i386-pc/` was populated from AZL3 (no BLS modules), so it errors with `file '.../blscfg.mod' not found` on boot.

## Fix

Install the legacy bootloader from the **target's own `grub2-install`, run inside the install chroot**, so the bootloader and its modules always come from the target. This requires the `grub2-install` command (and its `i386-pc` modules) in the target image — added via `os.packages.install`:

- Fedora, Azure Linux: `grub2-pc`
- Ubuntu: `grub2-common`

Behavior when the target does not ship them:

| Target distro version | Behavior |
|---|---|
| `grub2-install` present (any version) | Run `grub2-install` in the chroot; modules come from the target. |
| AZL2 / AZL3, not present | Fall back to the host's `grub2-install` with a **warning**. This preserves existing configs but is **deprecated** and will be removed in a future version. |
| All other distro versions, not present | Fail with a clear error directing the user to install the package. |

## Container: explicitly install `systemd-udev`

The IC container's host-side disk setup calls `udevadm settle` (`waitForDevicesToSettle`). `udevadm` is provided by the **`systemd-udev`** package, which until now arrived only transitively via `grub2`. `systemd-udev` is now listed explicitly in `imagecustomizer.Dockerfile` so `udevadm` can never silently disappear if the grub2 dependency changes.

## Testing

- **Functional:** `TestCustomizeImagePartitionsLegacy` covers the chroot path (config installs `grub2-pc`); `TestCustomizeImagePartitionsLegacy_TargetMissingPackages` removes the packages and asserts the AZL2/AZL3 host fallback still builds a valid legacy image; the AZL4 no-`grub2-pc` config asserts the error.
- **VM tests:** `test_legacy_bootloader_reset_azl{2,3,4}` boot a hard-reset legacy image built with `grub2-pc` (chroot path); `test_legacy_bootloader_reset_fallback_azl{2,3}` boot one built without it (host fallback).

## Docs

`storage.md` documents the `bootType: legacy` package requirement, the per-distro package names, and the deprecated AZL2/3 host fallback.