### PR TITLE
Allow ACL image to be mounted as read-only.

### DIFF
--- a/toolkit/tools/internal/imageconnection/imageConnection.go
+++ b/toolkit/tools/internal/imageconnection/imageConnection.go
@@ -5,6 +5,8 @@ package imageconnection
 
 import (
 	"fmt"
+	"os"
+	"slices"
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safechroot"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safeloopback"
@@ -14,6 +16,7 @@ type ImageConnection struct {
 	loopback            *safeloopback.Loopback
 	chroot              *safechroot.Chroot
 	chrootIsExistingDir bool
+	ownedDirectories    []string
 }
 
 func NewImageConnection() *ImageConnection {
@@ -51,6 +54,10 @@ func (c *ImageConnection) ConnectChroot(rootDir string, isExistingDir bool, extr
 	return nil
 }
 
+func (c *ImageConnection) AddOwnedDirectories(dirs ...string) {
+	c.ownedDirectories = append(c.ownedDirectories, dirs...)
+}
+
 func (c *ImageConnection) Chroot() *safechroot.Chroot {
 	return c.chroot
 }
@@ -64,6 +71,10 @@ func (c *ImageConnection) Close() {
 		c.chroot.Close(c.chrootIsExistingDir)
 	}
 
+	for _, dir := range slices.Backward(c.ownedDirectories) {
+		os.RemoveAll(dir)
+	}
+
 	if c.loopback != nil {
 		c.loopback.Close()
 	}
@@ -73,6 +84,16 @@ func (c *ImageConnection) CleanClose() error {
 	err := c.chroot.Close(c.chrootIsExistingDir)
 	if err != nil {
 		return err
+	}
+
+	for len(c.ownedDirectories) > 0 {
+		dir := c.ownedDirectories[len(c.ownedDirectories)-1]
+		err = os.RemoveAll(dir)
+		if err != nil {
+			return fmt.Errorf("failed to remove image connection directory (%s):\n%w", dir, err)
+		}
+
+		c.ownedDirectories = c.ownedDirectories[:len(c.ownedDirectories)-1]
 	}
 
 	err = c.loopback.CleanClose()

--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -24,6 +24,11 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+var (
+	// The directories required on the root directory (/) for the default mounts.
+	DefaultMountRootDirectories = []string{"/dev", "/proc", "/sys", "/run", "/tmp"}
+)
+
 // BindMountPointFlags is a set of flags to do a bind mount.
 const BindMountPointFlags = unix.MS_BIND | unix.MS_MGC_VAL
 

--- a/toolkit/tools/internal/targetos/targetos.go
+++ b/toolkit/tools/internal/targetos/targetos.go
@@ -73,6 +73,11 @@ var (
 		VersionId: "24.04",
 		Version:   []int{24, 4},
 	}
+
+	OsReleaseFileCandidates = []string{
+		"/etc/os-release",
+		"/usr/lib/os-release",
+	}
 )
 
 func New(distroId string, versionId string) TargetOs {
@@ -86,18 +91,36 @@ func New(distroId string, versionId string) TargetOs {
 }
 
 func GetInstalledTargetOs(rootfs string) (TargetOs, error) {
-	// Try /etc/os-release first, then fall back to /usr/lib/os-release.
-	fields, err := envfile.ParseEnvFile(filepath.Join(rootfs, "etc/os-release"))
-	if err != nil {
-		if !errors.Is(err, fs.ErrNotExist) {
-			return TargetOs{}, fmt.Errorf("failed to read /etc/os-release:\n%w", err)
+	var err error
+	var fields map[string]string
+
+	found := false
+	for _, candidate := range OsReleaseFileCandidates {
+		fields, err = envfile.ParseEnvFile(filepath.Join(rootfs, candidate))
+		if errors.Is(err, fs.ErrNotExist) {
+			continue
 		}
-		fields, err = envfile.ParseEnvFile(filepath.Join(rootfs, "usr/lib/os-release"))
 		if err != nil {
-			return TargetOs{}, fmt.Errorf("failed to read os-release (tried /etc/os-release and /usr/lib/os-release):\n%w", err)
+			return TargetOs{}, fmt.Errorf("failed to read os-release file (%s):\n%w", candidate, err)
 		}
+
+		found = true
+		break
 	}
 
+	if !found {
+		return TargetOs{}, fmt.Errorf("no os-release file found (candidates=%s):\n%w", OsReleaseFileCandidates, err)
+	}
+
+	targetOs, err := GetInstalledTargetOsFromEnvFields(fields)
+	if err != nil {
+		return TargetOs{}, err
+	}
+
+	return targetOs, err
+}
+
+func GetInstalledTargetOsFromEnvFields(fields map[string]string) (TargetOs, error) {
 	distroId := fields["ID"]
 	versionId := fields["VERSION_ID"]
 

--- a/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput.go
@@ -465,8 +465,8 @@ func prepareImageConversionData(ctx context.Context, rawImageFile string, buildD
 ) ([]fstabEntryPartNum, []verityDeviceMetadata, string,
 	[]OsPackage, [randomization.UuidSize]byte, string, *CosiBootloader, []string, error,
 ) {
-	imageConnection, partitionsLayout, baseImageVerityMetadata, readonlyPartUuids, err := connectToExistingImage(
-		ctx, rawImageFile, buildDir, chrootDir, true, true, true, true, nil)
+	imageConnection, partitionsLayout, baseImageVerityMetadata, readonlyPartUuids, distroHandler, err :=
+		connectToExistingImage(ctx, rawImageFile, buildDir, chrootDir, true, true, true, true, nil)
 	if err != nil {
 		err = fmt.Errorf("%w:\n%w", ErrArtifactImageConnectionForExtraction, err)
 		return nil, nil, "", nil, [randomization.UuidSize]byte{}, "", nil, nil, err
@@ -476,11 +476,6 @@ func prepareImageConversionData(ctx context.Context, rawImageFile string, buildD
 	osRelease, err := extractOSRelease(imageConnection)
 	if err != nil {
 		return nil, nil, "", nil, [randomization.UuidSize]byte{}, "", nil, nil, err
-	}
-
-	distroHandler, err := NewDistroHandlerFromChroot(imageConnection.Chroot())
-	if err != nil {
-		return nil, nil, "", nil, [randomization.UuidSize]byte{}, "", nil, nil, fmt.Errorf("failed to detect distribution:\n%w", err)
 	}
 
 	osPackages, cosiBootMetadata, err := collectOSInfoHelper(ctx, buildDir, imageConnection, distroHandler)

--- a/toolkit/tools/pkg/imagecustomizerlib/createimagehelper.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/createimagehelper.go
@@ -28,7 +28,7 @@ func CustomizeImageHelperCreate(ctx context.Context, rc *ResolvedConfig, tarFile
 	}
 	defer toolsChroot.Close(false)
 
-	imageConnection, partitionsLayout, _, _, err := connectToExistingImage(ctx, rc.RawImageFile, toolsChrootDir,
+	imageConnection, partitionsLayout, _, _, _, err := connectToExistingImage(ctx, rc.RawImageFile, toolsChrootDir,
 		toolsRootImageDir, true, false, false, false, distroHandler)
 	if err != nil {
 		return nil, "", err

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
@@ -23,7 +23,7 @@ var (
 func customizePartitionsUsingFileCopy(ctx context.Context, buildDir string, storage imagecustomizerapi.Storage,
 	buildImageFile string, newBuildImageFile string, distroHandler DistroHandler,
 ) (map[string]string, error) {
-	existingImageConnection, _, _, _, err := connectToExistingImage(ctx, buildImageFile, buildDir, "imageroot", false,
+	existingImageConnection, _, _, _, _, err := connectToExistingImage(ctx, buildImageFile, buildDir, "imageroot", false,
 		true, false, false, distroHandler)
 	if err != nil {
 		return nil, err

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler.go
@@ -123,6 +123,9 @@ type DistroHandler interface {
 
 	// GrubEfiPackage returns the package that provides the grub EFI binary for this distro on the current architecture.
 	GrubEfiPackage() string
+
+	// Distro has a root partition that is missing placeholder directories for special mounts like /dev.
+	RootMissingMountDirectories() bool
 }
 
 // NewDistroHandler creates a distro handler directly from TargetOs

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
@@ -28,6 +28,8 @@ type aclDistroHandler struct {
 }
 
 func newAclDistroHandler(targetOs targetos.TargetOs) *aclDistroHandler {
+	logger.Log.Debugf("Distro handler: ACL (distro='%s', versionid='%s')", targetOs.Distro, targetOs.VersionId)
+
 	return &aclDistroHandler{
 		targetOs:       targetOs,
 		packageManager: newTdnfPackageManager("3.0"),
@@ -232,4 +234,8 @@ func (d *aclDistroHandler) ShimPackage() string {
 func (d *aclDistroHandler) GrubEfiPackage() string {
 	// ACL does not use grub.
 	return ""
+}
+
+func (d *aclDistroHandler) RootMissingMountDirectories() bool {
+	return true
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux.go
@@ -39,6 +39,8 @@ var (
 )
 
 func newAzureLinuxDistroHandler(targetOs targetos.TargetOs) *azureLinuxDistroHandler {
+	logger.Log.Debugf("Distro handler: Azure Linux (distro='%s', versionid='%s')", targetOs.Distro, targetOs.VersionId)
+
 	return &azureLinuxDistroHandler{
 		targetOs:       targetOs,
 		packageManager: newTdnfPackageManager(targetOs.VersionId),
@@ -209,4 +211,8 @@ func (d *azureLinuxDistroHandler) ShimPackage() string {
 
 func (d *azureLinuxDistroHandler) GrubEfiPackage() string {
 	return grubEfiPackageAzl3
+}
+
+func (d *azureLinuxDistroHandler) RootMissingMountDirectories() bool {
+	return false
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux4.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux4.go
@@ -36,6 +36,8 @@ const (
 var systemdBootPackagesAzl4 = []string{systemdBootPackage, systemdBootUnsignedPackageAzl4}
 
 func newAzureLinux4DistroHandler(targetOs targetos.TargetOs) *azureLinux4DistroHandler {
+	logger.Log.Debugf("Distro handler: Azure Linux 4+ (distro='%s', versionid='%s')", targetOs.Distro, targetOs.VersionId)
+
 	return &azureLinux4DistroHandler{
 		targetOs:       targetOs,
 		packageManager: newDnfPackageManager("4.0"),
@@ -247,4 +249,8 @@ func (d *azureLinux4DistroHandler) GrubEfiPackage() string {
 	default:
 		return grubEfiPackageFedoraArm64
 	}
+}
+
+func (d *azureLinux4DistroHandler) RootMissingMountDirectories() bool {
+	return false
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
@@ -36,6 +36,8 @@ const (
 )
 
 func newFedoraDistroHandler(targetOs targetos.TargetOs) *fedoraDistroHandler {
+	logger.Log.Debugf("Distro handler: Fedora (distro='%s', versionid='%s')", targetOs.Distro, targetOs.VersionId)
+
 	return &fedoraDistroHandler{
 		targetOs:       targetOs,
 		packageManager: newDnfPackageManager(targetOs.VersionId),
@@ -211,4 +213,8 @@ func (d *fedoraDistroHandler) GrubEfiPackage() string {
 	default:
 		return grubEfiPackageFedoraArm64
 	}
+}
+
+func (d *fedoraDistroHandler) RootMissingMountDirectories() bool {
+	return false
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_ubuntu.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_ubuntu.go
@@ -32,6 +32,8 @@ const (
 )
 
 func newUbuntuDistroHandler(targetOs targetos.TargetOs) *ubuntuDistroHandler {
+	logger.Log.Debugf("Distro handler: Ubuntu (distro='%s', versionid='%s')", targetOs.Distro, targetOs.VersionId)
+
 	return &ubuntuDistroHandler{
 		targetOs: targetOs,
 	}
@@ -217,4 +219,8 @@ func (d *ubuntuDistroHandler) GrubEfiPackage() string {
 	default:
 		return grubEfiPackageDebianArm64
 	}
+}
+
+func (d *ubuntuDistroHandler) RootMissingMountDirectories() bool {
+	return false
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -278,7 +278,8 @@ func customizeImageOptionsHelper(ctx context.Context, baseConfigPath string, con
 	}
 
 	if rc.OutputSelinuxPolicyPath != "" {
-		err = outputSelinuxPolicy(ctx, rc.OutputSelinuxPolicyPath, rc.BuildDirAbs, rc.RawImageFile, im.partitionsLayout)
+		err = outputSelinuxPolicy(ctx, rc.OutputSelinuxPolicyPath, rc.BuildDirAbs, rc.RawImageFile, im.partitionsLayout,
+			im.distroHandler)
 		if err != nil {
 			return fmt.Errorf("%w:\n%w", ErrOutputSelinuxPolicy, err)
 		}
@@ -702,7 +703,7 @@ func customizeImageHelper(ctx context.Context, rc *ResolvedConfig, partitionsCus
 
 	readOnlyVerity := rc.Storage.ReinitializeVerity != imagecustomizerapi.ReinitializeVerityTypeAll
 
-	imageConnection, partitionsLayout, baseImageVerityMetadata, readonlyPartUuids, err := connectToExistingImage(
+	imageConnection, partitionsLayout, baseImageVerityMetadata, readonlyPartUuids, _, err := connectToExistingImage(
 		ctx, rc.RawImageFile, rc.BuildDirAbs, "imageroot", true, false, readOnlyVerity, false, distroHandler)
 	if err != nil {
 		return nil, nil, nil, "", err
@@ -766,7 +767,7 @@ func collectOSInfo(ctx context.Context, buildDir string, rawImageFile string, pa
 ) ([]OsPackage, *CosiBootloader, error) {
 	var err error
 	imageConnection, _, err := reconnectToExistingImage(ctx, rawImageFile, buildDir, "imageroot", true, true, false,
-		partitionsLayout)
+		partitionsLayout, distroHandler)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -896,18 +897,13 @@ func CheckEnvironmentVars() error {
 // features enabled. Returns the detected target OS.
 func validateTargetOs(ctx context.Context, rc *ResolvedConfig,
 ) (DistroHandler, error) {
-	existingImageConnection, _, _, _, err := connectToExistingImage(ctx, rc.RawImageFile, rc.BuildDirAbs,
+	existingImageConnection, _, _, _, distroHandler, err := connectToExistingImage(ctx, rc.RawImageFile, rc.BuildDirAbs,
 		"imageroot", false /* include-default-mounts */, true, /* read-only */
 		false /* read-only-verity */, false /* ignore-overlays */, nil /* distroHandler */)
 	if err != nil {
 		return nil, err
 	}
 	defer existingImageConnection.Close()
-
-	distroHandler, err := NewDistroHandlerFromChroot(existingImageConnection.Chroot())
-	if err != nil {
-		return nil, err
-	}
 
 	err = distroHandler.ValidateConfig(rc)
 	if err != nil {

--- a/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io/fs"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -16,12 +17,15 @@ import (
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/configuration"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/installutils"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/envfile"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/file"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/imageconnection"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/logger"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safechroot"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safemount"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/shell"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/sliceutils"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/targetos"
 	"go.opentelemetry.io/otel"
 	"golang.org/x/sys/unix"
 )
@@ -31,87 +35,108 @@ type installOSFunc func(imageChroot *safechroot.Chroot) error
 func connectToExistingImage(ctx context.Context, imageFilePath string, buildDir string, chrootDirName string,
 	includeDefaultMounts bool, readonly bool, readOnlyVerity bool, ignoreOverlays bool,
 	distroHandler DistroHandler,
-) (*imageconnection.ImageConnection, []fstabEntryPartNum, []verityDeviceMetadata, []string, error) {
+) (*imageconnection.ImageConnection, []fstabEntryPartNum, []verityDeviceMetadata, []string, DistroHandler, error) {
 	_, span := otel.GetTracerProvider().Tracer(OtelTracerName).Start(ctx, "connect_to_existing_image")
 	defer span.End()
 	imageConnection := imageconnection.NewImageConnection()
 
-	partitionsLayout, verityMetadata, readonlyPartUuids, err := connectToExistingImageHelper(imageConnection,
+	partitionsLayout, verityMetadata, readonlyPartUuids, distroHandler, err := connectToExistingImageHelper(imageConnection,
 		imageFilePath, buildDir, chrootDirName, includeDefaultMounts, readonly, readOnlyVerity, ignoreOverlays,
 		distroHandler)
 	if err != nil {
 		imageConnection.Close()
-		return nil, nil, nil, nil, fmt.Errorf("failed to connect to OS image file:\n%w", err)
+		return nil, nil, nil, nil, nil, fmt.Errorf("failed to connect to OS image file:\n%w", err)
 	}
 
-	return imageConnection, partitionsLayout, verityMetadata, readonlyPartUuids, nil
+	return imageConnection, partitionsLayout, verityMetadata, readonlyPartUuids, distroHandler, nil
 }
 
 func connectToExistingImageHelper(imageConnection *imageconnection.ImageConnection, imageFilePath string,
 	buildDir string, chrootDirName string, includeDefaultMounts bool, readonly bool, readOnlyVerity bool,
 	ignoreOverlays bool, distroHandler DistroHandler,
-) ([]fstabEntryPartNum, []verityDeviceMetadata, []string, error) {
+) ([]fstabEntryPartNum, []verityDeviceMetadata, []string, DistroHandler, error) {
 	// Connect to image file using loopback device.
 	err := imageConnection.ConnectLoopback(imageFilePath)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	partitionTable, err := diskutils.ReadDiskPartitionTable(imageConnection.Loopback().DevicePath())
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to read image's partition table:\n%w", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to read image's partition table:\n%w", err)
 	}
 
 	if partitionTable == nil {
-		return nil, nil, nil, fmt.Errorf("image does not contain a partition table")
+		return nil, nil, nil, nil, fmt.Errorf("image does not contain a partition table")
 	}
 
 	partitions, err := diskutils.GetDiskPartitions(imageConnection.Loopback().DevicePath())
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
 	rootfsPartition, rootfsPath, err := findRootfsPartition(partitions, buildDir)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to find rootfs partition:\n%w", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to find rootfs partition:\n%w", err)
 	}
 
 	fstabEntries, err := readFstabEntriesFromRootfs(rootfsPartition, buildDir, rootfsPath)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to read fstab entries from rootfs partition:\n%w", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to read fstab entries from rootfs partition:\n%w", err)
 	}
 
-	partitionsLayout, verityMetadata, err := discoverPartitionLayout(fstabEntries, partitions, buildDir, ignoreOverlays,
-		rootfsPartition, rootfsPath, distroHandler)
+	partitionsLayout, verityMetadata, distroHandler, err := discoverPartitionLayout(fstabEntries, partitions, buildDir,
+		ignoreOverlays, rootfsPartition, rootfsPath, distroHandler)
 	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to discover partitions from fstab entries:\n%w", err)
+		return nil, nil, nil, nil, fmt.Errorf("failed to discover partitions from fstab entries:\n%w", err)
 	}
 
-	mountPoints, readonlyPartUuids, err := partitionLayoutToMountPoints(partitionsLayout, partitions, readonly,
-		readOnlyVerity)
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("failed to find mount info for disk:\n%w", err)
+	if distroHandler == nil {
+		// The Azure Container Linux image doesn't create empty directories for some of the standard Linux partitions,
+		// like /dev. Hence, the `ConnectChroot` call below would fail when mounting as read-only. To workaround this
+		// issue, we need to know which distro we are dealing with here, so that we can add a workaround for ACL.
+		//
+		// But for the ACL image, we could do the distro check after `ConnectChroot` and drastically simplify the code.
+		// :-(
+		targetOs, err := getInstalledTargetOsFromPartitionLayout(partitions, partitionsLayout, buildDir)
+		if err != nil {
+			return nil, nil, nil, nil, fmt.Errorf("failed to determine the target OS:\n%w", err)
+		}
+
+		distroHandler, err = NewDistroHandler(targetOs)
+		if err != nil {
+			return nil, nil, nil, nil, err
+		}
 	}
+
+	mountPoints, readonlyPartUuids, tempDirectories, err := partitionLayoutToMountPoints(partitionsLayout, partitions,
+		readonly, readOnlyVerity, distroHandler, buildDir, includeDefaultMounts)
+	if err != nil {
+		return nil, nil, nil, nil, fmt.Errorf("failed to find mount info for disk:\n%w", err)
+	}
+
+	imageConnection.AddOwnedDirectories(tempDirectories...)
 
 	// Create chroot environment.
 	imageChrootDir := filepath.Join(buildDir, chrootDirName)
 
 	err = imageConnection.ConnectChroot(imageChrootDir, false, []string(nil), mountPoints, includeDefaultMounts)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, nil, nil, err
 	}
 
-	return partitionsLayout, verityMetadata, readonlyPartUuids, nil
+	return partitionsLayout, verityMetadata, readonlyPartUuids, distroHandler, nil
 }
 
 func reconnectToExistingImage(ctx context.Context, imageFilePath string, buildDir string, chrootDirName string,
 	includeDefaultMounts bool, readonly bool, readOnlyVerity bool, partitionsLayout []fstabEntryPartNum,
+	distroHandler DistroHandler,
 ) (*imageconnection.ImageConnection, []string, error) {
 	_, span := otel.GetTracerProvider().Tracer(OtelTracerName).Start(ctx, "reconnect_to_existing_image")
 	defer span.End()
 
 	imageConnection, readonlyPartUuids, err := reconnectToExistingImageHelper(imageFilePath, buildDir,
-		chrootDirName, includeDefaultMounts, readonly, readOnlyVerity, partitionsLayout)
+		chrootDirName, includeDefaultMounts, readonly, readOnlyVerity, partitionsLayout, distroHandler)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to connect to OS image file:\n%w", err)
 	}
@@ -120,6 +145,7 @@ func reconnectToExistingImage(ctx context.Context, imageFilePath string, buildDi
 
 func reconnectToExistingImageHelper(imageFilePath string, buildDir string, chrootDirName string,
 	includeDefaultMounts bool, readonly bool, readOnlyVerity bool, partitionsLayout []fstabEntryPartNum,
+	distroHandler DistroHandler,
 ) (*imageconnection.ImageConnection, []string, error) {
 	ok := false
 
@@ -141,11 +167,13 @@ func reconnectToExistingImageHelper(imageFilePath string, buildDir string, chroo
 		return nil, nil, err
 	}
 
-	mountPoints, readonlyPartUuids, err := partitionLayoutToMountPoints(partitionsLayout, partitions, readonly,
-		readOnlyVerity)
+	mountPoints, readonlyPartUuids, tempDirectories, err := partitionLayoutToMountPoints(partitionsLayout, partitions,
+		readonly, readOnlyVerity, distroHandler, buildDir, includeDefaultMounts)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to find mount info for disk:\n%w", err)
 	}
+
+	imageConnection.AddOwnedDirectories(tempDirectories...)
 
 	// Create chroot environment.
 	imageChrootDir := filepath.Join(buildDir, chrootDirName)
@@ -351,16 +379,19 @@ func createImageBoilerplate(distroHandler DistroHandler, imageConnection *imagec
 		return nil, "", err
 	}
 
-	partitionsLayout, _, err := discoverPartitionLayout(fstabEntries, diskPartitions, buildDir, false, nil, "",
+	partitionsLayout, _, _, err := discoverPartitionLayout(fstabEntries, diskPartitions, buildDir, false, nil, "",
 		distroHandler)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to discover partitions from fstab entries:\n%w", err)
 	}
 
-	mountPoints, _, err := partitionLayoutToMountPoints(partitionsLayout, diskPartitions, false, false)
+	mountPoints, _, tempDirectories, err := partitionLayoutToMountPoints(partitionsLayout, diskPartitions, false, false,
+		distroHandler, buildDir, false)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to find mount info for disk:\n%w", err)
 	}
+
+	imageConnection.AddOwnedDirectories(tempDirectories...)
 
 	// Create chroot environment.
 	imageChrootDir := filepath.Join(buildDir, chrootDirName)
@@ -446,4 +477,78 @@ func clearBtrfsReadOnlyProperties(imageConnection *imageconnection.ImageConnecti
 	}
 
 	return nil
+}
+
+// Get the target OS from the partition layout.
+// Note: This function primarily exists as part of a workaround for the ACL image.
+// Note: This function is similar to `detectDistroFromRootfs` but `detectDistroFromRootfs` has to run pre verity
+// resolution. Whereas this function is post verity resolution. So it can also scan verity partitions, making it more
+// robust.
+func getInstalledTargetOsFromPartitionLayout(diskPartitions []diskutils.PartitionInfo,
+	partitionsLayout []fstabEntryPartNum, buildDir string,
+) (targetos.TargetOs, error) {
+	for _, candidate := range targetos.OsReleaseFileCandidates {
+		entryIndex, relativePath, found := getMostSpecificPath(candidate, slices.All(partitionsLayout),
+			func(entry fstabEntryPartNum) string { return entry.FstabEntry.Target })
+		if !found {
+			return targetos.TargetOs{}, fmt.Errorf("failed to find fstab entry for path (path='%s')", candidate)
+		}
+
+		entry := partitionsLayout[entryIndex]
+		fstabEntry := entry.FstabEntry
+
+		diskPartition, foundDiskPartition := sliceutils.FindValueFunc(diskPartitions,
+			func(diskPartition diskutils.PartitionInfo) bool {
+				return diskPartition.PartUuid == entry.PartUuid
+			})
+		if !foundDiskPartition {
+			err := fmt.Errorf("failed to find partition for fstab entry (partuuid='%s')", entry.PartUuid)
+			return targetos.TargetOs{}, err
+		}
+
+		mountDir := filepath.Join(buildDir, tmpPartitionDirName)
+
+		mount, err := safemount.NewMount(diskPartition.Path, mountDir, diskPartition.FileSystemType,
+			uintptr(fstabEntry.VfsOptions), fstabEntry.FsOptions, true /*makeAndDeleteDir*/)
+		if err != nil {
+			return targetos.TargetOs{}, err
+		}
+		defer mount.Close()
+
+		osReleasePath := filepath.Join(mountDir, relativePath)
+		osReleaseFileExists, err := file.PathExists(osReleasePath)
+		if err != nil {
+			return targetos.TargetOs{}, fmt.Errorf("failed to check if os-release file exists (path='%s):\n%w",
+				osReleasePath, err)
+		}
+
+		if !osReleaseFileExists {
+			err = mount.CleanClose()
+			if err != nil {
+				return targetos.TargetOs{}, err
+			}
+
+			continue
+		}
+
+		fields, err := envfile.ParseEnvFile(osReleasePath)
+		if err != nil {
+			return targetos.TargetOs{}, fmt.Errorf("failed to read os-relase file (path='%s):\n%w", osReleasePath,
+				err)
+		}
+
+		err = mount.CleanClose()
+		if err != nil {
+			return targetos.TargetOs{}, err
+		}
+
+		targetOs, err := targetos.GetInstalledTargetOsFromEnvFields(fields)
+		if err != nil {
+			return targetos.TargetOs{}, err
+		}
+
+		return targetOs, nil
+	}
+
+	return targetos.TargetOs{}, fmt.Errorf("failed to determine OS distro:\ncould not find os-release file")
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
@@ -518,7 +518,7 @@ func getInstalledTargetOsFromPartitionLayout(diskPartitions []diskutils.Partitio
 		osReleasePath := filepath.Join(mountDir, relativePath)
 		osReleaseFileExists, err := file.PathExists(osReleasePath)
 		if err != nil {
-			return targetos.TargetOs{}, fmt.Errorf("failed to check if os-release file exists (path='%s):\n%w",
+			return targetos.TargetOs{}, fmt.Errorf("failed to check if os-release file exists (path='%s'):\n%w",
 				osReleasePath, err)
 		}
 
@@ -533,7 +533,7 @@ func getInstalledTargetOsFromPartitionLayout(diskPartitions []diskutils.Partitio
 
 		fields, err := envfile.ParseEnvFile(osReleasePath)
 		if err != nil {
-			return targetos.TargetOs{}, fmt.Errorf("failed to read os-relase file (path='%s):\n%w", osReleasePath,
+			return targetos.TargetOs{}, fmt.Errorf("failed to read os-release file (path='%s'):\n%w", osReleasePath,
 				err)
 		}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -197,19 +197,13 @@ func createLiveOSFromRawHelper(ctx context.Context, buildDir string, inputArtifa
 	}()
 
 	logger.Log.Debugf("Connecting to raw image (%s)", rawImageFile)
-	rawImageConnection, _, _, _, err := connectToExistingImage(ctx, rawImageFile, isoBuildDir, "readonly-rootfs-mount",
+	rawImageConnection, _, _, _, distroHandler, err := connectToExistingImage(ctx, rawImageFile, isoBuildDir, "readonly-rootfs-mount",
 		false /*includeDefaultMounts*/, false /*readonly*/, false /*readonlyVerity*/, false, /*ignoreOverlays*/
 		distroHandler)
 	if err != nil {
 		return err
 	}
 	defer rawImageConnection.Close()
-
-	// Detect the distro handler for the image.
-	distroHandler, err = NewDistroHandlerFromChroot(rawImageConnection.Chroot())
-	if err != nil {
-		return fmt.Errorf("failed to detect distribution:\n%w", err)
-	}
 
 	// Check if the base image is a UKI image
 	hasUkis, err := baseImageHasUkis(rawImageConnection.Chroot(), distroHandler)

--- a/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
@@ -596,7 +596,6 @@ func partitionLayoutToMountPoints(layout []fstabEntryPartNum, diskPartitions []d
 			vfsOptions = fstabEntry.VfsOptions & ^diskutils.MountFlags(unix.MS_RDONLY|unix.MS_NOEXEC)
 		}
 
-		var mountPoint *safechroot.MountPoint
 		if fstabEntry.Target == "/" {
 			mountPoint := safechroot.NewPreDefaultsMountPoint(
 				sourcePath, fstabEntry.Target, fsType,
@@ -616,7 +615,7 @@ func partitionLayoutToMountPoints(layout []fstabEntryPartNum, diskPartitions []d
 
 			foundRoot = true
 		} else {
-			mountPoint = safechroot.NewMountPoint(
+			mountPoint := safechroot.NewMountPoint(
 				sourcePath, fstabEntry.Target, fsType,
 				uintptr(vfsOptions), fstabEntry.FsOptions)
 

--- a/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
@@ -395,7 +395,7 @@ func detectDistroFromRootfs(buildDir string, rootfsPartition *diskutils.Partitio
 	}()
 
 	mountedTargets := map[string]bool{}
-	for _, osReleasePath := range []string{"/etc/os-release", "/usr/lib/os-release"} {
+	for _, osReleasePath := range targetos.OsReleaseFileCandidates {
 		index, _, found := getMostSpecificPath(osReleasePath, slices.All(fstabEntries),
 			func(entry diskutils.FstabEntry) string { return entry.Target })
 		if !found {
@@ -473,7 +473,7 @@ func mountFstabPartitionReadonly(rootDir string, mountTarget string, mountSubdir
 func discoverPartitionLayout(fstabEntries []diskutils.FstabEntry, diskPartitions []diskutils.PartitionInfo,
 	buildDir string, ignoreOverlays bool, rootfsPartition *diskutils.PartitionInfo, rootfsPath string,
 	distroHandler DistroHandler,
-) ([]fstabEntryPartNum, []verityDeviceMetadata, error) {
+) ([]fstabEntryPartNum, []verityDeviceMetadata, DistroHandler, error) {
 	filteredFstabEntries := filterOutSpecialPartitions(fstabEntries)
 
 	// Defer reading kernel cmdline until we know it is needed.
@@ -514,7 +514,7 @@ func discoverPartitionLayout(fstabEntries []diskutils.FstabEntry, diskPartitions
 
 		_, partition, _, verityMetadata, err := findSourcePartition(fstabEntry.Source, diskPartitions, getKernelCmdline)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 
 		partUuid := ""
@@ -535,16 +535,22 @@ func discoverPartitionLayout(fstabEntries []diskutils.FstabEntry, diskPartitions
 		}
 	}
 
-	return entries, verityMetadataList, nil
+	return entries, verityMetadataList, distroHandler, nil
 }
 
 func partitionLayoutToMountPoints(layout []fstabEntryPartNum, diskPartitions []diskutils.PartitionInfo,
-	readonly bool, readOnlyVerity bool,
-) ([]*safechroot.MountPoint, []string, error) {
+	readonly bool, readOnlyVerity bool, distroHandler DistroHandler, buildDir string, includeDefaultMounts bool,
+) ([]*safechroot.MountPoint, []string, []string, error) {
 	// Convert fstab entries into mount points.
 	var mountPoints []*safechroot.MountPoint
 	var foundRoot bool
 	readonlyPartUuids := []string(nil)
+	tempDirectories := []string(nil)
+	defer func() {
+		for _, dir := range tempDirectories {
+			os.RemoveAll(dir)
+		}
+	}()
 
 	for _, entry := range layout {
 		fstabEntry := entry.FstabEntry
@@ -564,7 +570,7 @@ func partitionLayoutToMountPoints(layout []fstabEntryPartNum, diskPartitions []d
 				return entry.PartUuid == partition.PartUuid
 			})
 			if !partitionFound {
-				return nil, nil, fmt.Errorf("failed to find partition (partuuid='%s')", entry.PartUuid)
+				return nil, nil, nil, fmt.Errorf("failed to find partition (partuuid='%s')", entry.PartUuid)
 			}
 
 			readOnlyPartition = readOnlyVerity && entry.IsVerity
@@ -576,8 +582,10 @@ func partitionLayoutToMountPoints(layout []fstabEntryPartNum, diskPartitions []d
 			fsType = fstabEntry.FsType
 		}
 
+		setReadOnly := readonly || readOnlyPartition
+
 		var vfsOptions diskutils.MountFlags
-		if readonly || readOnlyPartition {
+		if setReadOnly {
 			// In scenarios where the image has completed customization (e.g. when the image is re-mounted for injection),
 			// force read-only mount. Since we're only reading data, execution and write permissions aren't needed.
 			vfsOptions = fstabEntry.VfsOptions | diskutils.MountFlags(unix.MS_RDONLY)
@@ -590,25 +598,89 @@ func partitionLayoutToMountPoints(layout []fstabEntryPartNum, diskPartitions []d
 
 		var mountPoint *safechroot.MountPoint
 		if fstabEntry.Target == "/" {
-			mountPoint = safechroot.NewPreDefaultsMountPoint(
+			mountPoint := safechroot.NewPreDefaultsMountPoint(
 				sourcePath, fstabEntry.Target, fsType,
 				uintptr(vfsOptions), fstabEntry.FsOptions)
+
+			mountPoints = append(mountPoints, mountPoint)
+
+			if setReadOnly && distroHandler.RootMissingMountDirectories() {
+				mountPoint, tempDir, err := createMountsDirOverlay(buildDir, includeDefaultMounts, layout)
+				if err != nil {
+					return nil, nil, nil, err
+				}
+
+				mountPoints = append(mountPoints, mountPoint)
+				tempDirectories = append(tempDirectories, tempDir)
+			}
 
 			foundRoot = true
 		} else {
 			mountPoint = safechroot.NewMountPoint(
 				sourcePath, fstabEntry.Target, fsType,
 				uintptr(vfsOptions), fstabEntry.FsOptions)
-		}
 
-		mountPoints = append(mountPoints, mountPoint)
+			mountPoints = append(mountPoints, mountPoint)
+		}
 	}
 
 	if !foundRoot {
-		return nil, nil, fmt.Errorf("image has invalid fstab file: no root partition found")
+		return nil, nil, nil, fmt.Errorf("image has invalid fstab file: no root partition found")
 	}
 
-	return mountPoints, readonlyPartUuids, nil
+	outTempDirectories := tempDirectories
+	tempDirectories = nil
+
+	return mountPoints, readonlyPartUuids, outTempDirectories, nil
+}
+
+func createMountsDirOverlay(buildDir string, includeDefaultMounts bool, layout []fstabEntryPartNum,
+) (*safechroot.MountPoint, string, error) {
+	// The Azure Container Linux image doesn't create empty directories for some of the standard Linux
+	// mounts (e.g. /dev) or even its own mounts (e.g. /oem). So, when mounting as read-only, we have to
+	// create these directories for it, using an overlay. :-(
+
+	ok := false
+
+	// Create a directory that contains placeholders for all the special directories.
+	mountDirsDir := filepath.Join(buildDir, "rootmountdirsdir")
+	err := os.MkdirAll(mountDirsDir, os.ModePerm)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to create mount directories directory:\n%w", err)
+	}
+	defer func() {
+		if !ok {
+			os.RemoveAll(mountDirsDir)
+		}
+	}()
+
+	mountDirs := []string(nil)
+	if includeDefaultMounts {
+		mountDirs = append(mountDirs, safechroot.DefaultMountRootDirectories...)
+	}
+
+	for _, entry := range layout {
+		targetDir := entry.FstabEntry.Target
+		if targetDir == "/" || slices.Contains(mountDirs, targetDir) {
+			continue
+		}
+
+		mountDirs = append(mountDirs, targetDir)
+	}
+
+	for _, mountDir := range mountDirs {
+		err := os.Mkdir(filepath.Join(mountDirsDir, mountDir), os.ModePerm)
+		if err != nil {
+			return nil, "", fmt.Errorf("failed to create mount directory (%s):\n%w", mountDir, err)
+		}
+	}
+
+	// Overlay the ACL root on top of the special directories directory.
+	mountPoint := safechroot.NewPreDefaultsMountPoint("overlay", "/", "overlay", unix.MS_RDONLY,
+		fmt.Sprintf("lowerdir=%s:/", mountDirsDir))
+
+	ok = true
+	return mountPoint, mountDirsDir, nil
 }
 
 func filterOutSpecialPartitions(fstabEntries []diskutils.FstabEntry) []diskutils.FstabEntry {

--- a/toolkit/tools/pkg/imagecustomizerlib/selinuxpolicyoutput.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/selinuxpolicyoutput.go
@@ -49,7 +49,7 @@ func readSelinuxType(chrootDir string) (string, error) {
 }
 
 func outputSelinuxPolicy(ctx context.Context, outputDir string, buildDir string, buildImage string,
-	partitionsLayout []fstabEntryPartNum, distroHander DistroHandler,
+	partitionsLayout []fstabEntryPartNum, distroHandler DistroHandler,
 ) error {
 	logger.Log.Infof("Extracting SELinux policy from image")
 
@@ -64,7 +64,7 @@ func outputSelinuxPolicy(ctx context.Context, outputDir string, buildDir string,
 	// Connect to the image with read-only mounts.
 	// Use connectToExistingImage which automatically mounts all partitions based on fstab.
 	imageConnection, _, err := reconnectToExistingImage(ctx, buildImage, buildDir, "selinux-extract",
-		false /*includeDefaultMounts*/, true /*readonly*/, true /*readOnlyVerity*/, partitionsLayout, distroHander)
+		false /*includeDefaultMounts*/, true /*readonly*/, true /*readOnlyVerity*/, partitionsLayout, distroHandler)
 	if err != nil {
 		return fmt.Errorf("%w:\n%w", ErrSelinuxPolicyImageConnection, err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/selinuxpolicyoutput.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/selinuxpolicyoutput.go
@@ -49,7 +49,7 @@ func readSelinuxType(chrootDir string) (string, error) {
 }
 
 func outputSelinuxPolicy(ctx context.Context, outputDir string, buildDir string, buildImage string,
-	partitionsLayout []fstabEntryPartNum,
+	partitionsLayout []fstabEntryPartNum, distroHander DistroHandler,
 ) error {
 	logger.Log.Infof("Extracting SELinux policy from image")
 
@@ -64,7 +64,7 @@ func outputSelinuxPolicy(ctx context.Context, outputDir string, buildDir string,
 	// Connect to the image with read-only mounts.
 	// Use connectToExistingImage which automatically mounts all partitions based on fstab.
 	imageConnection, _, err := reconnectToExistingImage(ctx, buildImage, buildDir, "selinux-extract",
-		false /*includeDefaultMounts*/, true /*readonly*/, true /*readOnlyVerity*/, partitionsLayout)
+		false /*includeDefaultMounts*/, true /*readonly*/, true /*readOnlyVerity*/, partitionsLayout, distroHander)
 	if err != nil {
 		return fmt.Errorf("%w:\n%w", ErrSelinuxPolicyImageConnection, err)
 	}


### PR DESCRIPTION
The ACL image doesn't include placeholder directories for the standard linux directories (e.g. /dev) or even its own mounts (e.g. /oem). This causes problems for IC when mounting the ACL as read-only because some of the directories are missing for the mounts.

To workaround this issue, an overlay is used to create the placeholder directories underneath the root partition. That way, IC has directories it can attach the mounts to.

To facilitate this workaround, IC needs to know what the target distro is earlier in the process: in-between partition discovery and mounting.

Also, the DistroHandler instance is now passed between more components, instead of being (re-)discovered in multiple places.

Also, ensure there is a single place where all the potential `os-release` paths are listed.

Also, log when a DistroHandler instance is created and which one. This could help with debugging issues relating to the picked DistroHandler implementation.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
