### PR TITLE
Refactor CustomizeImage functions.

### DIFF
--- a/toolkit/tools/imagecustomizer/main.go
+++ b/toolkit/tools/imagecustomizer/main.go
@@ -166,7 +166,7 @@ func runCommand(ctx context.Context, command string, cli *RootCmd) error {
 }
 
 func customizeImage(ctx context.Context, cmd CustomizeCmd) error {
-	err := imagecustomizerlib.CustomizeImageWithConfigFileOptions(ctx, cmd.ConfigFile,
+	err := imagecustomizerlib.CustomizeImageWithConfigFile(ctx, cmd.ConfigFile,
 		imagecustomizerlib.ImageCustomizerOptions{
 			BuildDir:                cmd.BuildDir,
 			InputImageFile:          cmd.InputImageFile,

--- a/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput_test.go
@@ -49,8 +49,8 @@ func TestOutputAndInjectArtifacts(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Customize image
-	err = CustomizeImageWithConfigFile(t.Context(), buildDirCustomize, configFile, baseImage, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDirCustomize, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -157,8 +157,8 @@ func TestOutputAndInjectArtifactsCosi(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Customize image.
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/baseconfigs_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/baseconfigs_test.go
@@ -83,8 +83,8 @@ func TestBaseConfigsFullRun(t *testing.T) {
 
 	currentConfigFile := filepath.Join(testDir, hierarchicalConfigFile(t, baseImageInfo))
 
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, currentConfigFile, baseImage, nil,
-		outImageFilePath, "raw", true, "")
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, currentConfigFile, baseImage,
+		outImageFilePath, "raw", baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -297,7 +297,7 @@ func hierarchicalConfigFile(t *testing.T, baseImageInfo testBaseImageInfo) strin
 }
 
 func TestBaseConfigsStorageInBaseConfig(t *testing.T) {
-	baseImage, _ := checkSkipForCustomizeDefaultAzureLinuxImage(t)
+	baseImage, baseImageInfo := checkSkipForCustomizeDefaultAzureLinuxImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestBaseConfigsStorageInBaseConfig")
 	defer os.RemoveAll(testTmpDir)
@@ -307,7 +307,7 @@ func TestBaseConfigsStorageInBaseConfig(t *testing.T) {
 
 	currentConfigFile := filepath.Join(testDir, "storage-in-base-config.yaml")
 
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, currentConfigFile, baseImage, nil,
-		outImageFilePath, "raw", true, "")
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, currentConfigFile, baseImage,
+		outImageFilePath, "raw", baseImageInfo.PreviewFeatures)
 	assert.ErrorIs(t, err, ErrStorageInBaseConfig)
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/convertimage_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/convertimage_test.go
@@ -112,7 +112,7 @@ func testConvertImageRawToCosi(t *testing.T, baseImageInfo testBaseImageInfo) {
 	customizedImage := filepath.Join(testTempDir, "customized.raw")
 	configFile := filepath.Join(testDir, "verity-config.yaml")
 
-	err = CustomizeImageWithConfigFileOptions(t.Context(), configFile, ImageCustomizerOptions{
+	err = CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
 		BuildDir:             buildDir,
 		InputImageFile:       baseImage,
 		OutputImageFile:      customizedImage,
@@ -186,7 +186,7 @@ func testConvertImageRawToCosiWithCompression(t *testing.T, baseImageInfo testBa
 	customizedImage := filepath.Join(testTempDir, "customized.raw")
 	configFile := filepath.Join(testDir, "verity-config.yaml")
 
-	err = CustomizeImageWithConfigFileOptions(t.Context(), configFile, ImageCustomizerOptions{
+	err = CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
 		BuildDir:             buildDir,
 		InputImageFile:       baseImage,
 		OutputImageFile:      customizedImage,

--- a/toolkit/tools/pkg/imagecustomizerlib/createimage_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/createimage_test.go
@@ -65,9 +65,13 @@ func testCreateImageRaw(t *testing.T, name string, version string, configFile st
 	assert.Equal(t, expectedVirtualSize, imageInfo.VirtualSize)
 
 	// Customize image to vhd.
-	err = CustomizeImageWithConfigFile(
-		t.Context(), buildDir, noChangeConfigFile, outputImageFilePath, rpmSources,
-		vhdFixedImageFilePath, "vhd", false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = CustomizeImageWithConfigFile(t.Context(), noChangeConfigFile, ImageCustomizerOptions{
+		BuildDir:          buildDir,
+		InputImageFile:    outputImageFilePath,
+		RpmsSources:       rpmSources,
+		OutputImageFile:   vhdFixedImageFilePath,
+		OutputImageFormat: "vhd",
+	})
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizebootloader_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizebootloader_test.go
@@ -48,8 +48,8 @@ func testCustomizeImageMultiKernel(t *testing.T, testName string, baseImageInfo 
 	}
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizefiles_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizefiles_test.go
@@ -95,7 +95,7 @@ func testCustomizeImageAdditionalFiles(t *testing.T, baseImageInfo testBaseImage
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFileOptions(t.Context(), configFile, ImageCustomizerOptions{
+	err := CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
 		BuildDir:             buildDir,
 		InputImageFile:       baseImage,
 		OutputImageFile:      outImageFilePath,
@@ -143,7 +143,7 @@ func verifyAddFiles(t *testing.T, buildDir string, outImageFilePath string, base
 }
 
 func TestCustomizeImageAdditionalFilesInfiniteFile(t *testing.T) {
-	baseImage, _ := checkSkipForCustomizeDefaultAzureLinuxImage(t)
+	baseImage, baseImageInfo := checkSkipForCustomizeDefaultAzureLinuxImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageAdditionalFilesInfiniteFile")
 	defer os.RemoveAll(testTmpDir)
@@ -153,8 +153,8 @@ func TestCustomizeImageAdditionalFilesInfiniteFile(t *testing.T) {
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	assert.ErrorContains(t, err, "failed to copy (/dev/zero)")
 	assert.ErrorContains(t, err, "no space left on device")
 }
@@ -242,7 +242,7 @@ func testCustomizeImageAdditionalDirs(t *testing.T, baseImageInfo testBaseImageI
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFileOptions(t.Context(), configFile, ImageCustomizerOptions{
+	err := CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
 		BuildDir:             buildDir,
 		InputImageFile:       baseImage,
 		OutputImageFile:      outImageFilePath,
@@ -273,7 +273,7 @@ func verifyAddDirs(t *testing.T, baseImageInfo testBaseImageInfo, buildDir strin
 }
 
 func TestCustomizeImageAdditionalDirsInfiniteFile(t *testing.T) {
-	baseImage, _ := checkSkipForCustomizeDefaultAzureLinuxImage(t)
+	baseImage, baseImageInfo := checkSkipForCustomizeDefaultAzureLinuxImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageAdditionalDirsInfiniteFile")
 	defer os.RemoveAll(testTmpDir)
@@ -310,8 +310,8 @@ func TestCustomizeImageAdditionalDirsInfiniteFile(t *testing.T) {
 	}
 
 	// Customize image.
-	err = CustomizeImage(t.Context(), buildDir, testTmpDir, &config, baseImage, nil, outImageFilePath, "raw",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImage(t.Context(), buildDir, testTmpDir, &config, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	assert.ErrorContains(t, err, "failed to copy directory")
 	assert.ErrorContains(t, err, "failed to copy file")
 	assert.ErrorContains(t, err, "no space left on device")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizegroups_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizegroups_test.go
@@ -33,7 +33,7 @@ func testCustomizeImageGroupsExistingGid(t *testing.T, baseImageInfo testBaseIma
 	configFile := filepath.Join(testDir, "user-group-root-gid.yaml")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFileOptions(t.Context(), configFile, ImageCustomizerOptions{
+	err := CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
 		BuildDir:             buildDir,
 		InputImageFile:       baseImage,
 		OutputImageFile:      outImageFilePath,
@@ -63,7 +63,7 @@ func testCustomizeImageGroupsNewGid(t *testing.T, baseImageInfo testBaseImageInf
 	configFile := filepath.Join(testDir, "user-group-new-gid.yaml")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFileOptions(t.Context(), configFile, ImageCustomizerOptions{
+	err := CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
 		BuildDir:             buildDir,
 		InputImageFile:       baseImage,
 		OutputImageFile:      outImageFilePath,
@@ -112,7 +112,7 @@ func testCustomizeImageGroupsNew(t *testing.T, baseImageInfo testBaseImageInfo) 
 	configFile := filepath.Join(testDir, "user-group-new.yaml")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFileOptions(t.Context(), configFile, ImageCustomizerOptions{
+	err := CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
 		BuildDir:             buildDir,
 		InputImageFile:       baseImage,
 		OutputImageFile:      outImageFilePath,

--- a/toolkit/tools/pkg/imagecustomizerlib/customizehostname_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizehostname_test.go
@@ -62,7 +62,7 @@ func testCustomizeImageHostname(t *testing.T, baseImageInfo testBaseImageInfo) {
 	outImageFilePath := filepath.Join(buildDir, "image.qcow2")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFileOptions(t.Context(), configFile, ImageCustomizerOptions{
+	err := CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
 		BuildDir:             buildDir,
 		InputImageFile:       baseImage,
 		OutputImageFile:      outImageFilePath,

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeoverlays_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeoverlays_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func TestCustomizeImageOverlays(t *testing.T) {
-	baseImage, _ := checkSkipForCustomizeDefaultAzureLinuxImage(t)
+	baseImage, baseImageInfo := checkSkipForCustomizeDefaultAzureLinuxImage(t)
 
 	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageOverlays")
 	defer os.RemoveAll(testTempDir)
@@ -27,8 +27,8 @@ func TestCustomizeImageOverlays(t *testing.T) {
 	configFile := filepath.Join(testDir, "overlays-config.yaml")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -101,8 +101,8 @@ func testCustomizeImageOverlaysSELinuxHelper(t *testing.T, baseImageInfo testBas
 	configFile := filepath.Join(testDir, overlaysSELinuxConfigFile(t, baseImageInfo))
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
@@ -211,6 +211,9 @@ func testCustomizeImagePackagesAddOfflineLocalRepoHelper(t *testing.T, testName 
 		UseBaseImageRpmRepos: false,
 		PreviewFeatures:      baseImageInfo.PreviewFeatures,
 	})
+	if !assert.NoError(t, err) {
+		return
+	}
 
 	imageConnection, err := connectToAzureLinuxCoreEfiImage(buildDir, outImageFilePath)
 	if !assert.NoError(t, err) {

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
@@ -58,8 +58,15 @@ func TestCustomizeImagePackagesAddOfflineDir(t *testing.T) {
 		},
 	}
 
-	err = CustomizeImage(t.Context(), buildDir, testDir, &config, baseImage, []string{downloadedRpmsTmpDir}, outImageFilePath,
-		"raw", false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = CustomizeImage(t.Context(), testDir, &config, ImageCustomizerOptions{
+		BuildDir:             buildDir,
+		InputImageFile:       baseImage,
+		RpmsSources:          []string{downloadedRpmsTmpDir},
+		OutputImageFile:      outImageFilePath,
+		OutputImageFormat:    "raw",
+		UseBaseImageRpmRepos: false,
+		PreviewFeatures:      baseImageInfo.PreviewFeatures,
+	})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -108,8 +115,15 @@ func TestCustomizeImagePackagesAddOfflineDir(t *testing.T) {
 		},
 	}
 
-	err = CustomizeImage(t.Context(), buildDir, testDir, &config, outImageFilePath, []string{downloadedRpmsTmpDir}, outImageFilePath,
-		"raw", false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = CustomizeImage(t.Context(), testDir, &config, ImageCustomizerOptions{
+		BuildDir:             buildDir,
+		InputImageFile:       outImageFilePath,
+		RpmsSources:          []string{downloadedRpmsTmpDir},
+		OutputImageFile:      outImageFilePath,
+		OutputImageFormat:    "raw",
+		UseBaseImageRpmRepos: false,
+		PreviewFeatures:      baseImageInfo.PreviewFeatures,
+	})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -188,11 +202,15 @@ func testCustomizeImagePackagesAddOfflineLocalRepoHelper(t *testing.T, testName 
 	configFile := filepath.Join(testDir, packagesAddConfigFile(t, baseImageInfo))
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, rpmSources, outImageFilePath, "raw",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
-	if !assert.NoError(t, err) {
-		return
-	}
+	err := CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
+		BuildDir:             buildDir,
+		InputImageFile:       baseImage,
+		RpmsSources:          rpmSources,
+		OutputImageFile:      outImageFilePath,
+		OutputImageFormat:    "raw",
+		UseBaseImageRpmRepos: false,
+		PreviewFeatures:      baseImageInfo.PreviewFeatures,
+	})
 
 	imageConnection, err := connectToAzureLinuxCoreEfiImage(buildDir, outImageFilePath)
 	if !assert.NoError(t, err) {
@@ -245,7 +263,7 @@ func testCustomizeImagePackagesUpdateAfterInstall(t *testing.T, baseImageInfo te
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 	configFile := filepath.Join(testDir, packagesUpdateConfigFile(t, baseImageInfo))
 
-	err := CustomizeImageWithConfigFileOptions(t.Context(), configFile, ImageCustomizerOptions{
+	err := CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
 		BuildDir:             buildDir,
 		InputImageFile:       baseImage,
 		OutputImageFile:      outImageFilePath,
@@ -320,7 +338,7 @@ func testCustomizeImagePackagesUpdateExisting(t *testing.T, baseImageInfo testBa
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 	configFile := filepath.Join(testDir, "packages-update-existing-config.yaml")
 
-	err := CustomizeImageWithConfigFileOptions(t.Context(), configFile, ImageCustomizerOptions{
+	err := CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
 		BuildDir:             buildDir,
 		InputImageFile:       baseImage,
 		OutputImageFile:      outImageFilePath,
@@ -368,7 +386,7 @@ func testCustomizeImagePackagesRemove(t *testing.T, baseImageInfo testBaseImageI
 		removedListBinary = "/usr/bin/nano"
 	}
 
-	err := CustomizeImageWithConfigFileOptions(t.Context(), configFile, ImageCustomizerOptions{
+	err := CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
 		BuildDir:             buildDir,
 		InputImageFile:       baseImage,
 		OutputImageFile:      outImageFilePath,
@@ -502,8 +520,15 @@ func TestCustomizeImagePackagesDiskSpace(t *testing.T) {
 	configFile := filepath.Join(testDir, installPackageDiskSpaceConfigFile(t, baseImageInfo))
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
+		BuildDir:             buildDir,
+		InputImageFile:       baseImage,
+		RpmsSources:          nil,
+		OutputImageFile:      outImageFilePath,
+		OutputImageFormat:    "raw",
+		UseBaseImageRpmRepos: true,
+		PreviewFeatures:      baseImageInfo.PreviewFeatures,
+	})
 	assert.ErrorContains(t, err, "failed to customize OS")
 	assert.ErrorContains(t, err, "failed to install packages ([gcc])")
 }
@@ -557,8 +582,15 @@ func testCustomizeImagePackagesUrlSourceHelper(t *testing.T, baseImageInfo testB
 	configFile := filepath.Join(testDir, "packages-add-oras.yaml")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, []string{repoFile}, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
+		BuildDir:             buildDir,
+		InputImageFile:       baseImage,
+		RpmsSources:          []string{repoFile},
+		OutputImageFile:      outImageFilePath,
+		OutputImageFormat:    "raw",
+		UseBaseImageRpmRepos: true,
+		PreviewFeatures:      baseImageInfo.PreviewFeatures,
+	})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -596,8 +628,15 @@ func testCustomizeImagePackagesNewGpgKeyHelper(t *testing.T, baseImageInfo testB
 	repoFile := filepath.Join(testDir, "repos/lsg-6.18.repo")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, []string{repoFile},
-		outImageFilePath, "raw", true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
+		BuildDir:             buildDir,
+		InputImageFile:       baseImage,
+		RpmsSources:          []string{repoFile},
+		OutputImageFile:      outImageFilePath,
+		OutputImageFormat:    "raw",
+		UseBaseImageRpmRepos: true,
+		PreviewFeatures:      baseImageInfo.PreviewFeatures,
+	})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -639,8 +678,15 @@ func testCustomizeImagePackagesBadRepoHelper(t *testing.T, baseImageInfo testBas
 	repoFile := filepath.Join(testDir, "repos/bad-repo.repo")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, []string{repoFile}, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
+		BuildDir:             buildDir,
+		InputImageFile:       baseImage,
+		RpmsSources:          []string{repoFile},
+		OutputImageFile:      outImageFilePath,
+		OutputImageFormat:    "raw",
+		UseBaseImageRpmRepos: true,
+		PreviewFeatures:      baseImageInfo.PreviewFeatures,
+	})
 	assert.ErrorIs(t, err, ErrPackageRepoMetadataRefresh)
 }
 
@@ -716,8 +762,8 @@ func testCustomizeImagePackagesSnapshotTimeHelper(t *testing.T, baseImageInfo te
 		},
 	}
 
-	err := CustomizeImage(t.Context(), buildDir, testDir, &config, baseImage, nil, outImageFilePath,
-		"raw", true, "")
+	err := basicCustomizeImage(t.Context(), buildDir, testDir, &config, baseImage, outImageFilePath,
+		"raw", baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -781,8 +827,15 @@ func testCustomizeImagePackagesCliSnapshotTimeOverridesConfigFileHelper(t *testi
 	}
 
 	// Set the snapshot time in CLI to a date before unzip-6.0-22 (2025-04-16) was published
-	err := CustomizeImage(t.Context(), buildDir, testDir, &config, baseImage, nil, outImageFilePath,
-		"raw", true, snapshotTimeCLI)
+	err := CustomizeImage(t.Context(), testDir, &config, ImageCustomizerOptions{
+		BuildDir:             buildDir,
+		InputImageFile:       baseImage,
+		OutputImageFile:      outImageFilePath,
+		OutputImageFormat:    "raw",
+		UseBaseImageRpmRepos: true,
+		PackageSnapshotTime:  imagecustomizerapi.PackageSnapshotTime(snapshotTimeCLI),
+		PreviewFeatures:      baseImageInfo.PreviewFeatures,
+	})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -840,8 +893,8 @@ func testCustomizeImagePackagesSnapshotTimeWithoutPreviewFlagFailsHelper(t *test
 		},
 	}
 
-	err := CustomizeImage(t.Context(), buildDir, testDir, &config, baseImage, nil, outImageFilePath,
-		"raw", true, "")
+	err := basicCustomizeImage(t.Context(), buildDir, testDir, &config, baseImage, outImageFilePath,
+		"raw", baseImageInfo.PreviewFeatures)
 	assert.ErrorContains(t, err, "snapshotTime")
 	assert.ErrorContains(t, err, "preview feature")
 }
@@ -864,7 +917,7 @@ func testCustomizeImagePackagesInstallOnline(t *testing.T, baseImageInfo testBas
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 	configFile := filepath.Join(testDir, packagesAddConfigFile(t, baseImageInfo))
 
-	err := CustomizeImageWithConfigFileOptions(t.Context(), configFile, ImageCustomizerOptions{
+	err := CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
 		BuildDir:             buildDir,
 		InputImageFile:       baseImage,
 		OutputImageFile:      outImageFilePath,

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
@@ -49,8 +49,8 @@ func testCustomizeImagePartitionsToEfi(t *testing.T, testName string, baseImageI
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -157,8 +157,8 @@ func TestCustomizeImagePartitionsSizeOnly(t *testing.T) {
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -243,8 +243,8 @@ func testCustomizeImagePartitionsLegacy(t *testing.T, testName string, baseImage
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
 	// Convert to legacy image.
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, legacybootConfigFile, baseImage, nil, outImageFilePath, "raw",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, legacybootConfigFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -252,8 +252,8 @@ func testCustomizeImagePartitionsLegacy(t *testing.T, testName string, baseImage
 	verifyLegacyBootImage(t, outImageFilePath, baseImageInfo, buildDir)
 
 	// Recustomize legacy image.
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, legacybootConfigFile, outImageFilePath, nil, outImageFilePath, "raw",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, legacybootConfigFile, outImageFilePath, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -261,8 +261,8 @@ func testCustomizeImagePartitionsLegacy(t *testing.T, testName string, baseImage
 	verifyLegacyBootImage(t, outImageFilePath, baseImageInfo, buildDir)
 
 	// Convert back to EFI image.
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, efiConfigFile, outImageFilePath, nil, outImageFilePath, "raw",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, efiConfigFile, outImageFilePath, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -318,8 +318,8 @@ func testCustomizeImageKernelCommandLineHelper(t *testing.T, testName string, ba
 	outImageFilePath := filepath.Join(buildDir, "image.qcow2")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -411,8 +411,8 @@ func testCustomizeImageNewUUIDsHelper(t *testing.T, testName string, baseImageIn
 	os.Remove(tempRawBaseImage)
 
 	// Customize image.
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -528,8 +528,8 @@ func testCustomizeImagePartitionsXfsBootHelper(t *testing.T, testName string, ba
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -593,8 +593,8 @@ func testCustomizeImagePartitionsBtrfsBootHelper(t *testing.T, testName string, 
 	configFile := filepath.Join(testDir, "partitions-btrfs-boot.yaml")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -644,8 +644,8 @@ func testCustomizeImagePartitionsBtrfsSubvolumesBasicHelper(t *testing.T, testNa
 	configFile := filepath.Join(testDir, "partitions-btrfs-subvolumes-basic.yaml")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -704,8 +704,8 @@ func testCustomizeImagePartitionsBtrfsSubvolumesNestedHelper(t *testing.T, testN
 	configFile := filepath.Join(testDir, "partitions-btrfs-subvolumes-nested.yaml")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -770,8 +770,8 @@ func testCustomizeImagePartitionsBtrfsUnmountedHelper(t *testing.T, testName str
 	configFile := filepath.Join(testDir, "partitions-btrfs-unmounted.yaml")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -842,7 +842,7 @@ func testCustomizeImageAzureDataDiskHelper(t *testing.T, testName string,
 	// Create image with Azure data disk entry in /etc/fstab file.
 	configFile := filepath.Join(testDir, "azure-data-disk.yaml")
 	outImageFilePath1 := filepath.Join(testTmpDir, "image1.raw")
-	err := CustomizeImageWithConfigFileOptions(t.Context(), configFile, ImageCustomizerOptions{
+	err := CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
 		BuildDir:             buildDir,
 		InputImageFile:       baseImage,
 		OutputImageFile:      outImageFilePath1,
@@ -857,7 +857,7 @@ func testCustomizeImageAzureDataDiskHelper(t *testing.T, testName string,
 	// Try recustomizing the image but try to write to the read-only data disk placeholder directory.
 	configFile = filepath.Join(testDir, "addfiles-config.yaml")
 	outImageFilePath2 := filepath.Join(testTmpDir, "image2.raw")
-	err = CustomizeImageWithConfigFileOptions(t.Context(), configFile, ImageCustomizerOptions{
+	err = CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
 		BuildDir:             buildDir,
 		InputImageFile:       outImageFilePath1,
 		OutputImageFile:      outImageFilePath2,
@@ -870,7 +870,7 @@ func testCustomizeImageAzureDataDiskHelper(t *testing.T, testName string,
 
 	// Recustomize image, writing to locations that are not read-only.
 	configFile = filepath.Join(testDir, "adddirs-config.yaml")
-	err = CustomizeImageWithConfigFileOptions(t.Context(), configFile, ImageCustomizerOptions{
+	err = CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
 		BuildDir:             buildDir,
 		InputImageFile:       outImageFilePath1,
 		OutputImageFile:      outImageFilePath2,
@@ -887,7 +887,7 @@ func testCustomizeImageAzureDataDiskHelper(t *testing.T, testName string,
 	if baseImageInfo.Distro != baseImageDistroUbuntu {
 		// Recustomize image with partition customization.
 		configFile = filepath.Join(testDir, "partitions-config.yaml")
-		err = CustomizeImageWithConfigFileOptions(t.Context(), configFile, ImageCustomizerOptions{
+		err = CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
 			BuildDir:             buildDir,
 			InputImageFile:       outImageFilePath1,
 			OutputImageFile:      outImageFilePath2,
@@ -905,7 +905,7 @@ func testCustomizeImageAzureDataDiskHelper(t *testing.T, testName string,
 	// Recustomize and convert to COSI.
 	configFile = filepath.Join(testDir, "adddirs-config.yaml")
 	outImageCosiFilePath := filepath.Join(testTmpDir, "image.cosi")
-	err = CustomizeImageWithConfigFileOptions(t.Context(), configFile, ImageCustomizerOptions{
+	err = CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
 		BuildDir:             buildDir,
 		InputImageFile:       outImageFilePath1,
 		OutputImageFile:      outImageCosiFilePath,

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeselinux_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeselinux_test.go
@@ -37,8 +37,8 @@ func testCustomizeImageSELinuxHelper(t *testing.T, testName string, baseImageInf
 	// Customize image: SELinux enforcing.
 	// This tests enabling SELinux on a non-SELinux image.
 	configFile := filepath.Join(testDir, selinuxForceEnforcingConfigFile(t, baseImageInfo))
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -66,8 +66,8 @@ func testCustomizeImageSELinuxHelper(t *testing.T, testName string, baseImageInf
 	// Customize image: SELinux disabled.
 	// This tests disabling (but not removing) SELinux on an SELinux enabled image.
 	configFile = filepath.Join(testDir, "selinux-disabled.yaml")
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -95,8 +95,8 @@ func testCustomizeImageSELinuxHelper(t *testing.T, testName string, baseImageInf
 	// Customize image: SELinux permissive.
 	// This tests enabling SELinux on an image with SELinux installed but disabled.
 	configFile = filepath.Join(testDir, selinuxPermissiveConfigFile(t, baseImageInfo))
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -133,8 +133,8 @@ func testCustomizeImageSELinuxAndPartitionsHelper(t *testing.T, testName string,
 	// Customize image: SELinux enforcing.
 	// This tests enabling SELinux on a non-SELinux image.
 	configFile := filepath.Join(testDir, partitionsSELinuxEnforcingConfigFile(t, baseImageInfo))
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -198,8 +198,8 @@ func TestCustomizeImageSELinuxNoPolicy(t *testing.T) {
 	}
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 
 	switch baseImageInfo.Variant {
 	case baseImageAzureLinuxVariantCoreEfi:

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeservices_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeservices_test.go
@@ -34,7 +34,7 @@ func testCustomizeImageServicesEnableDisable(t *testing.T, baseImageInfo testBas
 
 	// Customize image.
 	configFile := filepath.Join(testDir, "services-config.yaml")
-	err := CustomizeImageWithConfigFileOptions(t.Context(), configFile, ImageCustomizerOptions{
+	err := CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
 		BuildDir:             buildDir,
 		InputImageFile:       baseImage,
 		OutputImageFile:      outImageFilePath,
@@ -93,8 +93,8 @@ func testCustomizeImageServicesEnableUnknown(t *testing.T, baseImageInfo testBas
 		},
 	}
 
-	err := CustomizeImage(t.Context(), buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImage(t.Context(), buildDir, testDir, &config, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	assert.ErrorContains(t, err, "failed to enable service (service='chocolate-chip-muffin')")
 	assert.ErrorContains(t, err, "chocolate-chip-muffin.service does not exist")
 }
@@ -128,7 +128,7 @@ func testCustomizeImageServicesDisableUnknown(t *testing.T, baseImageInfo testBa
 		},
 	}
 
-	err := CustomizeImage(t.Context(), buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImage(t.Context(), buildDir, testDir, &config, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	assert.ErrorContains(t, err, "failed to disable service (service='chocolate-chip-muffin')")
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
@@ -42,8 +42,8 @@ func testCustomizeImageVerityUsrUkiHelper(t *testing.T, baseImageInfo testBaseIm
 	configFile := filepath.Join(testDir, verityUsrUkiConfigFile(t, baseImageInfo))
 
 	// Customize image.
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -57,8 +57,8 @@ func testCustomizeImageVerityUsrUkiHelper(t *testing.T, baseImageInfo testBaseIm
 	outImageFilePath2 := filepath.Join(testTempDir, "image2.raw")
 	configFile2 := filepath.Join(testDir, "verity-reinit-usr-nop.yaml")
 
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile2, outImageFilePath, nil, outImageFilePath2, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile2, outImageFilePath, outImageFilePath2, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -90,8 +90,8 @@ func testCustomizeImageVerityUsrUkiRecustomizeHelper(t *testing.T, baseImageInfo
 	outImageFilePath := filepath.Join(testTempDir, "image.raw")
 	configFile := filepath.Join(testDir, verityUsrUkiConfigFile(t, baseImageInfo))
 
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -104,8 +104,8 @@ func testCustomizeImageVerityUsrUkiRecustomizeHelper(t *testing.T, baseImageInfo
 	outImageFilePath2 := filepath.Join(testTempDir, "image2.raw")
 	configFile2 := filepath.Join(testDir, "verity-reinit-usr-uki.yaml")
 
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile2, outImageFilePath, nil, outImageFilePath2, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile2, outImageFilePath, outImageFilePath2, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -201,8 +201,8 @@ func testCustomizeImageVerityUsrUkiPassthroughHelper(t *testing.T, baseImageInfo
 	outImageFilePath := filepath.Join(testTempDir, "image.raw")
 	configFile := filepath.Join(testDir, verityUsrUkiConfigFile(t, baseImageInfo))
 
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -215,8 +215,8 @@ func testCustomizeImageVerityUsrUkiPassthroughHelper(t *testing.T, baseImageInfo
 	outImageFilePath2 := filepath.Join(testTempDir, "image-passthrough.raw")
 	configFile2 := filepath.Join(testDir, "verity-usr-uki-passthrough.yaml")
 
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile2, outImageFilePath, nil, outImageFilePath2, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile2, outImageFilePath, outImageFilePath2, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -261,8 +261,8 @@ func testCustomizeImageVerityRootUkiHelper(t *testing.T, baseImageInfo testBaseI
 	configFile := filepath.Join(testDir, verityRootUkiConfigFile(t, baseImageInfo))
 
 	// Customize image.
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -276,8 +276,8 @@ func testCustomizeImageVerityRootUkiHelper(t *testing.T, baseImageInfo testBaseI
 	outImageFilePath2 := filepath.Join(testTempDir, "image2.raw")
 	configFile2 := filepath.Join(testDir, "verity-reinit-root-nop.yaml")
 
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile2, outImageFilePath, nil, outImageFilePath2, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile2, outImageFilePath, outImageFilePath2, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeusers_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeusers_test.go
@@ -99,8 +99,8 @@ func testCustomizeImageUsers(t *testing.T, baseImageInfo testBaseImageInfo) {
 	}
 
 	// Customize image.
-	err := CustomizeImage(t.Context(), buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImage(t.Context(), buildDir, testDir, &config, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -165,7 +165,7 @@ func testCustomizeImageUsers(t *testing.T, baseImageInfo testBaseImageInfo) {
 }
 
 func TestCustomizeImageUsersExitingUserHomeDir(t *testing.T) {
-	baseImage, _ := checkSkipForCustomizeDefaultAzureLinuxImage(t)
+	baseImage, baseImageInfo := checkSkipForCustomizeDefaultAzureLinuxImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageUsersExitingUserHomeDir")
 	defer os.RemoveAll(testTmpDir)
@@ -185,13 +185,13 @@ func TestCustomizeImageUsersExitingUserHomeDir(t *testing.T) {
 	}
 
 	// Customize image.
-	err := CustomizeImage(t.Context(), buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImage(t.Context(), buildDir, testDir, &config, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	assert.ErrorContains(t, err, "cannot set home directory on a user that already exists (homeDir='/home/root', user='root')")
 }
 
 func TestCustomizeImageUsersExitingUserUid(t *testing.T) {
-	baseImage, _ := checkSkipForCustomizeDefaultAzureLinuxImage(t)
+	baseImage, baseImageInfo := checkSkipForCustomizeDefaultAzureLinuxImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageUsersExitingUserUid")
 	defer os.RemoveAll(testTmpDir)
@@ -211,13 +211,13 @@ func TestCustomizeImageUsersExitingUserUid(t *testing.T) {
 	}
 
 	// Customize image.
-	err := CustomizeImage(t.Context(), buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImage(t.Context(), buildDir, testDir, &config, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	assert.ErrorContains(t, err, "cannot set UID on a user that already exists (UID='1', user='root')")
 }
 
 func TestCustomizeImageUsersMissingSshPublicKeyFile(t *testing.T) {
-	baseImage, _ := checkSkipForCustomizeDefaultAzureLinuxImage(t)
+	baseImage, baseImageInfo := checkSkipForCustomizeDefaultAzureLinuxImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageUsersMissingSshPublicKeyFile")
 	defer os.RemoveAll(testTmpDir)
@@ -239,13 +239,13 @@ func TestCustomizeImageUsersMissingSshPublicKeyFile(t *testing.T) {
 	}
 
 	// Customize image.
-	err := CustomizeImage(t.Context(), buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImage(t.Context(), buildDir, testDir, &config, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	assert.ErrorContains(t, err, "failed to find SSH public key file (path='does-not-exist')")
 }
 
 func TestCustomizeImageUsersAddFiles(t *testing.T) {
-	baseImage, _ := checkSkipForCustomizeDefaultAzureLinuxImage(t)
+	baseImage, baseImageInfo := checkSkipForCustomizeDefaultAzureLinuxImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageUsersAddFiles")
 	defer os.RemoveAll(testTmpDir)
@@ -255,8 +255,8 @@ func TestCustomizeImageUsersAddFiles(t *testing.T) {
 	configFile := filepath.Join(testDir, "add-user-files.yaml")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -343,7 +343,7 @@ func verifyPassword(t *testing.T, encryptedPassword string, plainTextPassword st
 }
 
 func TestCustomizeImageUsersExitingUserPassword(t *testing.T) {
-	baseImage, _ := checkSkipForCustomizeDefaultAzureLinuxImage(t)
+	baseImage, baseImageInfo := checkSkipForCustomizeDefaultAzureLinuxImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageUsersExitingUserPassword")
 	defer os.RemoveAll(testTmpDir)
@@ -367,8 +367,8 @@ func TestCustomizeImageUsersExitingUserPassword(t *testing.T) {
 		},
 	}
 
-	err := CustomizeImage(t.Context(), buildDir, testDir, &configWithPassword, baseImage, nil, outImageFilePath, "raw",
-		false, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImage(t.Context(), buildDir, testDir, &configWithPassword, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -385,8 +385,8 @@ func TestCustomizeImageUsersExitingUserPassword(t *testing.T) {
 		},
 	}
 
-	err = CustomizeImage(t.Context(), buildDir, testDir, &configWithoutPassword, outImageFilePath, nil, outImageFilePath, "raw",
-		false, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImage(t.Context(), buildDir, testDir, &configWithoutPassword, outImageFilePath, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
@@ -42,8 +42,8 @@ func testCustomizeImageVerityHelper(t *testing.T, testName string, baseImageInfo
 	configFile := filepath.Join(testDir, "verity-config.yaml")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -51,8 +51,8 @@ func testCustomizeImageVerityHelper(t *testing.T, testName string, baseImageInfo
 	verifyRootVerity(t, baseImageInfo, buildDir, outImageFilePath)
 
 	// Recustomize the image.
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -137,8 +137,8 @@ func testCustomizeImageVerityCosiExtractHelper(t *testing.T, testName string, ba
 	varPartitionNum := 5
 
 	// Customize image, shrink partitions, and split the partitions into individual files.
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "cosi",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "cosi",
+		baseImageInfo.PreviewFeatures)
 
 	if !assert.NoError(t, err) {
 		return
@@ -429,8 +429,8 @@ func testCustomizeImageVerityUsrHelper(t *testing.T, testName string, baseImageI
 	configFile := filepath.Join(testDir, "verity-usr-config.yaml")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -439,8 +439,8 @@ func testCustomizeImageVerityUsrHelper(t *testing.T, testName string, baseImageI
 
 	// Recustomize image.
 	// This helps verify that verity-enabled images can be recustomized.
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -511,15 +511,15 @@ func testCustomizeImageVerityUsr2StageHelper(t *testing.T, testName string, base
 	stage3FilePath := filepath.Join(testTempDir, "image3.vhdx")
 
 	// Stage 1: Create the partitions for verity.
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, stage1ConfigFile, baseImage, nil, stage1FilePath, "qcow2",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, stage1ConfigFile, baseImage, stage1FilePath, "qcow2",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
 
 	// Stage 2: Enable verity.
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, stage2ConfigFile, stage1FilePath, nil, stage2FilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, stage2ConfigFile, stage1FilePath, stage2FilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -527,8 +527,8 @@ func testCustomizeImageVerityUsr2StageHelper(t *testing.T, testName string, base
 	verityUsrVerity(t, baseImageInfo, buildDir, stage2FilePath, "panic-on-corruption")
 
 	// Stage 3: Re-apply verity settings.
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, stage3ConfigFile, stage2FilePath, nil, stage3FilePath, "vhdx",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, stage3ConfigFile, stage2FilePath, stage3FilePath, "vhdx",
+		baseImageInfo.PreviewFeatures)
 	assert.ErrorContains(t, err, "verity (verityusr) data partition is invalid")
 	assert.ErrorContains(t, err, "partition already in use as existing verity device's (usr) data partition")
 }
@@ -555,8 +555,8 @@ func testCustomizeImageVerityReinitRootHelper(t *testing.T, testName string, bas
 	stage2FilePath := filepath.Join(testTempDir, "image2.raw")
 
 	// Stage 1: Initialize verity.
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, stage1ConfigFile, baseImage, nil, stage1FilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, stage1ConfigFile, baseImage, stage1FilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -564,8 +564,8 @@ func testCustomizeImageVerityReinitRootHelper(t *testing.T, testName string, bas
 	verifyRootVerity(t, baseImageInfo, buildDir, stage1FilePath)
 
 	// Stage 2a: Reinitialize verity.
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, stage2aConfigFile, stage1FilePath, nil, stage2FilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, stage2aConfigFile, stage1FilePath, stage2FilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -573,8 +573,8 @@ func testCustomizeImageVerityReinitRootHelper(t *testing.T, testName string, bas
 	verifyRootVerity(t, baseImageInfo, buildDir, stage2FilePath)
 
 	// Stage 2b: Reinitialize verity + hard-reset bootloader.
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, stage2bConfigFile, stage1FilePath, nil, stage2FilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, stage2bConfigFile, stage1FilePath, stage2FilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -603,8 +603,8 @@ func testCustomizeImageVerityReinitUsrHelper(t *testing.T, testName string, base
 	stage2FilePath := filepath.Join(testTempDir, "image.raw")
 
 	// Stage 1: Initialize verity.
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, stage1ConfigFile, baseImage, nil, stage1FilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, stage1ConfigFile, baseImage, stage1FilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -612,8 +612,8 @@ func testCustomizeImageVerityReinitUsrHelper(t *testing.T, testName string, base
 	verityUsrVerity(t, baseImageInfo, buildDir, stage1FilePath, "")
 
 	// Stage 2: Reinitialize verity.
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, stage2ConfigFile, stage1FilePath, nil, stage2FilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, stage2ConfigFile, stage1FilePath, stage2FilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -722,8 +722,8 @@ func testCustomizeImageVerityBtrfsRootHelper(t *testing.T, testName string, base
 	configFile := filepath.Join(testDir, "verity-btrfs-root-subvolume.yaml")
 
 	// Customize image with verity + btrfs subvolume.
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -731,8 +731,8 @@ func testCustomizeImageVerityBtrfsRootHelper(t *testing.T, testName string, base
 	verifyBtrfsVerityRoot(t, baseImageInfo, outImageFilePath, testTempDir, "root")
 
 	// Recustomize the image to verify that verity-enabled btrfs images can be recustomized.
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -762,8 +762,8 @@ func testCustomizeImageVerityBtrfsNoSubvolumesHelper(t *testing.T, testName stri
 	configFile := filepath.Join(testDir, "verity-btrfs-root-no-subvolumes.yaml")
 
 	// Customize image with verity + btrfs (no subvolumes).
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -771,8 +771,8 @@ func testCustomizeImageVerityBtrfsNoSubvolumesHelper(t *testing.T, testName stri
 	verifyBtrfsVerityRoot(t, baseImageInfo, outImageFilePath, testTempDir, "" /*subvolPath*/)
 
 	// Recustomize the image.
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -890,8 +890,8 @@ func testCustomizeImageVerityRootInlineHelper(t *testing.T, testName string, bas
 	configFile := filepath.Join(testDir, "verity-root-inline.yaml")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -899,8 +899,8 @@ func testCustomizeImageVerityRootInlineHelper(t *testing.T, testName string, bas
 	verifyRootInlineVerity(t, baseImageInfo, buildDir, outImageFilePath)
 
 	// Recustomize the image.
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -910,8 +910,8 @@ func testCustomizeImageVerityRootInlineHelper(t *testing.T, testName string, bas
 	// Reinit verity without customizing partitions.
 	configFile = filepath.Join(testDir, "verity-reinit.yaml")
 
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -989,8 +989,8 @@ func testCustomizeImageVerityUsrInlineHelper(t *testing.T, testName string, base
 	configFile := filepath.Join(testDir, "verity-usr-inline.yaml")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -998,8 +998,8 @@ func testCustomizeImageVerityUsrInlineHelper(t *testing.T, testName string, base
 	verifyUsrInlineVerity(t, baseImageInfo, buildDir, outImageFilePath)
 
 	// Recustomize the image.
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -1009,8 +1009,8 @@ func testCustomizeImageVerityUsrInlineHelper(t *testing.T, testName string, base
 	// Reinit verity without customizing partitions.
 	configFile = filepath.Join(testDir, "verity-reinit.yaml")
 
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -1087,8 +1087,8 @@ func testCustomizeImageVerityRootInlineCosiHelper(t *testing.T, testName string,
 	configFile := filepath.Join(testDir, verityRootInlineUkiConfigFile(baseImageInfo))
 
 	// Customize image, shrink partitions, and split the partitions into individual files.
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "cosi",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "cosi",
+		baseImageInfo.PreviewFeatures)
 
 	if !assert.NoError(t, err) {
 		return

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_test.go
@@ -41,7 +41,7 @@ func testCustomizeImageDistroVersionInvalidHelper(t *testing.T, testName string,
 	}
 
 	// Corrupt the distro version.
-	err := CustomizeImageWithConfigFileOptions(t.Context(), configFile, options)
+	err := CustomizeImageWithConfigFile(t.Context(), configFile, options)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -51,12 +51,12 @@ func testCustomizeImageDistroVersionInvalidHelper(t *testing.T, testName string,
 
 	// Ensure 'unsupported-distro-version' preview feature flag is enforced.
 	configFile = filepath.Join(testDir, "nochange-config.yaml")
-	err = CustomizeImageWithConfigFileOptions(t.Context(), configFile, options)
+	err = CustomizeImageWithConfigFile(t.Context(), configFile, options)
 	assert.ErrorIs(t, err, ErrUnsupportedDistroVersion)
 
 	// Enable 'unsupported-distro-version' preview feature flag.
 	configFile = filepath.Join(testDir, "distro-version-preview-feature.yaml")
-	err = CustomizeImageWithConfigFileOptions(t.Context(), configFile, options)
+	err = CustomizeImageWithConfigFile(t.Context(), configFile, options)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -93,7 +93,7 @@ func testCustomizeImageDistroVersionNewHelper(t *testing.T, testName string, bas
 	}
 
 	// Set the distro version to a very large number.
-	err := CustomizeImageWithConfigFileOptions(t.Context(), configFile, options)
+	err := CustomizeImageWithConfigFile(t.Context(), configFile, options)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -103,12 +103,12 @@ func testCustomizeImageDistroVersionNewHelper(t *testing.T, testName string, bas
 
 	// Ensure 'unsupported-distro-version' preview feature flag is enforced.
 	configFile = filepath.Join(testDir, "nochange-config.yaml")
-	err = CustomizeImageWithConfigFileOptions(t.Context(), configFile, options)
+	err = CustomizeImageWithConfigFile(t.Context(), configFile, options)
 	assert.ErrorIs(t, err, ErrUnsupportedDistroVersion)
 
 	// Enable 'unsupported-distro-version' preview feature flag.
 	configFile = filepath.Join(testDir, "distro-version-preview-feature.yaml")
-	err = CustomizeImageWithConfigFileOptions(t.Context(), configFile, options)
+	err = CustomizeImageWithConfigFile(t.Context(), configFile, options)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/downloadimageazurelinux_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/downloadimageazurelinux_test.go
@@ -95,7 +95,7 @@ func TestCustomizeImageAZLBaseImageConfigValid(t *testing.T) {
 	}
 
 	// Customize image.
-	err := CustomizeImageWithConfigFileOptions(t.Context(), configFile, options)
+	err := CustomizeImageWithConfigFile(t.Context(), configFile, options)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -132,7 +132,7 @@ func TestCustomizeImageAZLBaseImageCliValid(t *testing.T) {
 	}
 
 	// Customize image.
-	err := CustomizeImageWithConfigFileOptions(t.Context(), configFile, options)
+	err := CustomizeImageWithConfigFile(t.Context(), configFile, options)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
@@ -558,7 +558,8 @@ func TestCustomizeImageNopShrink(t *testing.T) {
 	outImageFilePath := filepath.Join(testTempDir, "image.cosi")
 
 	// Customize image.
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "cosi", true, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "cosi",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -643,7 +644,7 @@ func TestCustomizeImageNopShrink(t *testing.T) {
 func TestCustomizeImageExtractEmptyPartition(t *testing.T) {
 	var err error
 
-	baseImage, _ := checkSkipForCustomizeDefaultAzureLinuxImage(t)
+	baseImage, baseImageInfo := checkSkipForCustomizeDefaultAzureLinuxImage(t)
 
 	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageExtractEmptyPartition")
 	defer os.RemoveAll(testTempDir)
@@ -653,7 +654,8 @@ func TestCustomizeImageExtractEmptyPartition(t *testing.T) {
 	outImageFilePath := filepath.Join(testTempDir, "image.raw")
 
 	// Customize image.
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "cosi", false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "cosi",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -745,8 +747,8 @@ func TestCustomizeImageFstabDelete(t *testing.T) {
 
 	// Customize image.
 	// Ensure there is no error even though the /etc/fstab file was deleted.
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "cosi",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "cosi",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -114,22 +114,7 @@ type imageMetadata struct {
 	partitionOriginalSizes map[string]uint64
 }
 
-func CustomizeImageWithConfigFile(ctx context.Context, buildDir string, configFile string, inputImageFile string,
-	rpmsSources []string, outputImageFile string, outputImageFormat string,
-	useBaseImageRpmRepos bool, packageSnapshotTime string,
-) error {
-	return CustomizeImageWithConfigFileOptions(ctx, configFile, ImageCustomizerOptions{
-		BuildDir:             buildDir,
-		InputImageFile:       inputImageFile,
-		RpmsSources:          rpmsSources,
-		OutputImageFile:      outputImageFile,
-		OutputImageFormat:    imagecustomizerapi.ImageFormatType(outputImageFormat),
-		UseBaseImageRpmRepos: useBaseImageRpmRepos,
-		PackageSnapshotTime:  imagecustomizerapi.PackageSnapshotTime(packageSnapshotTime),
-	})
-}
-
-func CustomizeImageWithConfigFileOptions(ctx context.Context, configFile string, options ImageCustomizerOptions) error {
+func CustomizeImageWithConfigFile(ctx context.Context, configFile string, options ImageCustomizerOptions) error {
 	var err error
 
 	var config imagecustomizerapi.Config
@@ -146,7 +131,7 @@ func CustomizeImageWithConfigFileOptions(ctx context.Context, configFile string,
 		return fmt.Errorf("%w:\n%w", ErrGetAbsoluteConfigPath, err)
 	}
 
-	err = CustomizeImageOptions(ctx, absBaseConfigPath, &config, options)
+	err = CustomizeImage(ctx, absBaseConfigPath, &config, options)
 	if err != nil {
 		return err
 	}
@@ -163,22 +148,7 @@ func cleanUp(rc *ResolvedConfig) error {
 	return nil
 }
 
-func CustomizeImage(ctx context.Context, buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
-	inputImageFile string, rpmsSources []string, outputImageFile string, outputImageFormat string,
-	useBaseImageRpmRepos bool, packageSnapshotTime string,
-) (err error) {
-	return CustomizeImageOptions(ctx, baseConfigPath, config, ImageCustomizerOptions{
-		BuildDir:             buildDir,
-		InputImageFile:       inputImageFile,
-		RpmsSources:          rpmsSources,
-		OutputImageFile:      outputImageFile,
-		OutputImageFormat:    imagecustomizerapi.ImageFormatType(outputImageFormat),
-		UseBaseImageRpmRepos: useBaseImageRpmRepos,
-		PackageSnapshotTime:  imagecustomizerapi.PackageSnapshotTime(packageSnapshotTime),
-	})
-}
-
-func CustomizeImageOptions(ctx context.Context, baseConfigPath string, config *imagecustomizerapi.Config,
+func CustomizeImage(ctx context.Context, baseConfigPath string, config *imagecustomizerapi.Config,
 	options ImageCustomizerOptions,
 ) (err error) {
 	ctx, span := otel.GetTracerProvider().Tracer(OtelTracerName).Start(ctx, "customize_image")

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -4,6 +4,7 @@
 package imagecustomizerlib
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -23,7 +24,7 @@ import (
 func TestCustomizeImageEmptyConfig(t *testing.T) {
 	var err error
 
-	baseImage, _ := checkSkipForCustomizeDefaultAzureLinuxImage(t)
+	baseImage, baseImageInfo := checkSkipForCustomizeDefaultAzureLinuxImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageEmptyConfig")
 	defer os.RemoveAll(testTmpDir)
@@ -32,9 +33,8 @@ func TestCustomizeImageEmptyConfig(t *testing.T) {
 	outImageFilePath := filepath.Join(testTmpDir, "image.vhd")
 
 	// Customize image.
-	err = CustomizeImage(t.Context(), buildDir, buildDir, &imagecustomizerapi.Config{}, baseImage, nil, outImageFilePath,
-		"vhd",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImage(t.Context(), buildDir, buildDir, &imagecustomizerapi.Config{}, baseImage, outImageFilePath,
+		"vhd", baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -44,7 +44,7 @@ func TestCustomizeImageEmptyConfig(t *testing.T) {
 }
 
 func TestCustomizeImageVhd(t *testing.T) {
-	baseImage, _ := checkSkipForCustomizeDefaultAzureLinuxImage(t)
+	baseImage, baseImageInfo := checkSkipForCustomizeDefaultAzureLinuxImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageVhd")
 	defer os.RemoveAll(testTmpDir)
@@ -57,8 +57,8 @@ func TestCustomizeImageVhd(t *testing.T) {
 	vhdxImageFilePath := filepath.Join(testTmpDir, "image3.vhdx")
 
 	// Customize image to vhd.
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, partitionsConfigFile, baseImage, nil, vhdImageFilePath,
-		"vhd", false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, partitionsConfigFile, baseImage, vhdImageFilePath,
+		"vhd", baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -73,8 +73,8 @@ func TestCustomizeImageVhd(t *testing.T) {
 	assert.Equal(t, int64(4*diskutils.GiB), imageInfo.VirtualSize)
 
 	// Customize image to vhd-fixed.
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, noChangeConfigFile, vhdImageFilePath, nil, vhdFixedImageFilePath,
-		"vhd-fixed", false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, noChangeConfigFile, vhdImageFilePath, vhdFixedImageFilePath,
+		"vhd-fixed", baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -91,8 +91,8 @@ func TestCustomizeImageVhd(t *testing.T) {
 	assert.Equal(t, int64(4*diskutils.GiB), imageInfo.VirtualSize-512)
 
 	// Customize image to vhdx.
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, noChangeConfigFile, vhdFixedImageFilePath, nil, vhdxImageFilePath,
-		"vhdx", false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, noChangeConfigFile, vhdFixedImageFilePath, vhdxImageFilePath,
+		"vhdx", baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -500,18 +500,15 @@ func TestCustomizeImage_InputImageFileSelection(t *testing.T) {
 	config := &imagecustomizerapi.Config{}
 
 	inputImageFileFake := filepath.Join(testTempDir, "doesnotexist.xxx")
-	inputImageFileReal, _ := checkSkipForCustomizeDefaultAzureLinuxImage(t)
+	inputImageFileReal, inputImageFileRealInfo := checkSkipForCustomizeDefaultAzureLinuxImage(t)
 
 	inputImageFile := inputImageFileReal
-	rpmSources := []string{}
 	outputImageFile := filepath.Join(testTempDir, "image.vhd")
 	outputImageFormat := filepath.Ext(outputImageFile)[1:]
-	useBaseImageRpmRepos := false
-	packageSnapshotTime := ""
 
 	// Pass the input image file only through the argument.
-	err := CustomizeImage(t.Context(), buildDir, baseConfigPath, config, inputImageFile, rpmSources, outputImageFile,
-		outputImageFormat, useBaseImageRpmRepos, packageSnapshotTime)
+	err := basicCustomizeImage(t.Context(), buildDir, baseConfigPath, config, inputImageFile, outputImageFile,
+		outputImageFormat, inputImageFileRealInfo.PreviewFeatures)
 	assert.NoError(t, err)
 	assert.FileExists(t, outputImageFile)
 	err = os.Remove(outputImageFile)
@@ -523,8 +520,8 @@ func TestCustomizeImage_InputImageFileSelection(t *testing.T) {
 	inputImageFile = ""
 
 	// Pass the input image file only through the config.
-	err = CustomizeImage(t.Context(), buildDir, baseConfigPath, config, inputImageFile, rpmSources, outputImageFile,
-		outputImageFormat, useBaseImageRpmRepos, packageSnapshotTime)
+	err = basicCustomizeImage(t.Context(), buildDir, baseConfigPath, config, inputImageFile, outputImageFile,
+		outputImageFormat, inputImageFileRealInfo.PreviewFeatures)
 	assert.NoError(t, err)
 	assert.FileExists(t, outputImageFile)
 	err = os.Remove(outputImageFile)
@@ -535,8 +532,8 @@ func TestCustomizeImage_InputImageFileSelection(t *testing.T) {
 
 	// Pass the input image file through both the config and the argument. The config's Path is ignored, so even though
 	// it doesn't exist, there will be no error.
-	err = CustomizeImage(t.Context(), buildDir, baseConfigPath, config, inputImageFile, rpmSources, outputImageFile,
-		outputImageFormat, useBaseImageRpmRepos, packageSnapshotTime)
+	err = basicCustomizeImage(t.Context(), buildDir, baseConfigPath, config, inputImageFile, outputImageFile,
+		outputImageFormat, inputImageFileRealInfo.PreviewFeatures)
 	assert.NoError(t, err)
 	assert.FileExists(t, outputImageFile)
 	err = os.Remove(outputImageFile)
@@ -552,7 +549,7 @@ func TestCustomizeImage_InputImageFileAsRelativePath(t *testing.T) {
 	config := &imagecustomizerapi.Config{}
 
 	inputImageFileAbsoluteFake := filepath.Join(testTempDir, "doesnotexist.xxx")
-	inputImageFileReal, _ := checkSkipForCustomizeDefaultAzureLinuxImage(t)
+	inputImageFileReal, inputImageFileRealInfo := checkSkipForCustomizeDefaultAzureLinuxImage(t)
 
 	inputImageFileAbsoluteReal, err := filepath.Abs(inputImageFileReal)
 	assert.NoError(t, err)
@@ -570,16 +567,13 @@ func TestCustomizeImage_InputImageFileAsRelativePath(t *testing.T) {
 	assert.NoError(t, err)
 
 	inputImageFile := inputImageFileRelativeToCwdReal
-	rpmSources := []string{}
 	outputImageFile := filepath.Join(testTempDir, "image.vhd")
 	outputImageFormat := filepath.Ext(outputImageFile)[1:]
-	useBaseImageRpmRepos := false
-	packageSnapshotTime := ""
 
 	// Pass the input image file relative to the current working directory through the argument. This works because
 	// paths on the command-line are expected to be relative to the current working directory.
-	err = CustomizeImage(t.Context(), buildDir, baseConfigPath, config, inputImageFile, rpmSources, outputImageFile,
-		outputImageFormat, useBaseImageRpmRepos, packageSnapshotTime)
+	err = basicCustomizeImage(t.Context(), buildDir, baseConfigPath, config, inputImageFile, outputImageFile,
+		outputImageFormat, inputImageFileRealInfo.PreviewFeatures)
 	assert.NoError(t, err)
 	assert.FileExists(t, outputImageFile)
 	err = os.Remove(outputImageFile)
@@ -588,8 +582,8 @@ func TestCustomizeImage_InputImageFileAsRelativePath(t *testing.T) {
 	inputImageFile = inputImageFileRelativeToCwdFake
 
 	// The same as above but for the fake path. This fails because the file does not exist.
-	err = CustomizeImage(t.Context(), buildDir, baseConfigPath, config, inputImageFile, rpmSources, outputImageFile,
-		outputImageFormat, useBaseImageRpmRepos, packageSnapshotTime)
+	err = basicCustomizeImage(t.Context(), buildDir, baseConfigPath, config, inputImageFile, outputImageFile,
+		outputImageFormat, inputImageFileRealInfo.PreviewFeatures)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "doesnotexist.xxx: no such file or directory")
 	assert.NoFileExists(t, outputImageFile)
@@ -599,8 +593,8 @@ func TestCustomizeImage_InputImageFileAsRelativePath(t *testing.T) {
 
 	// Pass the input image file relative to the config file through the config. This works because paths in the config
 	// as expected to be relative to the config file.
-	err = CustomizeImage(t.Context(), buildDir, baseConfigPath, config, inputImageFile, rpmSources, outputImageFile,
-		outputImageFormat, useBaseImageRpmRepos, packageSnapshotTime)
+	err = basicCustomizeImage(t.Context(), buildDir, baseConfigPath, config, inputImageFile, outputImageFile,
+		outputImageFormat, inputImageFileRealInfo.PreviewFeatures)
 	assert.NoError(t, err)
 	assert.FileExists(t, outputImageFile)
 	err = os.Remove(outputImageFile)
@@ -609,8 +603,8 @@ func TestCustomizeImage_InputImageFileAsRelativePath(t *testing.T) {
 	config.Input.Image.Path = inputImageFileRelativeToConfigFake
 
 	// The same as above but for the fake path. This fails because the file does not exist.
-	err = CustomizeImage(t.Context(), buildDir, baseConfigPath, config, inputImageFile, rpmSources, outputImageFile,
-		outputImageFormat, useBaseImageRpmRepos, packageSnapshotTime)
+	err = basicCustomizeImage(t.Context(), buildDir, baseConfigPath, config, inputImageFile, outputImageFile,
+		outputImageFormat, inputImageFileRealInfo.PreviewFeatures)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "doesnotexist.xxx: no such file or directory")
 }
@@ -640,8 +634,8 @@ func testCustomizeImageKernelCommandLineAddHelper(t *testing.T, testName string,
 		},
 	}
 
-	err = CustomizeImage(t.Context(), buildDir, buildDir, config, baseImage, nil, outImageFilePath, "raw",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImage(t.Context(), buildDir, buildDir, config, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -695,20 +689,17 @@ func TestCustomizeImage_OutputImageFileSelection(t *testing.T) {
 	buildDir := filepath.Join(testTmpDir, "build")
 	baseConfigPath := testTmpDir
 	config := &imagecustomizerapi.Config{}
-	inputImageFile, _ := checkSkipForCustomizeDefaultAzureLinuxImage(t)
-	rpmSources := []string{}
+	inputImageFile, inputImageFileInfo := checkSkipForCustomizeDefaultAzureLinuxImage(t)
 
 	outputImageFileAsArgument := filepath.Join(testTmpDir, "image-as-arg.vhd")
 	outputImageFilePathAsConfig := filepath.Join(testTmpDir, "image-as-config.vhd")
 
 	outputImageFile := outputImageFileAsArgument
 	outputImageFormat := filepath.Ext(outputImageFile)[1:]
-	useBaseImageRpmRepos := false
-	packageSnapshotTime := ""
 
 	// Pass the output image file only through the argument.
-	err := CustomizeImage(t.Context(), buildDir, baseConfigPath, config, inputImageFile, rpmSources, outputImageFile,
-		outputImageFormat, useBaseImageRpmRepos, packageSnapshotTime)
+	err := basicCustomizeImage(t.Context(), buildDir, baseConfigPath, config, inputImageFile, outputImageFile,
+		outputImageFormat, inputImageFileInfo.PreviewFeatures)
 	assert.NoError(t, err)
 	assert.FileExists(t, outputImageFileAsArgument)
 	err = os.Remove(outputImageFileAsArgument)
@@ -718,8 +709,8 @@ func TestCustomizeImage_OutputImageFileSelection(t *testing.T) {
 	outputImageFile = ""
 
 	// Pass the output image file only through the config.
-	err = CustomizeImage(t.Context(), buildDir, baseConfigPath, config, inputImageFile, rpmSources, "",
-		outputImageFormat, useBaseImageRpmRepos, packageSnapshotTime)
+	err = basicCustomizeImage(t.Context(), buildDir, baseConfigPath, config, inputImageFile, "",
+		outputImageFormat, inputImageFileInfo.PreviewFeatures)
 	assert.NoError(t, err)
 	assert.FileExists(t, outputImageFilePathAsConfig)
 	err = os.Remove(outputImageFilePathAsConfig)
@@ -730,8 +721,8 @@ func TestCustomizeImage_OutputImageFileSelection(t *testing.T) {
 
 	// Pass the output image file through both the config and the argument. The config's Path is ignored, so even though
 	// it is a directory, there will be no error.
-	err = CustomizeImage(t.Context(), buildDir, baseConfigPath, config, inputImageFile, rpmSources, outputImageFile,
-		outputImageFormat, useBaseImageRpmRepos, packageSnapshotTime)
+	err = basicCustomizeImage(t.Context(), buildDir, baseConfigPath, config, inputImageFile, outputImageFile,
+		outputImageFormat, inputImageFileInfo.PreviewFeatures)
 	assert.NoError(t, err)
 	assert.FileExists(t, outputImageFileAsArgument)
 	assert.NoFileExists(t, outputImageFilePathAsConfig)
@@ -746,8 +737,7 @@ func TestCustomizeImage_OutputImageFileAsRelativePath(t *testing.T) {
 	buildDir := filepath.Join(testTmpDir, "build")
 	baseConfigPath := testTmpDir
 	config := &imagecustomizerapi.Config{}
-	inputImageFile, _ := checkSkipForCustomizeDefaultAzureLinuxImage(t)
-	rpmSources := []string{}
+	inputImageFile, inputImageFileInfo := checkSkipForCustomizeDefaultAzureLinuxImage(t)
 
 	outputImageFileAbsolute := filepath.Join(testTmpDir, "image.vhdx")
 
@@ -761,13 +751,11 @@ func TestCustomizeImage_OutputImageFileAsRelativePath(t *testing.T) {
 
 	outputImageFile := outputImageFileRelativeToCwd
 	outputImageFormat := filepath.Ext(outputImageFile)[1:]
-	useBaseImageRpmRepos := false
-	packageSnapshotTime := ""
 
 	// Pass the output image file relative to the current working directory through the argument. This will create
 	// the file at the absolute path.
-	err = CustomizeImage(t.Context(), buildDir, baseConfigPath, config, inputImageFile, rpmSources, outputImageFile,
-		outputImageFormat, useBaseImageRpmRepos, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImage(t.Context(), buildDir, baseConfigPath, config, inputImageFile, outputImageFile,
+		outputImageFormat, inputImageFileInfo.PreviewFeatures)
 	assert.NoError(t, err)
 	assert.FileExists(t, outputImageFileAbsolute)
 	err = os.Remove(outputImageFileAbsolute)
@@ -778,8 +766,8 @@ func TestCustomizeImage_OutputImageFileAsRelativePath(t *testing.T) {
 
 	// Pass the output image file relative to the config file through the config. This will create the file at the
 	// absolute path.
-	err = CustomizeImage(t.Context(), buildDir, baseConfigPath, config, inputImageFile, rpmSources, outputImageFile,
-		outputImageFormat, useBaseImageRpmRepos, packageSnapshotTime)
+	err = basicCustomizeImage(t.Context(), buildDir, baseConfigPath, config, inputImageFile, outputImageFile,
+		outputImageFormat, inputImageFileInfo.PreviewFeatures)
 	assert.NoError(t, err)
 	assert.FileExists(t, outputImageFileAbsolute)
 	err = os.Remove(outputImageFileAbsolute)
@@ -787,7 +775,7 @@ func TestCustomizeImage_OutputImageFileAsRelativePath(t *testing.T) {
 }
 
 func TestCustomizeImage_OutputImageFormatSelection(t *testing.T) {
-	baseImage, _ := checkSkipForCustomizeDefaultAzureLinuxImage(t)
+	baseImage, baseImageInfo := checkSkipForCustomizeDefaultAzureLinuxImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImage_OutputImageFormatSelection")
 	defer os.RemoveAll(testTmpDir)
@@ -806,8 +794,8 @@ func TestCustomizeImage_OutputImageFormatSelection(t *testing.T) {
 			},
 		},
 	}
-	err := CustomizeImage(t.Context(), buildDir, testTmpDir, config, baseImage, nil, "", "",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImage(t.Context(), buildDir, testTmpDir, config, baseImage, "", "",
+		baseImageInfo.PreviewFeatures)
 	assert.NoError(t, err)
 	assert.FileExists(t, outputImageFile)
 	checkFileType(t, outputImageFile, outputImageFormatAsConfig)
@@ -818,8 +806,8 @@ func TestCustomizeImage_OutputImageFormatSelection(t *testing.T) {
 
 	// Pass the output image format only through the argument.
 	config.Output.Image.Format = imagecustomizerapi.ImageFormatTypeNone
-	err = CustomizeImage(t.Context(), buildDir, testTmpDir, config, baseImage, nil, "", outputImageFormatAsArg,
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImage(t.Context(), buildDir, testTmpDir, config, baseImage, "", outputImageFormatAsArg,
+		baseImageInfo.PreviewFeatures)
 	assert.NoError(t, err)
 	assert.FileExists(t, outputImageFile)
 	checkFileType(t, outputImageFile, outputImageFormatAsArg)
@@ -830,8 +818,8 @@ func TestCustomizeImage_OutputImageFormatSelection(t *testing.T) {
 
 	// Pass the output image format through both the config and the argument.
 	config.Output.Image.Format = imagecustomizerapi.ImageFormatType(outputImageFormatAsConfig)
-	err = CustomizeImage(t.Context(), buildDir, testTmpDir, config, baseImage, nil, "", outputImageFormatAsArg,
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImage(t.Context(), buildDir, testTmpDir, config, baseImage, "", outputImageFormatAsArg,
+		baseImageInfo.PreviewFeatures)
 	assert.NoError(t, err)
 	assert.FileExists(t, outputImageFile)
 	checkFileType(t, outputImageFile, outputImageFormatAsArg)
@@ -1107,8 +1095,8 @@ func TestCustomizeImageBaseImageMissing(t *testing.T) {
 	baseImage := filepath.Join(testTmpDir, "missing.qcow2")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath,
-		"raw", false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath,
+		"raw", nil)
 	assert.ErrorContains(t, err, "no such file or directory")
 }
 
@@ -1123,8 +1111,8 @@ func TestCustomizeImageBaseImageInvalid(t *testing.T) {
 	baseImage := configFile
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath,
-		"raw", false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath,
+		"raw", nil)
 	assert.ErrorContains(t, err, "failed to connect to OS image file:")
 	assert.ErrorContains(t, err, "image does not contain a partition table")
 }
@@ -1133,4 +1121,31 @@ func checkFileType(t *testing.T, filePath string, expectedFileType string) {
 	fileType, err := testutils.GetImageFileType(filePath)
 	assert.NoError(t, err)
 	assert.Equal(t, expectedFileType, fileType)
+}
+
+func basicCustomizeImageWithConfigFile(ctx context.Context, buildDir string, configFile string, inputImageFile string,
+	outputImageFile string, outputImageFormat string, previewFeatures []imagecustomizerapi.PreviewFeature,
+) error {
+	return CustomizeImageWithConfigFile(ctx, configFile, ImageCustomizerOptions{
+		BuildDir:             buildDir,
+		InputImageFile:       inputImageFile,
+		OutputImageFile:      outputImageFile,
+		OutputImageFormat:    imagecustomizerapi.ImageFormatType(outputImageFormat),
+		UseBaseImageRpmRepos: true,
+		PreviewFeatures:      previewFeatures,
+	})
+}
+
+func basicCustomizeImage(ctx context.Context, buildDir string, baseConfigPath string, config *imagecustomizerapi.Config,
+	inputImageFile string, outputImageFile string, outputImageFormat string,
+	previewFeatures []imagecustomizerapi.PreviewFeature,
+) error {
+	return CustomizeImage(ctx, baseConfigPath, config, ImageCustomizerOptions{
+		BuildDir:             buildDir,
+		InputImageFile:       inputImageFile,
+		OutputImageFile:      outputImageFile,
+		OutputImageFormat:    imagecustomizerapi.ImageFormatType(outputImageFormat),
+		UseBaseImageRpmRepos: true,
+		PreviewFeatures:      previewFeatures,
+	})
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/installedkernelcheck_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/installedkernelcheck_test.go
@@ -22,8 +22,8 @@ func TestCustomizeImageMissingKernel(t *testing.T) {
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	assert.ErrorContains(t, err, "no installed kernel found")
 }
 

--- a/toolkit/tools/pkg/imagecustomizerlib/kernelmoduleutils_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/kernelmoduleutils_test.go
@@ -250,7 +250,7 @@ func testCustomizeImageKernelModules(t *testing.T, baseImageInfo testBaseImageIn
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
 	// Customize image.
-	err := CustomizeImageWithConfigFileOptions(t.Context(), configFile, ImageCustomizerOptions{
+	err := CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
 		BuildDir:             buildDir,
 		InputImageFile:       baseImage,
 		OutputImageFile:      outImageFilePath,

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
@@ -466,8 +466,8 @@ func testCustomizeImageLiveOSKeepKdumpFilesA(t *testing.T, baseImageInfo testBas
 		"" /*pxe url*/, false /*enlarge disk*/, true /*enable os config*/, false /*bootstrap prereqs*/, false, /*2 kernels*/
 		imagecustomizerapi.KdumpBootFilesTypeKeep, imagecustomizerapi.SELinuxModeDisabled)
 
-	err := CustomizeImage(t.Context(), buildDir, testDir, configA0, baseImage, nil, outImageFilePath,
-		string(imagecustomizerapi.ImageFormatTypeIso), false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImage(t.Context(), buildDir, testDir, configA0, baseImage, outImageFilePath,
+		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
 	if baseImageInfo.Version == baseImageVersionAzl4 {
 		assert.ErrorContains(t, err, azl4IsoPxeUnsupportedError)
 		return
@@ -496,8 +496,8 @@ func testCustomizeImageLiveOSKeepKdumpFilesA(t *testing.T, baseImageInfo testBas
 		},
 	}
 
-	err = CustomizeImage(t.Context(), buildDir, testDir, configA1, outImageFilePath, nil, outImageFilePath,
-		string(imagecustomizerapi.ImageFormatTypeIso), false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImage(t.Context(), buildDir, testDir, configA1, outImageFilePath, outImageFilePath,
+		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -588,8 +588,8 @@ func testCustomizeImageLiveOSKeepKdumpFilesBC(t *testing.T, baseImageInfo testBa
 		"" /*pxe url*/, false /*enlarge disk*/, true /*enable os config*/, false /*bootstrap prereqs*/, false, /*2 kernels*/
 		imagecustomizerapi.KdumpBootFilesTypeKeep, imagecustomizerapi.SELinuxModeDisabled)
 
-	err := CustomizeImage(t.Context(), buildDir, testDir, configB, baseImage, nil, outImageFilePath,
-		string(imagecustomizerapi.ImageFormatTypeIso), false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImage(t.Context(), buildDir, testDir, configB, baseImage, outImageFilePath,
+		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
 	if baseImageInfo.Version == baseImageVersionAzl4 {
 		assert.ErrorContains(t, err, azl4IsoPxeUnsupportedError)
 		return
@@ -614,8 +614,8 @@ func testCustomizeImageLiveOSKeepKdumpFilesBC(t *testing.T, baseImageInfo testBa
 		"" /*pxe url*/, false /*enlarge disk*/, true /*enable os config*/, false /*bootstrap prereqs*/, false, /*2 kernels*/
 		imagecustomizerapi.KdumpBootFilesTypeNone, imagecustomizerapi.SELinuxModeDisabled)
 
-	err = CustomizeImage(t.Context(), buildDir, testDir, configC, baseImage, nil, outImageFilePath,
-		string(imagecustomizerapi.ImageFormatTypeIso), false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImage(t.Context(), buildDir, testDir, configC, baseImage, outImageFilePath,
+		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -653,8 +653,8 @@ func testCustomizeImageLiveOSMultiKernel(t *testing.T, baseImageInfo testBaseIma
 		"" /*pxe url*/, true /*enlarge disk*/, true /*enable os config*/, true /*bootstrap prereqs*/, true, /*2 kernels*/
 		imagecustomizerapi.KdumpBootFilesTypeNone, selinuxMode)
 
-	err := CustomizeImage(t.Context(), buildDir, testDir, configA, baseImage, nil, outImageFilePath,
-		string(imagecustomizerapi.ImageFormatTypeIso), true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImage(t.Context(), buildDir, testDir, configA, baseImage, outImageFilePath,
+		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
 	switch baseImageInfo.Version {
 	case baseImageVersionAzl2:
 		// Azl2 should fail.
@@ -700,8 +700,8 @@ func TestCustomizeImageLiveOSInitramfs1(t *testing.T) {
 		imagecustomizerapi.KdumpBootFilesTypeNone, selinuxMode)
 
 	// vhdx {raw} to ISO {bootstrap}, selinux enforcing + bootstrap prereqs
-	err := CustomizeImage(t.Context(), buildDir, testDir, configA, baseImage, nil, outImageFilePath,
-		string(imagecustomizerapi.ImageFormatTypeIso), true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImage(t.Context(), buildDir, testDir, configA, baseImage, outImageFilePath,
+		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
 	if baseImageInfo.Version == baseImageVersionAzl4 {
 		assert.ErrorContains(t, err, azl4IsoPxeUnsupportedError)
 		return
@@ -717,8 +717,8 @@ func TestCustomizeImageLiveOSInitramfs1(t *testing.T) {
 		"" /*pxe url*/, false /*enlarge disk*/, false /*enable os config*/, false /*bootstrap prereqs*/, false, /*2 kernels*/
 		imagecustomizerapi.KdumpBootFilesTypeNone, imagecustomizerapi.SELinuxModeDefault)
 
-	err = CustomizeImage(t.Context(), buildDir, testDir, configB, outImageFilePath, nil, outImageFilePath,
-		string(imagecustomizerapi.ImageFormatTypeIso), false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImage(t.Context(), buildDir, testDir, configB, outImageFilePath, outImageFilePath,
+		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -730,8 +730,8 @@ func TestCustomizeImageLiveOSInitramfs1(t *testing.T) {
 		"" /*pxe url*/, false /*enlarge disk*/, true /*enable os config*/, false /*bootstrap prereqs*/, false, /*2 kernels*/
 		imagecustomizerapi.KdumpBootFilesTypeNone, imagecustomizerapi.SELinuxModeDisabled)
 
-	err = CustomizeImage(t.Context(), buildDir, testDir, configC, outImageFilePath, nil, outImageFilePath,
-		string(imagecustomizerapi.ImageFormatTypeIso), true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImage(t.Context(), buildDir, testDir, configC, outImageFilePath, outImageFilePath,
+		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -759,8 +759,8 @@ func TestCustomizeImageLiveOSInitramfs2(t *testing.T) {
 		"" /*pxe url*/, false /*enlarge disk*/, true /*enable os config*/, false /*bootstrap prereqs*/, false, /*2 kernels*/
 		imagecustomizerapi.KdumpBootFilesTypeNone, imagecustomizerapi.SELinuxModeDisabled)
 
-	err := CustomizeImage(t.Context(), buildDir, testDir, configA, baseImage, nil, outImageFilePath,
-		string(imagecustomizerapi.ImageFormatTypeIso), false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImage(t.Context(), buildDir, testDir, configA, baseImage, outImageFilePath,
+		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
 	if baseImageInfo.Version == baseImageVersionAzl4 {
 		assert.ErrorContains(t, err, azl4IsoPxeUnsupportedError)
 		return
@@ -776,8 +776,8 @@ func TestCustomizeImageLiveOSInitramfs2(t *testing.T) {
 		"" /*pxe url*/, false /*enlarge disk*/, true /*enable os config*/, true /*bootstrap prereqs*/, false, /*2 kernels*/
 		imagecustomizerapi.KdumpBootFilesTypeNone, imagecustomizerapi.SELinuxModeDisabled)
 
-	err = CustomizeImage(t.Context(), buildDir, testDir, configB, outImageFilePath, nil, outImageFilePath, string(imagecustomizerapi.ImageFormatTypeIso),
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImage(t.Context(), buildDir, testDir, configB, outImageFilePath, outImageFilePath, string(imagecustomizerapi.ImageFormatTypeIso),
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -796,8 +796,8 @@ func TestCustomizeImageLiveOSInitramfs2(t *testing.T) {
 		"" /*pxe url*/, false /*enlarge disk*/, true /*enable os config*/, true /*bootstrap prereqs*/, false, /*2 kernels*/
 		imagecustomizerapi.KdumpBootFilesTypeNone, selinuxMode)
 
-	err = CustomizeImage(t.Context(), buildDir, testDir, configC, outImageFilePath, nil, outImageFilePath,
-		string(imagecustomizerapi.ImageFormatTypeIso), true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImage(t.Context(), buildDir, testDir, configC, outImageFilePath, outImageFilePath,
+		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -821,8 +821,8 @@ func TestCustomizeImageLiveOSInitramfs3(t *testing.T) {
 		"" /*pxe url*/, false /*enlarge disk*/, true /*enable os config*/, false /*bootstrap prereqs*/, false, /*2 kernels*/
 		imagecustomizerapi.KdumpBootFilesTypeNone, imagecustomizerapi.SELinuxModeEnforcing)
 
-	err := CustomizeImage(t.Context(), buildDir, testDir, configA, baseImage, nil, outImageFilePath,
-		string(imagecustomizerapi.ImageFormatTypeIso), true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImage(t.Context(), buildDir, testDir, configA, baseImage, outImageFilePath,
+		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
 	if baseImageInfo.Version == baseImageVersionAzl4 {
 		assert.ErrorContains(t, err, azl4IsoPxeUnsupportedError)
 		return
@@ -850,8 +850,8 @@ func TestCustomizeImageLiveOSPxe1(t *testing.T) {
 		pxeBootstrapUrl, false /*enlarge disk*/, true /*enable os config*/, true /*bootstrap prereqs*/, false, /*2 kernels*/
 		imagecustomizerapi.KdumpBootFilesTypeNone, imagecustomizerapi.SELinuxModeEnforcing)
 
-	err := CustomizeImage(t.Context(), buildDir, testDir, config, baseImage, nil, outImageFilePath,
-		string(imagecustomizerapi.ImageFormatTypePxeTar), true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImage(t.Context(), buildDir, testDir, config, baseImage, outImageFilePath,
+		string(imagecustomizerapi.ImageFormatTypePxeTar), baseImageInfo.PreviewFeatures)
 	if baseImageInfo.Version == baseImageVersionAzl4 {
 		assert.ErrorContains(t, err, azl4IsoPxeUnsupportedError)
 		return
@@ -878,8 +878,8 @@ func TestCustomizeImageLiveOSPxe2(t *testing.T) {
 		"" /*pxe url*/, false /*enlarge disk*/, true /*enable os config*/, false /*bootstrap prereqs*/, false, /*2 kernels*/
 		imagecustomizerapi.KdumpBootFilesTypeNone, imagecustomizerapi.SELinuxModeDisabled)
 
-	err := CustomizeImage(t.Context(), buildDir, testDir, config, baseImage, nil, outImageFilePath,
-		string(imagecustomizerapi.ImageFormatTypePxeTar), true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImage(t.Context(), buildDir, testDir, config, baseImage, outImageFilePath,
+		string(imagecustomizerapi.ImageFormatTypePxeTar), baseImageInfo.PreviewFeatures)
 	if baseImageInfo.Version == baseImageVersionAzl4 {
 		assert.ErrorContains(t, err, azl4IsoPxeUnsupportedError)
 		return
@@ -925,8 +925,8 @@ func testCustomizeImageLiveOSIsoNoShimEfi(t *testing.T, testName string, baseIma
 	}
 
 	// Customize image.
-	err := CustomizeImage(t.Context(), buildDir, testDir, config, baseImage, nil, outImageFilePath,
-		string(imagecustomizerapi.ImageFormatTypeIso), true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImage(t.Context(), buildDir, testDir, config, baseImage, outImageFilePath,
+		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
 	assert.Error(t, err)
 	if baseImageInfo.Version == baseImageVersionAzl4 {
 		assert.ErrorContains(t, err, azl4IsoPxeUnsupportedError)
@@ -980,8 +980,8 @@ func TestCustomizeImageLiveOSIsoNoGrubEfi(t *testing.T) {
 	}
 
 	// Customize image.
-	err := CustomizeImage(t.Context(), buildDir, testDir, config, baseImage, nil, outImageFilePath,
-		string(imagecustomizerapi.ImageFormatTypeIso), true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImage(t.Context(), buildDir, testDir, config, baseImage, outImageFilePath,
+		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
 	assert.Error(t, err)
 	if baseImageInfo.Version == baseImageVersionAzl4 {
 		assert.ErrorContains(t, err, azl4IsoPxeUnsupportedError)

--- a/toolkit/tools/pkg/imagecustomizerlib/oras_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/oras_test.go
@@ -32,12 +32,12 @@ func TestCustomizeImageOciBaseImageInvalid(t *testing.T) {
 	}
 
 	// No image cache directory.
-	err := CustomizeImageWithConfigFileOptions(t.Context(), configFile, options)
+	err := CustomizeImageWithConfigFile(t.Context(), configFile, options)
 	assert.ErrorIs(t, err, ErrOciDownloadMissingCacheDir)
 
 	// Image cache directory points to a file.
 	options.ImageCacheDir = configFile
-	err = CustomizeImageWithConfigFileOptions(t.Context(), configFile, options)
+	err = CustomizeImageWithConfigFile(t.Context(), configFile, options)
 	assert.ErrorIs(t, err, ErrOciDownloadCreateCacheDir)
 }
 
@@ -64,7 +64,7 @@ func TestCustomizeImageOciBaseImageValid(t *testing.T) {
 	defer logMessagesHook.Close()
 
 	// Customize image, with empty cache.
-	err := CustomizeImageWithConfigFileOptions(t.Context(), configFile, options)
+	err := CustomizeImageWithConfigFile(t.Context(), configFile, options)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -78,7 +78,7 @@ func TestCustomizeImageOciBaseImageValid(t *testing.T) {
 	assert.Contains(t, logMessages, expectedDownloadLogMessage)
 
 	// Customize image, with populated cache.
-	err = CustomizeImageWithConfigFileOptions(t.Context(), configFile, options)
+	err = CustomizeImageWithConfigFile(t.Context(), configFile, options)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -119,18 +119,18 @@ func TestCustomizeImageOciBaseImageCliInvalid(t *testing.T) {
 	}
 
 	// Bad string format
-	err := CustomizeImageWithConfigFileOptions(t.Context(), configFile, options)
+	err := CustomizeImageWithConfigFile(t.Context(), configFile, options)
 	assert.ErrorIs(t, err, ErrInvalidInputImageStringFormat)
 
 	// Bad URI
 	options.InputImage = "oci:mcr.microsoft.com"
-	err = CustomizeImageWithConfigFileOptions(t.Context(), configFile, options)
+	err = CustomizeImageWithConfigFile(t.Context(), configFile, options)
 	assert.ErrorIs(t, err, ErrInvalidInputImageStringFormat)
 
 	// No image cache directory.
 	options.ImageCacheDir = ""
 	options.InputImage = "oci:mcr.microsoft.com/azurelinux/3.0/image/minimal-os:latest"
-	err = CustomizeImageWithConfigFileOptions(t.Context(), configFile, options)
+	err = CustomizeImageWithConfigFile(t.Context(), configFile, options)
 	assert.ErrorIs(t, err, ErrOciDownloadMissingCacheDir)
 }
 
@@ -154,7 +154,7 @@ func TestCustomizeImageOciBaseImageCliValid(t *testing.T) {
 	}
 
 	// Customize image, with empty cache.
-	err := CustomizeImageWithConfigFileOptions(t.Context(), configFile, options)
+	err := CustomizeImageWithConfigFile(t.Context(), configFile, options)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/resolvconf_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/resolvconf_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestCustomizeImageResolvConfDelete(t *testing.T) {
-	baseImage, _ := checkSkipForCustomizeDefaultAzureLinuxImage(t)
+	baseImage, baseImageInfo := checkSkipForCustomizeDefaultAzureLinuxImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageResolvConfDelete")
 	defer os.RemoveAll(testTmpDir)
@@ -31,8 +31,8 @@ func TestCustomizeImageResolvConfDelete(t *testing.T) {
 		},
 	}
 
-	err := CustomizeImage(t.Context(), buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImage(t.Context(), buildDir, testDir, &config, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -53,7 +53,7 @@ func TestCustomizeImageResolvConfDelete(t *testing.T) {
 }
 
 func TestCustomizeImageResolvConfRestoreFile(t *testing.T) {
-	baseImage, _ := checkSkipForCustomizeDefaultAzureLinuxImage(t)
+	baseImage, baseImageInfo := checkSkipForCustomizeDefaultAzureLinuxImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageResolvConfRestoreFile")
 	defer os.RemoveAll(testTmpDir)
@@ -96,8 +96,8 @@ func TestCustomizeImageResolvConfRestoreFile(t *testing.T) {
 		OS: &imagecustomizerapi.OS{},
 	}
 
-	err = CustomizeImage(t.Context(), buildDir, testDir, &config, outImageFilePath, nil, outImageFilePath, "raw",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImage(t.Context(), buildDir, testDir, &config, outImageFilePath, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -126,7 +126,7 @@ func TestCustomizeImageResolvConfRestoreFile(t *testing.T) {
 }
 
 func TestCustomizeImageResolvConfRestoreSymlink(t *testing.T) {
-	baseImage, _ := checkSkipForCustomizeDefaultAzureLinuxImage(t)
+	baseImage, baseImageInfo := checkSkipForCustomizeDefaultAzureLinuxImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageResolvConfRestoreSymlink")
 	defer os.RemoveAll(testTmpDir)
@@ -168,8 +168,8 @@ func TestCustomizeImageResolvConfRestoreSymlink(t *testing.T) {
 		OS: &imagecustomizerapi.OS{},
 	}
 
-	err = CustomizeImage(t.Context(), buildDir, testDir, &config, outImageFilePath, nil, outImageFilePath, "raw",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImage(t.Context(), buildDir, testDir, &config, outImageFilePath, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -191,7 +191,7 @@ func TestCustomizeImageResolvConfRestoreSymlink(t *testing.T) {
 }
 
 func TestCustomizeImageResolvConfNewSymlink(t *testing.T) {
-	baseImage, _ := checkSkipForCustomizeDefaultAzureLinuxImage(t)
+	baseImage, baseImageInfo := checkSkipForCustomizeDefaultAzureLinuxImage(t)
 
 	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageResolvConfNewSymlink")
 	defer os.RemoveAll(testTmpDir)
@@ -208,8 +208,8 @@ func TestCustomizeImageResolvConfNewSymlink(t *testing.T) {
 		},
 	}
 
-	err := CustomizeImage(t.Context(), buildDir, testDir, &config, baseImage, nil, outImageFilePath, "raw",
-		false /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err := basicCustomizeImage(t.Context(), buildDir, testDir, &config, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/runscripts_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/runscripts_test.go
@@ -34,7 +34,7 @@ func testCustomizeImageRunScripts(t *testing.T, baseImageInfo testBaseImageInfo)
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
 	// Customize image.
-	err = CustomizeImageWithConfigFileOptions(t.Context(), configFile, ImageCustomizerOptions{
+	err = CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
 		BuildDir:             buildDir,
 		InputImageFile:       baseImage,
 		OutputImageFile:      outImageFilePath,
@@ -108,7 +108,7 @@ func testCustomizeImageRunScriptsFunkyInterpreter(t *testing.T, baseImageInfo te
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
 	// Customize image.
-	err = CustomizeImageWithConfigFileOptions(t.Context(), configFile, ImageCustomizerOptions{
+	err = CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
 		BuildDir:             buildDir,
 		InputImageFile:       baseImage,
 		OutputImageFile:      outImageFilePath,

--- a/toolkit/tools/pkg/imagecustomizerlib/selinuxpolicyoutput_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/selinuxpolicyoutput_test.go
@@ -27,8 +27,8 @@ func TestOutputSelinuxPolicy(t *testing.T) {
 	err := file.Copy(originalConfigFile, configFile)
 	assert.NoError(t, err)
 
-	err = CustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, nil, outImageFilePath, "raw",
-		true /*useBaseImageRpmRepos*/, "" /*packageSnapshotTime*/)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}


### PR DESCRIPTION
1. Remove the `CustomizeImageWithConfigFile` and `CustomizeImage` functions since they are only being used by tests.

2. Rename `CustomizeImageOptions` to `CustomizeImage` and `CustomizeImageWithConfigFileOptions` to `CustomizeImageWithConfigFile`.

3. Add the `basicCustomizeImageWithConfigFile` and `basicCustomizeImage` functions to the functional test code. These functions handle the most commonly used parameters in tests. This includes a `previewFeatures` parameter, which is needed for tests that run against distros in preview support.

   Tests that need more advanced functionality can call the `CustomizeImage` functions directly.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
