### PR TITLE
VMTests: Bump paramiko to v5.

### DIFF
--- a/test/vmtests/requirements.txt
+++ b/test/vmtests/requirements.txt
@@ -1,5 +1,5 @@
 docker == 7.1.0
 libvirt-python == 12.1.0
-paramiko == 3.5.1
+paramiko == 5.0.0
 pytest == 9.0.3
 PyYAML == 6.0.3

--- a/test/vmtests/requirements/dev.txt
+++ b/test/vmtests/requirements/dev.txt
@@ -7,5 +7,7 @@ flake8 == 7.3.0
 isort == 8.0.1
 mypy == 1.19.1
 types-docker == 7.1.0.20260109
-types-paramiko == 3.5.0.20250801
+# types-paramiko for v5 isn't available yet. v4 and v5 has mostly identical APIs. (v5 is mostly just removing deprecated
+# crypto algorithms.) So, using v4 types for now is fine.
+types-paramiko == 4.0.0.20260518
 types-PyYAML == 6.0.12.20250915


### PR DESCRIPTION
paramiko v5 removes support for a bunch of deprecated crypto algorithms (e.g. DSA, SHA-1, etc.).

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
