### PR TITLE
Remove --base-image-bare-metal-azl2/3 from functional tests.

### DIFF
--- a/docs/imagecustomizer/developer-guide.md
+++ b/docs/imagecustomizer/developer-guide.md
@@ -42,8 +42,6 @@ sudo go test -C ./toolkit/tools ./...
    - [Azure Linux 2.0 core-efi](https://github.com/microsoft/azurelinux/blob/2.0/toolkit/imageconfigs/core-efi.json)
    - [Azure Linux 3.0 core-efi](https://github.com/microsoft/azurelinux/blob/3.0/toolkit/imageconfigs/core-efi.json)
    - Azure Linux 4.0 core-efi
-   - [Azure Linux 2.0 core-legacy](https://github.com/microsoft/azurelinux/blob/2.0/toolkit/imageconfigs/core-legacy.json)
-   - [Azure Linux 3.0 core-legacy](https://github.com/microsoft/azurelinux/blob/3.0/toolkit/imageconfigs/core-legacy.json)
    - [Ubuntu 22.04 Azure cloud](https://cloud-images.ubuntu.com/releases/22.04/release/) (download the `*-azure.vhd.tar.gz` and extract)
    - [Ubuntu 24.04 Azure cloud](https://cloud-images.ubuntu.com/releases/24.04/release/) (download the `*-azure.vhd.tar.gz` and extract)
 
@@ -59,8 +57,6 @@ sudo go test -C ./toolkit/tools ./...
    AZURE_LINUX_2_CORE_EFI_VHDX="<core-efi-2.0.vhdx>"
    AZURE_LINUX_3_CORE_EFI_VHDX="<core-efi-3.0.vhdx>"
    AZURE_LINUX_4_CORE_EFI_VHDX="<core-efi-4.0.vhdx>"
-   AZURE_LINUX_2_CORE_LEGACY_VHD="<core-legacy-2.0.vhd>"
-   AZURE_LINUX_3_CORE_LEGACY_VHD="<core-legacy-3.0.vhd>"
    UBUNTU_2204_AZURE_CLOUD_VHD="<ubuntu-22.04-azure-cloud.vhd>"
    UBUNTU_2404_AZURE_CLOUD_VHD="<ubuntu-24.04-azure-cloud.vhd>"
 
@@ -68,8 +64,6 @@ sudo go test -C ./toolkit/tools ./...
      --base-image-core-efi-azl2 "$AZURE_LINUX_2_CORE_EFI_VHDX" \
      --base-image-core-efi-azl3 "$AZURE_LINUX_3_CORE_EFI_VHDX" \
      --base-image-core-efi-azl4 "$AZURE_LINUX_4_CORE_EFI_VHDX" \
-     --base-image-bare-metal-azl2 "$AZURE_LINUX_2_CORE_LEGACY_VHD" \
-     --base-image-bare-metal-azl3 "$AZURE_LINUX_3_CORE_LEGACY_VHD" \
      --base-image-azure-cloud-ubuntu2204 "$UBUNTU_2204_AZURE_CLOUD_VHD" \
      --base-image-azure-cloud-ubuntu2404 "$UBUNTU_2404_AZURE_CLOUD_VHD"
    ```

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
@@ -551,7 +551,7 @@ func installPackageDiskSpaceConfigFile(t *testing.T, baseImageInfo testBaseImage
 }
 
 func TestCustomizeImagePackagesUrlSource(t *testing.T) {
-	for _, baseImageInfo := range baseImageAzureLinuxCoreEfiAll {
+	for _, baseImageInfo := range baseImageAzureLinux3Plus {
 		t.Run(baseImageInfo.Name, func(t *testing.T) {
 			testCustomizeImagePackagesUrlSourceHelper(t, baseImageInfo)
 		})
@@ -612,7 +612,7 @@ func testCustomizeImagePackagesUrlSourceHelper(t *testing.T, baseImageInfo testB
 
 // Test RPM repo that uses a GPG different from the default.
 func TestCustomizeImagePackagesNewGpgKey(t *testing.T) {
-	for _, baseImageInfo := range baseImageAzureLinuxCoreEfiAll {
+	for _, baseImageInfo := range baseImageAzureLinux3Plus {
 		t.Run(baseImageInfo.Name, func(t *testing.T) {
 			testCustomizeImagePackagesNewGpgKeyHelper(t, baseImageInfo)
 		})
@@ -660,7 +660,7 @@ func testCustomizeImagePackagesNewGpgKeyHelper(t *testing.T, baseImageInfo testB
 }
 
 func TestCustomizeImagePackagesBadRepo(t *testing.T) {
-	for _, baseImageInfo := range baseImageAzureLinuxCoreEfiAll {
+	for _, baseImageInfo := range baseImageAzureLinux3Plus {
 		t.Run(baseImageInfo.Name, func(t *testing.T) {
 			testCustomizeImagePackagesBadRepoHelper(t, baseImageInfo)
 		})
@@ -730,7 +730,7 @@ func ensureRpmCacheCleanup(t *testing.T, imageConnection *imageconnection.ImageC
 }
 
 func TestCustomizeImagePackagesSnapshotTime(t *testing.T) {
-	for _, baseImageInfo := range baseImageAzureLinuxCoreEfiAll {
+	for _, baseImageInfo := range baseImageAzureLinux3Plus {
 		t.Run(baseImageInfo.Name, func(t *testing.T) {
 			testCustomizeImagePackagesSnapshotTimeHelper(t, baseImageInfo)
 		})
@@ -795,7 +795,7 @@ func testCustomizeImagePackagesSnapshotTimeHelper(t *testing.T, baseImageInfo te
 }
 
 func TestCustomizeImagePackagesCliSnapshotTimeOverridesConfigFile(t *testing.T) {
-	for _, baseImageInfo := range baseImageAzureLinuxCoreEfiAll {
+	for _, baseImageInfo := range baseImageAzureLinux3Plus {
 		t.Run(baseImageInfo.Name, func(t *testing.T) {
 			testCustomizeImagePackagesCliSnapshotTimeOverridesConfigFileHelper(t, baseImageInfo)
 		})
@@ -867,7 +867,7 @@ func testCustomizeImagePackagesCliSnapshotTimeOverridesConfigFileHelper(t *testi
 }
 
 func TestCustomizeImagePackagesSnapshotTimeWithoutPreviewFlagFails(t *testing.T) {
-	for _, baseImageInfo := range baseImageAzureLinuxCoreEfiAll {
+	for _, baseImageInfo := range baseImageAzureLinux3Plus {
 		t.Run(baseImageInfo.Name, func(t *testing.T) {
 			testCustomizeImagePackagesSnapshotTimeWithoutPreviewFlagFailsHelper(t, baseImageInfo)
 		})

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeselinux_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeselinux_test.go
@@ -188,12 +188,7 @@ func TestCustomizeImageSELinuxNoPolicy(t *testing.T) {
 
 	buildDir := filepath.Join(testTmpDir, "build")
 	outImageFilePath := filepath.Join(testTmpDir, "image.qcow2")
-
-	configFile := ""
-	switch baseImageInfo.Variant {
-	case baseImageAzureLinuxVariantCoreEfi:
-		configFile = filepath.Join(testDir, "selinux-enforcing-nopackages.yaml")
-	}
+	configFile := filepath.Join(testDir, "selinux-enforcing-nopackages.yaml")
 
 	// Customize image.
 	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeselinux_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeselinux_test.go
@@ -193,13 +193,9 @@ func TestCustomizeImageSELinuxNoPolicy(t *testing.T) {
 	// Customize image.
 	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
 		baseImageInfo.PreviewFeatures)
-
-	switch baseImageInfo.Variant {
-	case baseImageAzureLinuxVariantCoreEfi:
-		assert.ErrorContains(t, err, "SELinux is enabled but policy file is missing (file='/etc/selinux/config')")
-		assert.ErrorContains(t, err, "please ensure an SELinux policy is installed")
-		assert.ErrorContains(t, err, "the 'selinux-policy' package provides the default policy")
-	}
+	assert.ErrorContains(t, err, "SELinux is enabled but policy file is missing (file='/etc/selinux/config')")
+	assert.ErrorContains(t, err, "please ensure an SELinux policy is installed")
+	assert.ErrorContains(t, err, "the 'selinux-policy' package provides the default policy")
 }
 
 func verifyKernelCommandLine(t *testing.T, imageConnection *imageconnection.ImageConnection, hasUkis bool,

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeselinux_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeselinux_test.go
@@ -193,8 +193,6 @@ func TestCustomizeImageSELinuxNoPolicy(t *testing.T) {
 	switch baseImageInfo.Variant {
 	case baseImageAzureLinuxVariantCoreEfi:
 		configFile = filepath.Join(testDir, "selinux-enforcing-nopackages.yaml")
-	case baseImageAzureLinuxVariantBareMetal:
-		configFile = filepath.Join(testDir, "selinux-enforcing-removepackages.yaml")
 	}
 
 	// Customize image.
@@ -206,11 +204,6 @@ func TestCustomizeImageSELinuxNoPolicy(t *testing.T) {
 		assert.ErrorContains(t, err, "SELinux is enabled but policy file is missing (file='/etc/selinux/config')")
 		assert.ErrorContains(t, err, "please ensure an SELinux policy is installed")
 		assert.ErrorContains(t, err, "the 'selinux-policy' package provides the default policy")
-
-	case baseImageAzureLinuxVariantBareMetal:
-		// The /etc/selinux/config file survives the removal of the selinux-policy package.
-		// So, the error is different.
-		assert.ErrorContains(t, err, "etc/selinux/targeted/contexts/files/file_contexts: No such file or directory")
 	}
 }
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestCustomizeImageVerityUsrUki(t *testing.T) {
-	for _, baseImageInfo := range baseImageAzureLinuxCoreEfiAll {
+	for _, baseImageInfo := range baseImageAzureLinux3Plus {
 		t.Run(baseImageInfo.Name, func(t *testing.T) {
 			testCustomizeImageVerityUsrUkiHelper(t, baseImageInfo)
 		})
@@ -67,7 +67,7 @@ func testCustomizeImageVerityUsrUkiHelper(t *testing.T, baseImageInfo testBaseIm
 }
 
 func TestCustomizeImageVerityUsrUkiRecustomize(t *testing.T) {
-	for _, baseImageInfo := range baseImageAzureLinuxCoreEfiAll {
+	for _, baseImageInfo := range baseImageAzureLinux3Plus {
 		t.Run(baseImageInfo.Name, func(t *testing.T) {
 			testCustomizeImageVerityUsrUkiRecustomizeHelper(t, baseImageInfo)
 		})
@@ -178,7 +178,7 @@ func testCustomizeImageVerityUsrUkiRecustomizeHelper(t *testing.T, baseImageInfo
 }
 
 func TestCustomizeImageVerityUsrUkiPassthrough(t *testing.T) {
-	for _, baseImageInfo := range baseImageAzureLinuxCoreEfiAll {
+	for _, baseImageInfo := range baseImageAzureLinux3Plus {
 		t.Run(baseImageInfo.Name, func(t *testing.T) {
 			testCustomizeImageVerityUsrUkiPassthroughHelper(t, baseImageInfo)
 		})
@@ -237,7 +237,7 @@ func testCustomizeImageVerityUsrUkiPassthroughHelper(t *testing.T, baseImageInfo
 }
 
 func TestCustomizeImageVerityRootUki(t *testing.T) {
-	for _, baseImageInfo := range baseImageAzureLinuxCoreEfiAll {
+	for _, baseImageInfo := range baseImageAzureLinux3Plus {
 		t.Run(baseImageInfo.Name, func(t *testing.T) {
 			testCustomizeImageVerityRootUkiHelper(t, baseImageInfo)
 		})

--- a/toolkit/tools/pkg/imagecustomizerlib/main_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/main_test.go
@@ -30,8 +30,7 @@ const (
 	baseImageVersionUbuntu2404 = "24.04"
 
 	// Azure Linux variants
-	baseImageAzureLinuxVariantCoreEfi   = "core-efi"
-	baseImageAzureLinuxVariantBareMetal = "bare-metal"
+	baseImageAzureLinuxVariantCoreEfi = "core-efi"
 
 	// Ubuntu variants
 	baseImageVariantUbuntuAzureCloud = "azure-cloud"
@@ -45,8 +44,6 @@ const (
 	paramBaseImageAzl2CoreEfi          = "base-image-core-efi-azl2"
 	paramBaseImageAzl3CoreEfi          = "base-image-core-efi-azl3"
 	paramBaseImageAzl4CoreEfi          = "base-image-core-efi-azl4"
-	paramBaseImageAzl2BareMetal        = "base-image-bare-metal-azl2"
-	paramBaseImageAzl3BareMetal        = "base-image-bare-metal-azl3"
 	paramBaseImageUbuntu2204AzureCloud = "base-image-azure-cloud-ubuntu2204"
 	paramBaseImageUbuntu2404AzureCloud = "base-image-azure-cloud-ubuntu2404"
 	paramLogLevel                      = "log-level"
@@ -132,28 +129,6 @@ var (
 		DefaultShell: defaultShellAzureLinux,
 	}
 
-	testBaseImageAzl2BareMetal = testBaseImageInfo{
-		Name:         "AzureLinux2BareMetal",
-		Distro:       baseImageDistroAzureLinux,
-		Version:      baseImageVersionAzl2,
-		Variant:      baseImageAzureLinuxVariantBareMetal,
-		ParamName:    paramBaseImageAzl2BareMetal,
-		Param:        baseImageBareMetalAzl2,
-		MountPoints:  azureLinuxCoreLegacyMountPoints,
-		DefaultShell: defaultShellAzureLinux,
-	}
-
-	testBaseImageAzl3BareMetal = testBaseImageInfo{
-		Name:         "AzureLinux3BareMetal",
-		Distro:       baseImageDistroAzureLinux,
-		Version:      baseImageVersionAzl3,
-		Variant:      baseImageAzureLinuxVariantBareMetal,
-		ParamName:    paramBaseImageAzl3BareMetal,
-		Param:        baseImageBareMetalAzl3,
-		MountPoints:  azureLinuxCoreLegacyMountPoints,
-		DefaultShell: defaultShellAzureLinux,
-	}
-
 	testBaseImageUbuntu2204AzureCloud = testBaseImageInfo{
 		Name:         "Ubuntu2204AzureCloud",
 		Distro:       baseImageDistroUbuntu,
@@ -186,8 +161,6 @@ var (
 		testBaseImageAzl2CoreEfi,
 		testBaseImageAzl3CoreEfi,
 		testBaseImageAzl4CoreEfi,
-		testBaseImageAzl2BareMetal,
-		testBaseImageAzl3BareMetal,
 	}
 
 	baseImageAzureLinuxCoreEfiAll = []testBaseImageInfo{
@@ -202,11 +175,9 @@ var (
 
 	defaultAzureLinuxPriorityList = []testBaseImageInfo{
 		testBaseImageAzl3CoreEfi,
-		testBaseImageAzl3BareMetal,
 		// AZL4 is still in preview. So, prefer AZL3 until AZL4 has its first official release.
 		testBaseImageAzl4CoreEfi,
 		testBaseImageAzl2CoreEfi,
-		testBaseImageAzl2BareMetal,
 	}
 )
 
@@ -214,8 +185,6 @@ var (
 	baseImageCoreEfiAzl2          = flag.String(paramBaseImageAzl2CoreEfi, "", "An Azure Linux 2.0 core-efi image to use as a base image.")
 	baseImageCoreEfiAzl3          = flag.String(paramBaseImageAzl3CoreEfi, "", "An Azure Linux 3.0 core-efi image to use as a base image.")
 	baseImageCoreEfiAzl4          = flag.String(paramBaseImageAzl4CoreEfi, "", "An Azure Linux 4.0 core-efi image to use as a base image.")
-	baseImageBareMetalAzl2        = flag.String(paramBaseImageAzl2BareMetal, "", "An Azure Linux 2.0 bare-metal image to use as a base image.")
-	baseImageBareMetalAzl3        = flag.String(paramBaseImageAzl3BareMetal, "", "An Azure Linux 3.0 bare-metal image to use as a base image.")
 	baseImageUbuntuAzureCloud2204 = flag.String(paramBaseImageUbuntu2204AzureCloud, "", "An Ubuntu 22.04 Azure cloud image to use as a base image.")
 	baseImageUbuntuAzureCloud2404 = flag.String(paramBaseImageUbuntu2404AzureCloud, "", "An Ubuntu 24.04 Azure cloud image to use as a base image.")
 	logLevel                      = flag.String(paramLogLevel, "info", "The log level (error, warning, info, debug, or trace)")

--- a/toolkit/tools/pkg/imagecustomizerlib/main_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/main_test.go
@@ -163,7 +163,7 @@ var (
 		testBaseImageAzl4CoreEfi,
 	}
 
-	baseImageAzureLinuxCoreEfiAll = []testBaseImageInfo{
+	baseImageAzureLinux3Plus = []testBaseImageInfo{
 		testBaseImageAzl3CoreEfi,
 		testBaseImageAzl4CoreEfi,
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/selinux-enforcing-removepackages.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/selinux-enforcing-removepackages.yaml
@@ -1,7 +1,0 @@
-os:
-  selinux:
-    mode: enforcing
-
-  packages:
-    remove:
-    - selinux-policy


### PR DESCRIPTION
In the functional tests, the `--base-image-bare-metal-azl2` and `--base-image-bare-metal-azl3` params aren't being used. So, remove them.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
