### PR TITLE
docs: Add Host Kernel Modules concepts page

### DIFF
--- a/docs/imagecustomizer/concepts/README.md
+++ b/docs/imagecustomizer/concepts/README.md
@@ -16,3 +16,4 @@ following scenarios:
 * ISO: Live-ISO creation. More details in [ISO Support](./iso.md)
 * PXE: Creating a PXE bootable image. More details in [PXE Support](./pxe.md)
 * Verity protected images: [Guidelines for creating a verity-protected root filesystem](./verity/verity.md)
+* Host kernel modules: [Kernel modules the host must provide](./host-kernel-modules.md)

--- a/docs/imagecustomizer/concepts/host-kernel-modules.md
+++ b/docs/imagecustomizer/concepts/host-kernel-modules.md
@@ -1,0 +1,46 @@
+---
+parent: Concepts
+title: Host Kernel Modules
+nav_order: 8
+---
+
+# Host Kernel Modules
+
+Image Customizer mounts the input disk image and its partitions on the host so
+that it can modify them offline. These mounts happen in kernel space, so the
+host kernel must provide a few modules for Image Customizer to work.
+
+This applies whether you run Image Customizer as a
+[binary](../quick-start/quick-start-binary.md) or via the
+[container image](../quick-start/quick-start.md): the container shares the
+host's kernel, so any module needed at runtime must be available on the host.
+
+## Core functionality
+
+- `loop`: Attaches disk image files as block devices via `losetup`. Used on
+  every run.
+- `ext4`: Mounts ext4 partitions. Used whenever the image has ext4 (nearly all
+  Azure Linux images).
+- `vfat`: Mounts FAT32 EFI System Partitions. Used whenever the image has UEFI
+  boot.
+- `btrfs`: Mounts btrfs partitions and subvolumes. Used only when the image
+  uses btrfs.
+- `xfs`: Mounts XFS partitions. Used only when the image uses XFS.
+
+## Verity images
+
+Required when the image has [verity](./verity/verity.md) features enabled.
+
+- `dm_mod`: Device-mapper core. Used when verity features are enabled.
+- `dm_verity`: Device-mapper verity target. Used when verity features are
+  enabled.
+
+## ISO and Live OS
+
+Required only when working with [ISO](./iso.md) or [Live OS](./liveos.md)
+images.
+
+- `squashfs`: Mounts SquashFS filesystems. Used only when building Live OS /
+  ISO images.
+- `iso9660`: Mounts ISO 9660 filesystems. Used only when re-customizing an
+  existing ISO image.

--- a/docs/imagecustomizer/quick-start/quick-start-binary.md
+++ b/docs/imagecustomizer/quick-start/quick-start-binary.md
@@ -13,6 +13,7 @@ Note: Using the [Image Customizer container](../quick-start/quick-start.md) is t
 
 - Linux host
 - Image Customizer binary downloaded. Check out [Developers Guide](../developer-guide.md) to learn how.
+- The required [host kernel modules](../concepts/host-kernel-modules.md)
 
 ## Instructions
 

--- a/docs/imagecustomizer/quick-start/quick-start.md
+++ b/docs/imagecustomizer/quick-start/quick-start.md
@@ -45,6 +45,7 @@ The container is published to both:
 
 - Linux host
 - Docker (or equivalent container engine) installed on your host
+- The required [host kernel modules](../concepts/host-kernel-modules.md) (the container shares the host's kernel)
 
 ## Instructions
 


### PR DESCRIPTION
Document the kernel modules Image Customizer requires the host kernel to provide (loop, ext4, vfat, btrfs, xfs for core functionality; dm_mod and dm_verity for verity images; squashfs and iso9660 for ISO / Live OS work).

Also adds a link to the new page from the concepts landing page and from the prerequisites section of both the container and binary quick-start guides, since the container shares the host kernel and the requirement applies to both usage paths.