### PR TITLE
ACL: Don't fail when collecting the list of packages.

### DIFF
--- a/toolkit/tools/internal/shell/execbuilder.go
+++ b/toolkit/tools/internal/shell/execbuilder.go
@@ -194,10 +194,9 @@ func (b ExecBuilder) executeHelper(captureOutput bool) (string, string, error) {
 	// Note: 'exec.Command' only does a path lookup when 'filepath.Base(command) == command'.
 	if b.chrootDir != "" && filepath.Base(command) == command {
 		// Resolve the command's path relative to the chroot directory.
-		resolvedCmd, err := chrootLookPath(command, b.chrootDir, chrootPathDirs)
+		resolvedCmd, err := LookPathChroot(command, b.chrootDir)
 		if err != nil {
-			err = fmt.Errorf("failed to resolve command path:\n%w", err)
-			return "", "", err
+			return "", "", fmt.Errorf("failed to resolve command path:\n%w", err)
 		}
 
 		command = resolvedCmd

--- a/toolkit/tools/internal/shell/shell.go
+++ b/toolkit/tools/internal/shell/shell.go
@@ -158,6 +158,12 @@ func MustExecuteLive(command string, args ...string) {
 	}
 }
 
+// Tries to find a commnad within a chroot.
+// Returns an error iff. the command is not found.
+func LookPathChroot(command string, rootDir string) (string, error) {
+	return chrootLookPath(command, rootDir, chrootPathDirs)
+}
+
 func trackAndStartProcess(cmd *exec.Cmd, capabilities []uintptr) (err error) {
 	logger.Log.Debugf("Executing: %v", cmd.Args)
 

--- a/toolkit/tools/internal/shell/shell.go
+++ b/toolkit/tools/internal/shell/shell.go
@@ -158,7 +158,7 @@ func MustExecuteLive(command string, args ...string) {
 	}
 }
 
-// Tries to find a commnad within a chroot.
+// Tries to find a command within a chroot.
 // Returns an error iff. the command is not found.
 func LookPathChroot(command string, rootDir string) (string, error) {
 	return chrootLookPath(command, rootDir, chrootPathDirs)

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
@@ -115,7 +115,7 @@ func (d *aclDistroHandler) GetAllPackagesFromChroot(imageChroot safechroot.Chroo
 	// Check if the rpm database is available.
 	exists, err := file.PathExists(filepath.Join(imageChroot.RootDir(), "/var/lib/rpm"))
 	if err != nil {
-		// RPM command is not found.
+		// RPM database is not found.
 		return nil, fmt.Errorf("failed to check if rpm db exists:\n%w", err)
 	}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
@@ -8,10 +8,12 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path/filepath"
 	"slices"
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/diskutils"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/file"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/imageconnection"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/logger"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safechroot"
@@ -100,12 +102,40 @@ func (d *aclDistroHandler) IsPackageInstalled(imageChroot safechroot.ChrootInter
 }
 
 func (d *aclDistroHandler) GetAllPackagesFromChroot(imageChroot safechroot.ChrootInterface) ([]OsPackage, error) {
-	return getAllPackagesFromChrootRpm(imageChroot)
+	// This function is only used for metadata within a COSI file.
+	// So, it doesn't matter too much if the package list can't be provided.
+
+	// Check if the rpm command is available.
+	_, err := shell.LookPathChroot("rpm", imageChroot.ChrootDir())
+	if err != nil {
+		// RPM command is not found.
+		return nil, nil
+	}
+
+	// Check if the rpm database is available.
+	exists, err := file.PathExists(filepath.Join(imageChroot.RootDir(), "/var/lib/rpm"))
+	if err != nil {
+		// RPM command is not found.
+		return nil, fmt.Errorf("failed to check if rpm db exists:\n%w", err)
+	}
+
+	if !exists {
+		// RPM database doesn't exist.
+		return nil, nil
+	}
+
+	// Get the list of packages.
+	packages, err := getAllPackagesFromChrootRpm(imageChroot)
+	if err != nil {
+		return nil, err
+	}
+
+	return packages, nil
 }
 
 func (d *aclDistroHandler) DetectBootloaderType(imageChroot safechroot.ChrootInterface) (BootloaderType, error) {
-	bootloaderType, _, err := detectBootloaderType(d, imageChroot, nil, []string{systemdBootPackage})
-	return bootloaderType, err
+	// ACL always uses systemd-boot.
+	return BootloaderTypeSystemdBoot, nil
 }
 
 func (d *aclDistroHandler) ValidateUkiDependencies(imageChroot safechroot.ChrootInterface) error {


### PR DESCRIPTION
The ACL image commonly doesn't contain an RPM db file or even the rpm command. This causes a `convert` to COSI command to fail. To prevent this failure, just populate an empty package list in the COSI file when either the RPM db or rpm command are missing.

Also, hardcode the bootloader type in the COSI file to systemd-boot for the ACL image, since again it isn't possible to query the list of packages for ACL and ACL always uses systemd-boot.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
