### PR TITLE
Add --tools-dir to customize, rename create's --tools-file to --tools-dir

### DIFF
--- a/.github/workflows/tests-vmtests.yml
+++ b/.github/workflows/tests-vmtests.yml
@@ -182,9 +182,9 @@ jobs:
           RPM_SOURCES_AZL3="$TEST_RPMS_DIR/downloadedrpms/azurelinux/3.0" \
           RPM_SOURCES_AZL4="$TEST_RPMS_DIR/downloadedrpms/azurelinux/4.0" \
           RPM_SOURCES_FEDORA42="$TEST_RPMS_DIR/downloadedrpms/fedora/42" \
-          TOOLS_FILE_AZL3="$TEST_RPMS_DIR/build/tools-azurelinux-3.0.tar.gz" \
-          TOOLS_FILE_AZL4="$TEST_RPMS_DIR/build/tools-azurelinux-4.0.tar.gz" \
-          TOOLS_FILE_FEDORA42="$TEST_RPMS_DIR/build/tools-fedora-42.tar.gz" \
+          TOOLS_DIR_AZL3="$TEST_RPMS_DIR/build/tools-azurelinux-3.0-dir" \
+          TOOLS_DIR_AZL4="$TEST_RPMS_DIR/build/tools-azurelinux-4.0-dir" \
+          TOOLS_DIR_FEDORA42="$TEST_RPMS_DIR/build/tools-fedora-42-dir" \
           SSH_PRIVATE_KEY_FILE=~/.ssh/id_ed25519
       env:
         HOST_ARCH: ${{ inputs.hostArch }}

--- a/docs/imagecustomizer/api/cli/create.md
+++ b/docs/imagecustomizer/api/cli/create.md
@@ -129,7 +129,7 @@ dependencies) needed to install packages during image creation.
 For instructions on how to create this directory, see:
 [How to create the tools directory](../../how-to/create-tools-dir.md)
 
-Added in v1.2. Renamed from `--tools-file` in v1.5.
+Added in v1.5.
 
 ## --distro=DISTRO
 

--- a/docs/imagecustomizer/api/cli/create.md
+++ b/docs/imagecustomizer/api/cli/create.md
@@ -119,13 +119,15 @@ RPMs from an existing RPM repo (such as packages.microsoft.com). Using a cloned 
 
 Added in v1.2.
 
-## --tools-file=PATH
+## --tools-dir=DIRECTORY-PATH
 
 Required.
 
-Specifies the path to a tools file in `.tar.gz` format.
+Specifies the path to a directory that provides the tools (tdnf/dnf and their
+dependencies) needed to install packages during image creation.
 
-This file should contain the TDNF tar package (or an equivalent), which is used to manage package dependencies and facilitate installation workflows.
+For instructions on how to create this directory, see:
+[How to create the tools directory](../../how-to/create-tools-dir.md)
 
 Added in v1.2.
 

--- a/docs/imagecustomizer/api/cli/create.md
+++ b/docs/imagecustomizer/api/cli/create.md
@@ -129,7 +129,7 @@ dependencies) needed to install packages during image creation.
 For instructions on how to create this directory, see:
 [How to create the tools directory](../../how-to/create-tools-dir.md)
 
-Added in v1.2.
+Added in v1.2. Renamed from `--tools-file` in v1.5.
 
 ## --distro=DISTRO
 

--- a/docs/imagecustomizer/api/cli/customize.md
+++ b/docs/imagecustomizer/api/cli/customize.md
@@ -267,18 +267,20 @@ You may enable this feature by adding `input-image-oci` to the
 
 Added in v1.1.
 
-## --tools-file=PATH
+## --tools-dir=DIRECTORY-PATH
 
 Optional.
 
-Specifies the path to a tools tarball in `.tar.gz` format that provides an external
-package manager (tdnf/dnf). Required when performing package operations on images that
-do not include a package manager in the base image (e.g. Azure Container Linux, where
-`/usr` is immutable and verity-protected).
+Specifies the path to a directory that provides an external package manager (tdnf/dnf).
+Required when performing package operations on images that do not include a package
+manager in the base image.
 
-When provided, the tools tarball is unpacked into a separate chroot environment. The
-image is mounted inside that chroot at `/_imageroot`, and tdnf is invoked with
+When provided, the directory is copied into a separate chroot environment. The image is
+mounted inside that chroot at `/_imageroot`, and tdnf is invoked with
 `--installroot=/_imageroot`. Images that already include tdnf (e.g. standard Azure
 Linux images) do not need this flag.
+
+For instructions on how to create this directory, see:
+[How to create the tools directory](../../how-to/create-tools-dir.md)
 
 Added in v1.5.

--- a/docs/imagecustomizer/api/cli/customize.md
+++ b/docs/imagecustomizer/api/cli/customize.md
@@ -266,3 +266,19 @@ You may enable this feature by adding `input-image-oci` to the
 [previewfeatures](../configuration/config.md#previewfeatures-string) API.
 
 Added in v1.1.
+
+## --tools-file=PATH
+
+Optional.
+
+Specifies the path to a tools tarball in `.tar.gz` format that provides an external
+package manager (tdnf/dnf). Required when performing package operations on images that
+do not include a package manager in the base image (e.g. Azure Container Linux, where
+`/usr` is immutable and verity-protected).
+
+When provided, the tools tarball is unpacked into a separate chroot environment. The
+image is mounted inside that chroot at `/_imageroot`, and tdnf is invoked with
+`--installroot=/_imageroot`. Images that already include tdnf (e.g. standard Azure
+Linux images) do not need this flag.
+
+Added in v1.5.

--- a/docs/imagecustomizer/how-to/create-image.md
+++ b/docs/imagecustomizer/how-to/create-image.md
@@ -174,23 +174,19 @@ As such, the example configuration files below must specify `create` in the [pre
    For documentation on the supported configuration options, see:
    [Supported configuration](../api/configuration/configuration.md)
 
-2. Download the tools file.
+2. Create the tools directory.
 
-   The tools file contains bootstrap utilities needed to create an image from scratch.
+   The tools directory contains the bootstrap utilities (tdnf and its dependencies)
+   needed to install packages during image creation.
 
-   To create a tools file for a new Azure Linux 3.0:
+   For step-by-step instructions, see:
+   [How to create the tools directory](../how-to/create-tools-dir.md)
 
-    ```bash
-    ./toolkit/tools/internal/testutils/testrpms/create-tools-file.sh \
-      "mcr.microsoft.com/azurelinux/base/core:3.0" "$HOME/staging/azure-linux-3.0-tools.tar.gz"
-    ```
+   For Azure Linux 3.0, the tools directory should be created from the
+   `mcr.microsoft.com/azurelinux/base/core:3.0` container image.
 
-   To create a tools file for a new Fedora 42:
-
-    ```bash
-    ./toolkit/tools/internal/testutils/testrpms/create-tools-file.sh \
-      "quay.io/fedora/fedora:42" "$HOME/staging/fedora-42-tools.tar.gz"
-    ```
+   For Fedora 42, the tools directory should be created from the
+   `quay.io/fedora/fedora:42` container image.
 
 3. Create a repository configuration file and, if needed, a GPG key file.
 
@@ -246,7 +242,7 @@ As such, the example configuration files below must specify `create` in the [pre
       mcr.microsoft.com/azurelinux/imagecustomizer:latest create \
         --distro azurelinux \
         --distro-version 3.0 \
-        --tools-file /mnt/staging/azure-linux-3.0-tools.tar.gz \
+        --tools-dir /mnt/staging/tools-azurelinux-3.0 \
         --rpm-source /mnt/staging/azure-linux-3.0-rpms.repo \
         --config-file /mnt/staging/config-azl3.yaml \
         --build-dir /build \
@@ -265,7 +261,7 @@ As such, the example configuration files below must specify `create` in the [pre
       mcr.microsoft.com/azurelinux/imagecustomizer:latest create \
         --distro fedora \
         --distro-version 42 \
-        --tools-file /mnt/staging/fedora-42-tools.tar.gz \
+        --tools-dir /mnt/staging/tools-fedora-42 \
         --rpm-source /mnt/staging/fedora-42-rpms.repo \
         --config-file /mnt/staging/config-fedora.yaml \
         --build-dir /build \
@@ -302,8 +298,8 @@ As such, the example configuration files below must specify `create` in the [pre
 
     - `--distro-version 42`: Specify the Fedora version to create the image for.
 
-    - `--tools-file /mnt/staging/fedora-42-tools.tar.gz`: Use the host's
-      `$HOME/staging/fedora-42-tools.tar.gz` file as the bootstrapping tools file.
+    - `--tools-dir /mnt/staging/tools-fedora-42`: Use the host's
+      `$HOME/staging/tools-fedora-42` directory as the bootstrapping tools directory.
 
     - `--rpm-source /mnt/staging/fedora-42-rpms.repo`: Use the host's
       `$HOME/staging/fedora-42-rpms.repo` file for installing packages.

--- a/docs/imagecustomizer/how-to/create-image.md
+++ b/docs/imagecustomizer/how-to/create-image.md
@@ -182,12 +182,6 @@ As such, the example configuration files below must specify `create` in the [pre
    For step-by-step instructions, see:
    [How to create the tools directory](../how-to/create-tools-dir.md)
 
-   For Azure Linux 3.0, the tools directory should be created from the
-   `mcr.microsoft.com/azurelinux/base/core:3.0` container image.
-
-   For Fedora 42, the tools directory should be created from the
-   `quay.io/fedora/fedora:42` container image.
-
 3. Create a repository configuration file and, if needed, a GPG key file.
 
    The repository configuration file (`.repo` file) tells the Image Customizer where to download RPM packages from.

--- a/docs/imagecustomizer/how-to/create-tools-dir.md
+++ b/docs/imagecustomizer/how-to/create-tools-dir.md
@@ -1,19 +1,18 @@
 ---
-title: Create Tools Directory
+title: Tools Directory
 parent: How To
 nav_order: 9
 has_toc: false
 ---
 
-# Creating the Tools Directory
+# Tools Directory
 
-The `--tools-dir` flag used by the Image Customizer
-[create](../api/cli/create.md) and [customize](../api/cli/customize.md) subcommands
-requires a directory that contains a package manager (tdnf or dnf) and its runtime
-dependencies.
+Both the `create` and `customize` subcommands of the Image Customizer accept a
+`--tools-dir` flag. The directory it points to must contain a package manager
+(tdnf or dnf) and its runtime dependencies.
 
-This directory is used as a bootstrap environment to install packages into the target
-image. It is not added to the image itself.
+Image Customizer uses this directory as a chroot to run utilities needed during
+image customization.
 
 ## Prerequisites
 

--- a/docs/imagecustomizer/how-to/create-tools-dir.md
+++ b/docs/imagecustomizer/how-to/create-tools-dir.md
@@ -1,0 +1,107 @@
+---
+title: Create Tools Directory
+parent: How To
+nav_order: 9
+has_toc: false
+---
+
+# Creating the Tools Directory
+
+The `--tools-dir` flag used by the Image Customizer
+[create](../api/cli/create.md) and [customize](../api/cli/customize.md) subcommands
+requires a directory that contains a package manager (tdnf or dnf) and its runtime
+dependencies.
+
+This directory is used as a bootstrap environment to install packages into the target
+image. It is not added to the image itself.
+
+## Prerequisites
+
+- Linux host
+- Docker (or equivalent container engine) installed
+
+## How It Works
+
+The tools directory is created by exporting the filesystem of a container image that
+already contains the package manager you need. Image Customizer then uses this directory
+as a chroot environment, mounting the target image inside it at `/_imageroot` and
+running `tdnf --installroot=/_imageroot`.
+
+## Instructions
+
+### Azure Linux 3.0
+
+The Azure Linux base core container includes tdnf and all its dependencies.
+
+```bash
+# Pull the container image
+docker pull mcr.microsoft.com/azurelinux/base/core:3.0
+
+# Create a temporary container (does not start it)
+docker create --name ic-tools-azurelinux-3.0 mcr.microsoft.com/azurelinux/base/core:3.0
+
+# Export the container filesystem and extract it into a directory
+mkdir -p "$HOME/staging/tools-azurelinux-3.0"
+docker export ic-tools-azurelinux-3.0 | tar -x -C "$HOME/staging/tools-azurelinux-3.0"
+
+# Remove the temporary container
+docker rm ic-tools-azurelinux-3.0
+```
+
+The tools directory is now at `$HOME/staging/tools-azurelinux-3.0`.
+
+### Fedora 42
+
+The Fedora base container includes dnf and all its dependencies.
+
+```bash
+# Pull the container image
+docker pull quay.io/fedora/fedora:42
+
+# Create a temporary container (does not start it)
+docker create --name ic-tools-fedora-42 quay.io/fedora/fedora:42
+
+# Export the container filesystem and extract it into a directory
+mkdir -p "$HOME/staging/tools-fedora-42"
+docker export ic-tools-fedora-42 | tar -x -C "$HOME/staging/tools-fedora-42"
+
+# Remove the temporary container
+docker rm ic-tools-fedora-42
+```
+
+The tools directory is now at `$HOME/staging/tools-fedora-42`.
+
+## Reusing the Tools Directory
+
+The tools directory can be reused across multiple Image Customizer runs as long as the
+container image it was created from has not changed. You do not need to recreate it each
+time.
+
+To pick up updates (e.g. a newer version of tdnf), pull the container image again and
+repeat the steps above to recreate the directory.
+
+## Using the Tools Directory
+
+Pass the tools directory to Image Customizer with the `--tools-dir` flag.
+
+For example, when running Image Customizer via Docker:
+
+```bash
+docker run \
+  --rm \
+  --privileged=true \
+  -v /dev:/dev \
+  -v "$HOME/staging:/mnt/staging:z" \
+  mcr.microsoft.com/azurelinux/imagecustomizer:latest customize \
+    --tools-dir /mnt/staging/tools-azurelinux-3.0 \
+    ...
+```
+
+Note that `$HOME/staging` is mounted into the container at `/mnt/staging`, so the tools
+directory path inside the container is `/mnt/staging/tools-azurelinux-3.0`.
+
+## See Also
+
+- [create subcommand](../api/cli/create.md)
+- [customize subcommand](../api/cli/customize.md)
+- [Creating a new image from scratch](../how-to/create-image.md)

--- a/test/vmtests/Makefile
+++ b/test/vmtests/Makefile
@@ -95,9 +95,9 @@ test-imagecustomizer:
 		--rpm-sources-azl3="${RPM_SOURCES_AZL3}" \
 		--rpm-sources-azl4="${RPM_SOURCES_AZL4}" \
 		--rpm-sources-fedora42="${RPM_SOURCES_FEDORA42}" \
-		--tools-file-azl3="${TOOLS_FILE_AZL3}" \
-		--tools-file-azl4="${TOOLS_FILE_AZL4}" \
-		--tools-file-fedora42="${TOOLS_FILE_FEDORA42}" \
+		--tools-dir-azl3="${TOOLS_DIR_AZL3}" \
+		--tools-dir-azl4="${TOOLS_DIR_AZL4}" \
+		--tools-dir-fedora42="${TOOLS_DIR_FEDORA42}" \
 		--ssh-private-key="${SSH_PRIVATE_KEY_FILE}" \
 		$(if $(filter y,$(KEEP_ENVIRONMENT)),--keep-environment) \
 		--log-cli-level=DEBUG \

--- a/test/vmtests/vmtests/imagecustomizer/conftest.py
+++ b/test/vmtests/vmtests/imagecustomizer/conftest.py
@@ -20,9 +20,9 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption("--rpm-sources-azl3", action="store", help="Path to Azure Linux 3 RPM sources directory")
     parser.addoption("--rpm-sources-azl4", action="store", help="Path to Azure Linux 4 RPM sources directory")
     parser.addoption("--rpm-sources-fedora42", action="store", help="Path to Fedora 42 RPM sources directory")
-    parser.addoption("--tools-file-azl3", action="store", help="Path to Azure Linux 3 tools tar file")
-    parser.addoption("--tools-file-azl4", action="store", help="Path to Azure Linux 4 tools tar file")
-    parser.addoption("--tools-file-fedora42", action="store", help="Path to Fedora 42 tools tar file")
+    parser.addoption("--tools-dir-azl3", action="store", help="Path to Azure Linux 3 tools directory")
+    parser.addoption("--tools-dir-azl4", action="store", help="Path to Azure Linux 4 tools directory")
+    parser.addoption("--tools-dir-fedora42", action="store", help="Path to Fedora 42 tools directory")
 
 
 @pytest.fixture(scope="session")
@@ -98,24 +98,24 @@ def rpm_sources_fedora42(request: pytest.FixtureRequest) -> Generator[Path, None
 
 
 @pytest.fixture(scope="session")
-def tools_file_azl3(request: pytest.FixtureRequest) -> Generator[Path, None, None]:
-    tar_path = request.config.getoption("--tools-file-azl3")
-    if not tar_path:
-        pytest.skip("--tools-file-azl3 is required for test")
-    yield Path(tar_path)
+def tools_dir_azl3(request: pytest.FixtureRequest) -> Generator[Path, None, None]:
+    dir_path = request.config.getoption("--tools-dir-azl3")
+    if not dir_path:
+        pytest.skip("--tools-dir-azl3 is required for test")
+    yield Path(dir_path)
 
 
 @pytest.fixture(scope="session")
-def tools_file_azl4(request: pytest.FixtureRequest) -> Generator[Path, None, None]:
-    tar_path = request.config.getoption("--tools-file-azl4")
-    if not tar_path:
-        pytest.skip("--tools-file-azl4 is required for test")
-    yield Path(tar_path)
+def tools_dir_azl4(request: pytest.FixtureRequest) -> Generator[Path, None, None]:
+    dir_path = request.config.getoption("--tools-dir-azl4")
+    if not dir_path:
+        pytest.skip("--tools-dir-azl4 is required for test")
+    yield Path(dir_path)
 
 
 @pytest.fixture(scope="session")
-def tools_file_fedora42(request: pytest.FixtureRequest) -> Generator[Path, None, None]:
-    tar_path = request.config.getoption("--tools-file-fedora42")
-    if not tar_path:
-        pytest.skip("--tools-file-fedora42 is required for test")
-    yield Path(tar_path)
+def tools_dir_fedora42(request: pytest.FixtureRequest) -> Generator[Path, None, None]:
+    dir_path = request.config.getoption("--tools-dir-fedora42")
+    if not dir_path:
+        pytest.skip("--tools-dir-fedora42 is required for test")
+    yield Path(dir_path)

--- a/test/vmtests/vmtests/imagecustomizer/test_create.py
+++ b/test/vmtests/vmtests/imagecustomizer/test_create.py
@@ -127,7 +127,7 @@ def run_create_image_test(
     image_customizer_container_url: str,
     docker_client: DockerClient,
     rpm_sources: List[Path],
-    tools_file: Path,
+    tools_dir: Path,
     config_path: Path,
     output_format: str,
     ssh_key: Tuple[str, Path],
@@ -152,7 +152,7 @@ def run_create_image_test(
     logging.debug("Test parameters:")
     logging.debug(f"- image_customizer_container_url = {image_customizer_container_url}")
     logging.debug(f"- rpm_sources                    = {rpm_sources}")
-    logging.debug(f"- tools_file                     = {tools_file}")
+    logging.debug(f"- tools_dir                      = {tools_dir}")
     logging.debug(f"- config_path                    = {config_path}")
     logging.debug(f"- output_format                  = {output_format}")
     logging.debug(f"- target_boot_type               = {target_boot_type}")
@@ -172,7 +172,7 @@ def run_create_image_test(
         output_format,
         initial_output_image_path,
         rpm_sources=rpm_sources,
-        tools_file=tools_file,
+        tools_dir=tools_dir,
         distro=distro,
         distro_version=version,
     )
@@ -289,7 +289,7 @@ def test_create_image_efi_qcow_output_azl3(
     image_customizer_container_url: str,
     docker_client: DockerClient,
     rpm_sources_azl3: Path,
-    tools_file_azl3: Path,
+    tools_dir_azl3: Path,
     ssh_key: Tuple[str, Path],
     test_temp_dir: Path,
     test_instance_name: str,
@@ -301,7 +301,7 @@ def test_create_image_efi_qcow_output_azl3(
         image_customizer_container_url,
         docker_client,
         [rpm_sources_azl3],
-        tools_file_azl3,
+        tools_dir_azl3,
         TEST_CONFIGS_DIR.joinpath("create-minimal-os.yaml"),
         "qcow2",
         ssh_key,
@@ -319,7 +319,7 @@ def test_create_image_efi_qcow_output_azl4(
     image_customizer_container_url: str,
     docker_client: DockerClient,
     rpm_sources_azl4: Path,
-    tools_file_azl4: Path,
+    tools_dir_azl4: Path,
     ssh_key: Tuple[str, Path],
     test_temp_dir: Path,
     test_instance_name: str,
@@ -336,7 +336,7 @@ def test_create_image_efi_qcow_output_azl4(
         image_customizer_container_url,
         docker_client,
         [rpm_sources_azl4],
-        tools_file_azl4,
+        tools_dir_azl4,
         config_path,
         "qcow2",
         ssh_key,
@@ -354,7 +354,7 @@ def test_create_image_efi_qcow_output_fedora(
     image_customizer_container_url: str,
     docker_client: DockerClient,
     rpm_sources_fedora42: Path,
-    tools_file_fedora42: Path,
+    tools_dir_fedora42: Path,
     ssh_key: Tuple[str, Path],
     test_temp_dir: Path,
     test_instance_name: str,
@@ -371,7 +371,7 @@ def test_create_image_efi_qcow_output_fedora(
         image_customizer_container_url,
         docker_client,
         [rpm_sources_fedora42],
-        tools_file_fedora42,
+        tools_dir_fedora42,
         config_path,
         "qcow2",
         ssh_key,

--- a/test/vmtests/vmtests/utils/imagecustomizer.py
+++ b/test/vmtests/vmtests/utils/imagecustomizer.py
@@ -29,7 +29,7 @@ def run_image_customizer(
     output_image_path: Path,
     image_file: Path | None = None,
     rpm_sources: List[Path] | None = None,
-    tools_file: Path | None = None,
+    tools_dir: Path | None = None,
     distro: str | None = None,
     distro_version: str | None = None,
     log_format: str | None = None,
@@ -79,12 +79,10 @@ def run_image_customizer(
             volumes.append(f"{rpm_source_abs}:{container_rpm_source_path}:z")
             args.extend(["--rpm-source", str(container_rpm_source_path)])
 
-    if tools_file:
-        tools_dir = tools_file.parent.absolute()
+    if tools_dir:
         container_tools_dir = Path("/container/tools")
-        container_tools_file = container_tools_dir.joinpath(tools_file.name)
-        args.extend(["--tools-file", str(container_tools_file)])
-        volumes.append(f"{tools_dir}:{container_tools_dir}:z")
+        args.extend(["--tools-dir", str(container_tools_dir)])
+        volumes.append(f"{tools_dir.absolute()}:{container_tools_dir}:z")
 
     if distro:
         args.extend(["--distro", distro])

--- a/toolkit/tools/imagecustomizer/main.go
+++ b/toolkit/tools/imagecustomizer/main.go
@@ -23,7 +23,7 @@ type CreateCmd struct {
 	BuildDir            string   `name:"build-dir" help:"Directory to run build out of." required:""`
 	ConfigFile          string   `name:"config-file" help:"Path of the image creation config file." required:""`
 	RpmSources          []string `name:"rpm-source" help:"Path to a RPM repo config file or a directory containing RPMs." required:""`
-	ToolsTar            string   `name:"tools-file" help:"Path to tdnf/dnf worker tarball" required:""`
+	ToolsDir            string   `name:"tools-dir" help:"Path to a directory containing tdnf/dnf and its dependencies." required:""`
 	OutputImageFile     string   `name:"output-image-file" aliases:"output-path" help:"Path to write the customized image to."`
 	OutputImageFormat   string   `name:"output-image-format" placeholder:"(vhd|vhd-fixed|vhdx|qcow2|raw)" help:"Format of output image." enum:"${imageformatcreate}" default:""`
 	Distro              string   `name:"distro" help:"Target distribution for the image." enum:"azurelinux,fedora" default:"azurelinux"`
@@ -44,7 +44,7 @@ type CustomizeCmd struct {
 	PackageSnapshotTime      string   `name:"package-snapshot-time" help:"Only packages published before this snapshot time will be available during customization. Supports 'YYYY-MM-DD' or full RFC3339 timestamp (e.g., 2024-05-20T23:59:59Z)."`
 	ImageCacheDir            string   `name:"image-cache-dir" help:"The directory to use as the image download cache"`
 	CosiCompressionLevel     *int     `name:"cosi-compression-level" help:"Zstd compression level for COSI output (1-22, default: 9)."`
-	ToolsTar                 string   `name:"tools-file" help:"Path to tools tarball providing tdnf/dnf. Required for package operations on images that do not include a package manager (e.g. ACL)."`
+	ToolsDir                 string   `name:"tools-dir" help:"Path to a directory containing tdnf/dnf and its dependencies. Required for package operations on images that do not include a package manager (e.g. ACL)."`
 }
 
 type InjectFilesCmd struct {
@@ -181,7 +181,7 @@ func customizeImage(ctx context.Context, cmd CustomizeCmd) error {
 			PackageSnapshotTime:     imagecustomizerapi.PackageSnapshotTime(cmd.PackageSnapshotTime),
 			ImageCacheDir:           cmd.ImageCacheDir,
 			CosiCompressionLevel:    cmd.CosiCompressionLevel,
-			ToolsTar:                cmd.ToolsTar,
+			ToolsDir:                cmd.ToolsDir,
 		})
 	if err != nil {
 		return err
@@ -227,7 +227,7 @@ func createImage(ctx context.Context, cmd CreateCmd) error {
 		BuildDir:            cmd.BuildDir,
 		Distro:              targetos.Distro(cmd.Distro),
 		DistroVersion:       cmd.DistroVersion,
-		ToolsTar:            cmd.ToolsTar,
+		ToolsDir:            cmd.ToolsDir,
 		RpmsSources:         cmd.RpmSources,
 		OutputImageFile:     cmd.OutputImageFile,
 		OutputImageFormat:   imagecustomizerapi.ImageFormatType(cmd.OutputImageFormat),

--- a/toolkit/tools/imagecustomizer/main.go
+++ b/toolkit/tools/imagecustomizer/main.go
@@ -44,6 +44,7 @@ type CustomizeCmd struct {
 	PackageSnapshotTime      string   `name:"package-snapshot-time" help:"Only packages published before this snapshot time will be available during customization. Supports 'YYYY-MM-DD' or full RFC3339 timestamp (e.g., 2024-05-20T23:59:59Z)."`
 	ImageCacheDir            string   `name:"image-cache-dir" help:"The directory to use as the image download cache"`
 	CosiCompressionLevel     *int     `name:"cosi-compression-level" help:"Zstd compression level for COSI output (1-22, default: 9)."`
+	ToolsTar                 string   `name:"tools-file" help:"Path to tools tarball providing tdnf/dnf. Required for package operations on images that do not include a package manager (e.g. ACL)."`
 }
 
 type InjectFilesCmd struct {
@@ -180,6 +181,7 @@ func customizeImage(ctx context.Context, cmd CustomizeCmd) error {
 			PackageSnapshotTime:     imagecustomizerapi.PackageSnapshotTime(cmd.PackageSnapshotTime),
 			ImageCacheDir:           cmd.ImageCacheDir,
 			CosiCompressionLevel:    cmd.CosiCompressionLevel,
+			ToolsTar:                cmd.ToolsTar,
 		})
 	if err != nil {
 		return err

--- a/toolkit/tools/internal/testutils/testrpms/download-test-utils.sh
+++ b/toolkit/tools/internal/testutils/testrpms/download-test-utils.sh
@@ -101,6 +101,12 @@ if [ "$CREATE_IMAGE" = "true" ]; then
   $SCRIPT_DIR/create-tools-file.sh "$CONTAINER_IMAGE" "$TOOLS_FILE"
   echo "Tools file created successfully."
 
+  TOOLS_DIR="${TOOLS_FILE%.tar.gz}-dir"
+  echo "Extracting tools dir: $TOOLS_DIR"
+  mkdir -p "$TOOLS_DIR"
+  tar -x -z -f "$TOOLS_FILE" -C "$TOOLS_DIR"
+  echo "Tools dir extracted successfully."
+
   # Check for python3 availability
   if ! command -v python3 >/dev/null 2>&1; then
     echo "Error: python3 is required but not found in PATH"

--- a/toolkit/tools/internal/testutils/testutils.go
+++ b/toolkit/tools/internal/testutils/testutils.go
@@ -103,18 +103,6 @@ func GetDownloadedRpmsDir(t *testing.T, testutilsDir string, distro string, dist
 	return downloadedRpmsDir
 }
 
-func GetDownloadedToolsFile(t *testing.T, testutilsDir string, distro string, distroVersion string, createImage bool,
-) string {
-	toolsFileName := fmt.Sprintf("tools-%s-%s.tar.gz", distro, distroVersion)
-	toolsFilePath := filepath.Join(testutilsDir, "testrpms/build", toolsFileName)
-	if _, err := os.Stat(toolsFilePath); os.IsNotExist(err) {
-		t.Skipf("test requires downloaded tools file: %s;\n"+
-			"please run toolkit/tools/internal/testutils/testrpms/download-test-utils.sh -d %s -t %s -s %t",
-			toolsFilePath, distro, distroVersion, createImage)
-	}
-	return toolsFilePath
-}
-
 func GetDownloadedToolsDir(t *testing.T, testutilsDir string, distro string, distroVersion string, createImage bool,
 ) string {
 	toolsDirName := fmt.Sprintf("tools-%s-%s-dir", distro, distroVersion)

--- a/toolkit/tools/internal/testutils/testutils.go
+++ b/toolkit/tools/internal/testutils/testutils.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -112,6 +113,36 @@ func GetDownloadedToolsFile(t *testing.T, testutilsDir string, distro string, di
 			toolsFilePath, distro, distroVersion, createImage)
 	}
 	return toolsFilePath
+}
+
+func GetDownloadedToolsDir(t *testing.T, testutilsDir string, distro string, distroVersion string, createImage bool,
+) string {
+	toolsDirName := fmt.Sprintf("tools-%s-%s-dir", distro, distroVersion)
+	toolsDirPath := filepath.Join(testutilsDir, "testrpms/build", toolsDirName)
+
+	if _, err := os.Stat(toolsDirPath); err == nil {
+		return toolsDirPath
+	}
+
+	toolsFileName := fmt.Sprintf("tools-%s-%s.tar.gz", distro, distroVersion)
+	toolsFilePath := filepath.Join(testutilsDir, "testrpms/build", toolsFileName)
+	if _, err := os.Stat(toolsFilePath); os.IsNotExist(err) {
+		t.Skipf("test requires downloaded tools file: %s;\n"+
+			"please run toolkit/tools/internal/testutils/testrpms/download-test-utils.sh -d %s -t %s -s %t",
+			toolsFilePath, distro, distroVersion, createImage)
+	}
+
+	if err := os.MkdirAll(toolsDirPath, os.ModePerm); err != nil {
+		t.Fatalf("failed to create tools directory (%s): %v", toolsDirPath, err)
+	}
+
+	cmd := exec.Command("tar", "-x", "-z", "-f", toolsFilePath, "-C", toolsDirPath)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		_ = os.RemoveAll(toolsDirPath)
+		t.Fatalf("failed to extract tools tarball (%s): %v\n%s", toolsFilePath, err, out)
+	}
+
+	return toolsDirPath
 }
 
 func GetDownloadedRpmsRepoFile(t *testing.T, testutilsDir string, distro string, distroVersion string, withGpgKey bool,

--- a/toolkit/tools/internal/testutils/testutils.go
+++ b/toolkit/tools/internal/testutils/testutils.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -108,26 +107,10 @@ func GetDownloadedToolsDir(t *testing.T, testutilsDir string, distro string, dis
 	toolsDirName := fmt.Sprintf("tools-%s-%s-dir", distro, distroVersion)
 	toolsDirPath := filepath.Join(testutilsDir, "testrpms/build", toolsDirName)
 
-	if _, err := os.Stat(toolsDirPath); err == nil {
-		return toolsDirPath
-	}
-
-	toolsFileName := fmt.Sprintf("tools-%s-%s.tar.gz", distro, distroVersion)
-	toolsFilePath := filepath.Join(testutilsDir, "testrpms/build", toolsFileName)
-	if _, err := os.Stat(toolsFilePath); os.IsNotExist(err) {
-		t.Skipf("test requires downloaded tools file: %s;\n"+
+	if _, err := os.Stat(toolsDirPath); os.IsNotExist(err) {
+		t.Skipf("test requires downloaded tools dir: %s;\n"+
 			"please run toolkit/tools/internal/testutils/testrpms/download-test-utils.sh -d %s -t %s -s %t",
-			toolsFilePath, distro, distroVersion, createImage)
-	}
-
-	if err := os.MkdirAll(toolsDirPath, os.ModePerm); err != nil {
-		t.Fatalf("failed to create tools directory (%s): %v", toolsDirPath, err)
-	}
-
-	cmd := exec.Command("tar", "-x", "-z", "-f", toolsFilePath, "-C", toolsDirPath)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		_ = os.RemoveAll(toolsDirPath)
-		t.Fatalf("failed to extract tools tarball (%s): %v\n%s", toolsFilePath, err, out)
+			toolsDirPath, distro, distroVersion, createImage)
 	}
 
 	return toolsDirPath

--- a/toolkit/tools/pkg/imagecustomizerlib/createimage.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/createimage.go
@@ -23,7 +23,7 @@ type ImageCreateOptions struct {
 	BuildDir            string
 	Distro              targetos.Distro
 	DistroVersion       string
-	ToolsTar            string
+	ToolsDir            string
 	RpmsSources         []string
 	OutputImageFile     string
 	OutputImageFormat   imagecustomizerapi.ImageFormatType
@@ -107,7 +107,7 @@ func CreateImage(ctx context.Context, baseConfigPath string, config imagecustomi
 	logger.Log.Debugf("Part id to part uuid map %v\n", partIdToPartUuid)
 	logger.Log.Infof("Image UUID: %s", rc.ImageUuidStr)
 
-	partUuidToFstabEntry, osRelease, err := CustomizeImageHelperCreate(ctx, rc, options.ToolsTar,
+	partUuidToFstabEntry, osRelease, err := CustomizeImageHelperCreate(ctx, rc, options.ToolsDir,
 		distroHandler)
 	if err != nil {
 		return err

--- a/toolkit/tools/pkg/imagecustomizerlib/createimage_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/createimage_test.go
@@ -171,6 +171,8 @@ func TestCreateImageRawNoTar(t *testing.T) {
 }
 
 func testCreateImageRawNoTar(t *testing.T, name string, version string, configFile string) {
+	testutils.CheckSkipForCustomizeImageRequirements(t)
+
 	testTmpDir := filepath.Join(tmpDir, fmt.Sprintf("TestCreateImageRawNoTar_%s", name))
 	defer os.RemoveAll(testTmpDir)
 

--- a/toolkit/tools/pkg/imagecustomizerlib/createimage_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/createimage_test.go
@@ -48,7 +48,7 @@ func testCreateImageRaw(t *testing.T, name string, version string, configFile st
 	// get RPM sources
 	downloadedRpmsRepoFile := testutils.GetDownloadedRpmsRepoFile(t, testutilsDir, "azurelinux", version, false, true)
 	rpmSources := []string{downloadedRpmsRepoFile}
-	toolsFile := testutils.GetDownloadedToolsFile(t, testutilsDir, "azurelinux", version, true)
+	toolsFile := testutils.GetDownloadedToolsDir(t, testutilsDir, "azurelinux", version, true)
 
 	err := basicCreateImageWithConfigFile(
 		t.Context(), buildDir, partitionsConfigFile, rpmSources, toolsFile,
@@ -114,7 +114,7 @@ func testCreateImageBtrfs(t *testing.T, name string, version string, configFile 
 
 	downloadedRpmsRepoFile := testutils.GetDownloadedRpmsRepoFile(t, testutilsDir, "azurelinux", version, false, true)
 	rpmSources := []string{downloadedRpmsRepoFile}
-	toolsFile := testutils.GetDownloadedToolsFile(t, testutilsDir, "azurelinux", version, true)
+	toolsFile := testutils.GetDownloadedToolsDir(t, testutilsDir, "azurelinux", version, true)
 
 	err := basicCreateImageWithConfigFile(
 		t.Context(), buildDir, partitionsConfigFile, rpmSources, toolsFile,
@@ -171,8 +171,6 @@ func TestCreateImageRawNoTar(t *testing.T) {
 }
 
 func testCreateImageRawNoTar(t *testing.T, name string, version string, configFile string) {
-	testutils.CheckSkipForCustomizeImageRequirements(t)
-
 	testTmpDir := filepath.Join(tmpDir, fmt.Sprintf("TestCreateImageRawNoTar_%s", name))
 	defer os.RemoveAll(testTmpDir)
 
@@ -180,14 +178,14 @@ func testCreateImageRawNoTar(t *testing.T, name string, version string, configFi
 	partitionsConfigFile := filepath.Join(testDir, configFile)
 	outputImageFilePath := filepath.Join(testTmpDir, "image1.raw")
 
-	// get RPM sources
-	downloadedRpmsRepoFile := testutils.GetDownloadedRpmsRepoFile(t, testutilsDir, "azurelinux", version, false, true)
-	rpmSources := []string{downloadedRpmsRepoFile}
+	// Use testDir as a dummy RPM source — validation rejects missing tools dir before
+	// any RPM resolution occurs, so the source does not need to be a real repo.
+	rpmSources := []string{testDir}
 
 	err := basicCreateImageWithConfigFile(t.Context(), buildDir, partitionsConfigFile, rpmSources, "",
 		outputImageFilePath, "raw", "azurelinux", version)
 
-	assert.ErrorContains(t, err, "tools tar file is required for image creation")
+	assert.ErrorContains(t, err, "tools directory is required for image creation")
 }
 
 func TestCreateImageEmptyConfig(t *testing.T) {
@@ -236,7 +234,7 @@ func testCreateImage_OutputImageFileAsRelativePath(t *testing.T, name string, ve
 	assert.NoError(t, err)
 
 	rpmSources := []string{testutils.GetDownloadedRpmsRepoFile(t, testutilsDir, "azurelinux", version, false, true)}
-	toolsFile := testutils.GetDownloadedToolsFile(t, testutilsDir, "azurelinux", version, true)
+	toolsFile := testutils.GetDownloadedToolsDir(t, testutilsDir, "azurelinux", version, true)
 	outputImageFileAbsolute := filepath.Join(buildDir, "image1.raw")
 
 	cwd, err := os.Getwd()
@@ -273,12 +271,12 @@ func testCreateImage_OutputImageFileAsRelativePath(t *testing.T, name string, ve
 }
 
 func basicCreateImageWithConfigFile(ctx context.Context, buildDir string, configFile string, rpmsSources []string,
-	toolsTar string, outputImageFile string, outputImageFormat string, distro string, distroVersion string,
+	toolsDir string, outputImageFile string, outputImageFormat string, distro string, distroVersion string,
 ) error {
 	return CreateImageWithConfigFile(ctx, configFile, ImageCreateOptions{
 		BuildDir:          buildDir,
 		RpmsSources:       rpmsSources,
-		ToolsTar:          toolsTar,
+		ToolsDir:          toolsDir,
 		OutputImageFile:   outputImageFile,
 		OutputImageFormat: imagecustomizerapi.ImageFormatType(outputImageFormat),
 		Distro:            targetos.Distro(distro),
@@ -287,13 +285,13 @@ func basicCreateImageWithConfigFile(ctx context.Context, buildDir string, config
 }
 
 func basicCreateImage(ctx context.Context, buildDir string, baseConfigPath string, config imagecustomizerapi.Config,
-	rpmsSources []string, outputImageFile string, outputImageFormat string, toolsTar string, distro string,
+	rpmsSources []string, outputImageFile string, outputImageFormat string, toolsDir string, distro string,
 	distroVersion string,
 ) error {
 	return CreateImage(ctx, baseConfigPath, config, ImageCreateOptions{
 		BuildDir:          buildDir,
 		RpmsSources:       rpmsSources,
-		ToolsTar:          toolsTar,
+		ToolsDir:          toolsDir,
 		OutputImageFile:   outputImageFile,
 		OutputImageFormat: imagecustomizerapi.ImageFormatType(outputImageFormat),
 		Distro:            targetos.Distro(distro),

--- a/toolkit/tools/pkg/imagecustomizerlib/createimage_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/createimage_test.go
@@ -48,10 +48,10 @@ func testCreateImageRaw(t *testing.T, name string, version string, configFile st
 	// get RPM sources
 	downloadedRpmsRepoFile := testutils.GetDownloadedRpmsRepoFile(t, testutilsDir, "azurelinux", version, false, true)
 	rpmSources := []string{downloadedRpmsRepoFile}
-	toolsFile := testutils.GetDownloadedToolsDir(t, testutilsDir, "azurelinux", version, true)
+	toolsDir := testutils.GetDownloadedToolsDir(t, testutilsDir, "azurelinux", version, true)
 
 	err := basicCreateImageWithConfigFile(
-		t.Context(), buildDir, partitionsConfigFile, rpmSources, toolsFile,
+		t.Context(), buildDir, partitionsConfigFile, rpmSources, toolsDir,
 		outputImageFilePath, outputImageFormat, "azurelinux", version)
 	if !assert.NoError(t, err) {
 		return
@@ -114,10 +114,10 @@ func testCreateImageBtrfs(t *testing.T, name string, version string, configFile 
 
 	downloadedRpmsRepoFile := testutils.GetDownloadedRpmsRepoFile(t, testutilsDir, "azurelinux", version, false, true)
 	rpmSources := []string{downloadedRpmsRepoFile}
-	toolsFile := testutils.GetDownloadedToolsDir(t, testutilsDir, "azurelinux", version, true)
+	toolsDir := testutils.GetDownloadedToolsDir(t, testutilsDir, "azurelinux", version, true)
 
 	err := basicCreateImageWithConfigFile(
-		t.Context(), buildDir, partitionsConfigFile, rpmSources, toolsFile,
+		t.Context(), buildDir, partitionsConfigFile, rpmSources, toolsDir,
 		outputImageFilePath, outputImageFormat, "azurelinux", version)
 	if !assert.NoError(t, err) {
 		return
@@ -234,7 +234,7 @@ func testCreateImage_OutputImageFileAsRelativePath(t *testing.T, name string, ve
 	assert.NoError(t, err)
 
 	rpmSources := []string{testutils.GetDownloadedRpmsRepoFile(t, testutilsDir, "azurelinux", version, false, true)}
-	toolsFile := testutils.GetDownloadedToolsDir(t, testutilsDir, "azurelinux", version, true)
+	toolsDir := testutils.GetDownloadedToolsDir(t, testutilsDir, "azurelinux", version, true)
 	outputImageFileAbsolute := filepath.Join(buildDir, "image1.raw")
 
 	cwd, err := os.Getwd()
@@ -251,7 +251,7 @@ func testCreateImage_OutputImageFileAsRelativePath(t *testing.T, name string, ve
 	// Pass the output image file relative to the current working directory through the argument.
 	// This will create the file at the absolute path.
 	err = basicCreateImage(t.Context(), buildDir, baseConfigPath, config, rpmSources, outputImageFile,
-		outputImageFormat, toolsFile, "azurelinux", version)
+		outputImageFormat, toolsDir, "azurelinux", version)
 	assert.NoError(t, err)
 	assert.FileExists(t, outputImageFileAbsolute)
 	err = os.Remove(outputImageFileAbsolute)
@@ -263,7 +263,7 @@ func testCreateImage_OutputImageFileAsRelativePath(t *testing.T, name string, ve
 	// Pass the output image file relative to the config file through the config. This will create
 	// the file at the absolute path.
 	err = basicCreateImage(t.Context(), buildDir, baseConfigPath, config, rpmSources, outputImageFile,
-		outputImageFormat, toolsFile, "azurelinux", version)
+		outputImageFormat, toolsDir, "azurelinux", version)
 	assert.NoError(t, err)
 	assert.FileExists(t, outputImageFileAbsolute)
 	err = os.Remove(outputImageFileAbsolute)

--- a/toolkit/tools/pkg/imagecustomizerlib/createimagehelper.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/createimagehelper.go
@@ -53,6 +53,11 @@ func CustomizeImageHelperCreate(ctx context.Context, rc *ResolvedConfig, toolsDi
 		return nil, "", err
 	}
 
+	err = toolsChroot.Close(false)
+	if err != nil {
+		return nil, "", err
+	}
+
 	return partitionsLayout, osRelease, nil
 }
 

--- a/toolkit/tools/pkg/imagecustomizerlib/createimagehelper.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/createimagehelper.go
@@ -19,11 +19,11 @@ func CustomizeImageHelperCreate(ctx context.Context, rc *ResolvedConfig, toolsDi
 ) ([]fstabEntryPartNum, string, error) {
 	logger.Log.Debugf("Customizing OS image")
 
-	toolsChroot, cleanup, err := initToolsChroot(ctx, toolsDir)
+	toolsChroot, err := initToolsChroot(toolsDir)
 	if err != nil {
 		return nil, "", err
 	}
-	defer cleanup()
+	defer toolsChroot.Close(ctx)
 
 	imageConnection, partitionsLayout, _, _, _, err := connectToExistingImage(ctx, rc.RawImageFile, toolsDir,
 		toolsRootImageDir, true, false, false, false, distroHandler)
@@ -33,7 +33,7 @@ func CustomizeImageHelperCreate(ctx context.Context, rc *ResolvedConfig, toolsDi
 	defer imageConnection.Close()
 
 	// Do the actual customizations.
-	err = doOsCustomizationsCreate(ctx, rc, imageConnection, toolsChroot, partitionsLayout, distroHandler)
+	err = doOsCustomizationsCreate(ctx, rc, imageConnection, toolsChroot.Chroot(), partitionsLayout, distroHandler)
 
 	// Out of disk space errors can be difficult to diagnose.
 	// So, warn about any partitions with low free space.
@@ -53,7 +53,7 @@ func CustomizeImageHelperCreate(ctx context.Context, rc *ResolvedConfig, toolsDi
 		return nil, "", err
 	}
 
-	err = toolsChroot.Close(false)
+	err = toolsChroot.CleanClose(ctx)
 	if err != nil {
 		return nil, "", err
 	}
@@ -72,6 +72,9 @@ func doOsCustomizationsCreate(
 	imageChroot := imageConnection.Chroot()
 	buildTime := time.Now().Format(buildTimeFormat)
 
+	// Override resolv.conf inside the image chroot so user scripts and RPM
+	// scriptlets, run via tdnf --installroot, have DNS. The tools chroot's own
+	// resolv.conf is handled separately by initToolsChroot.
 	resolvConf, err := overrideResolvConf(imageChroot)
 	if err != nil {
 		return err

--- a/toolkit/tools/pkg/imagecustomizerlib/createimagehelper.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/createimagehelper.go
@@ -19,25 +19,13 @@ func CustomizeImageHelperCreate(ctx context.Context, rc *ResolvedConfig, toolsDi
 ) ([]fstabEntryPartNum, string, error) {
 	logger.Log.Debugf("Customizing OS image")
 
-	toolsChrootDir := toolsDir
-	toolsChroot := safechroot.NewChroot(toolsChrootDir, true)
-	if err := toolsChroot.Initialize("", nil, nil, true); err != nil {
-		return nil, "", fmt.Errorf("failed to initialize tools chroot from %s:\n%w", toolsDir, err)
-	}
-	defer toolsChroot.Close(false)
-
-	toolsResolvConf, err := overrideResolvConf(toolsChroot)
+	toolsChroot, cleanup, err := initToolsChroot(ctx, toolsDir)
 	if err != nil {
-		return nil, "", fmt.Errorf("failed to override resolv.conf in tools chroot:\n%w", err)
+		return nil, "", err
 	}
-	defer func() {
-		if restoreErr := restoreResolvConf(ctx, toolsResolvConf, toolsChroot); restoreErr != nil {
-			logger.Log.Warnf("Failed to restore resolv.conf in tools chroot (%s): %v",
-				toolsChrootDir, restoreErr)
-		}
-	}()
+	defer cleanup()
 
-	imageConnection, partitionsLayout, _, _, _, err := connectToExistingImage(ctx, rc.RawImageFile, toolsChrootDir,
+	imageConnection, partitionsLayout, _, _, _, err := connectToExistingImage(ctx, rc.RawImageFile, toolsDir,
 		toolsRootImageDir, true, false, false, false, distroHandler)
 	if err != nil {
 		return nil, "", err
@@ -61,12 +49,6 @@ func CustomizeImageHelperCreate(ctx context.Context, rc *ResolvedConfig, toolsDi
 	}
 
 	err = imageConnection.CleanClose()
-	if err != nil {
-		return nil, "", err
-	}
-
-	// Close the tools chroot and image connection.
-	err = toolsChroot.Close(false)
 	if err != nil {
 		return nil, "", err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/createimagehelper.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/createimagehelper.go
@@ -19,11 +19,11 @@ func CustomizeImageHelperCreate(ctx context.Context, rc *ResolvedConfig, toolsDi
 ) ([]fstabEntryPartNum, string, error) {
 	logger.Log.Debugf("Customizing OS image")
 
-	toolsChroot, err := initToolsChroot(toolsDir)
+	toolsChroot, err := initToolsChroot(ctx, toolsDir)
 	if err != nil {
 		return nil, "", err
 	}
-	defer toolsChroot.Close(ctx)
+	defer toolsChroot.Close()
 
 	imageConnection, partitionsLayout, _, _, _, err := connectToExistingImage(ctx, rc.RawImageFile, toolsDir,
 		toolsRootImageDir, true, false, false, false, distroHandler)
@@ -53,7 +53,7 @@ func CustomizeImageHelperCreate(ctx context.Context, rc *ResolvedConfig, toolsDi
 		return nil, "", err
 	}
 
-	err = toolsChroot.CleanClose(ctx)
+	err = toolsChroot.CleanClose()
 	if err != nil {
 		return nil, "", err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/createimagehelper.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/createimagehelper.go
@@ -6,6 +6,7 @@ package imagecustomizerlib
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -13,18 +14,24 @@ import (
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/imageconnection"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/logger"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safechroot"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/shell"
 )
 
-func CustomizeImageHelperCreate(ctx context.Context, rc *ResolvedConfig, tarFile string,
+func CustomizeImageHelperCreate(ctx context.Context, rc *ResolvedConfig, toolsDir string,
 	distroHandler DistroHandler,
 ) ([]fstabEntryPartNum, string, error) {
 	logger.Log.Debugf("Customizing OS image")
 
 	toolsChrootDir := filepath.Join(rc.BuildDirAbs, toolsRoot)
-	toolsChroot := safechroot.NewChroot(toolsChrootDir, false)
-	err := toolsChroot.Initialize(tarFile, nil, nil, true)
-	if err != nil {
-		return nil, "", err
+	if err := os.MkdirAll(toolsChrootDir, os.ModePerm); err != nil {
+		return nil, "", fmt.Errorf("failed to create tools chroot directory:\n%w", err)
+	}
+	if _, _, err := shell.Execute("cp", "-a", toolsDir+"/.", toolsChrootDir); err != nil {
+		return nil, "", fmt.Errorf("failed to copy tools directory (%s):\n%w", toolsDir, err)
+	}
+	toolsChroot := safechroot.NewChroot(toolsChrootDir, true)
+	if err := toolsChroot.Initialize("", nil, nil, true); err != nil {
+		return nil, "", fmt.Errorf("failed to initialize tools chroot from %s:\n%w", toolsDir, err)
 	}
 	defer toolsChroot.Close(false)
 

--- a/toolkit/tools/pkg/imagecustomizerlib/createimagehelper.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/createimagehelper.go
@@ -6,15 +6,12 @@ package imagecustomizerlib
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/installutils"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/imageconnection"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/logger"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safechroot"
-	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/shell"
 )
 
 func CustomizeImageHelperCreate(ctx context.Context, rc *ResolvedConfig, toolsDir string,
@@ -22,18 +19,23 @@ func CustomizeImageHelperCreate(ctx context.Context, rc *ResolvedConfig, toolsDi
 ) ([]fstabEntryPartNum, string, error) {
 	logger.Log.Debugf("Customizing OS image")
 
-	toolsChrootDir := filepath.Join(rc.BuildDirAbs, toolsRoot)
-	if err := os.MkdirAll(toolsChrootDir, os.ModePerm); err != nil {
-		return nil, "", fmt.Errorf("failed to create tools chroot directory:\n%w", err)
-	}
-	if _, _, err := shell.Execute("cp", "-a", toolsDir+"/.", toolsChrootDir); err != nil {
-		return nil, "", fmt.Errorf("failed to copy tools directory (%s):\n%w", toolsDir, err)
-	}
+	toolsChrootDir := toolsDir
 	toolsChroot := safechroot.NewChroot(toolsChrootDir, true)
 	if err := toolsChroot.Initialize("", nil, nil, true); err != nil {
 		return nil, "", fmt.Errorf("failed to initialize tools chroot from %s:\n%w", toolsDir, err)
 	}
 	defer toolsChroot.Close(false)
+
+	toolsResolvConf, err := overrideResolvConf(toolsChroot)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to override resolv.conf in tools chroot:\n%w", err)
+	}
+	defer func() {
+		if restoreErr := restoreResolvConf(ctx, toolsResolvConf, toolsChroot); restoreErr != nil {
+			logger.Log.Warnf("Failed to restore resolv.conf in tools chroot (%s): %v",
+				toolsChrootDir, restoreErr)
+		}
+	}()
 
 	imageConnection, partitionsLayout, _, _, _, err := connectToExistingImage(ctx, rc.RawImageFile, toolsChrootDir,
 		toolsRootImageDir, true, false, false, false, distroHandler)
@@ -83,7 +85,7 @@ func doOsCustomizationsCreate(
 	imageChroot := imageConnection.Chroot()
 	buildTime := time.Now().Format(buildTimeFormat)
 
-	resolvConf, err := overrideResolvConf(toolsChroot)
+	resolvConf, err := overrideResolvConf(imageChroot)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/createimagevalidation.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/createimagevalidation.go
@@ -124,6 +124,9 @@ func validateCreateImageMandatoryFields(baseConfigPath string, config *imagecust
 		return fmt.Errorf("rpm sources must be specified for creating a seed image")
 	}
 
+	if toolsDir == "" {
+		return fmt.Errorf("tools directory is required for image creation")
+	}
 	err := validateToolsDir(toolsDir)
 	if err != nil {
 		return err
@@ -133,10 +136,6 @@ func validateCreateImageMandatoryFields(baseConfigPath string, config *imagecust
 }
 
 func validateToolsDir(toolsDir string) error {
-	if toolsDir == "" {
-		return fmt.Errorf("tools directory is required for image creation")
-	}
-
 	info, err := os.Stat(toolsDir)
 	if os.IsNotExist(err) {
 		return fmt.Errorf("tools directory (%s) does not exist", toolsDir)

--- a/toolkit/tools/pkg/imagecustomizerlib/createimagevalidation.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/createimagevalidation.go
@@ -4,8 +4,6 @@
 package imagecustomizerlib
 
 import (
-	"archive/tar"
-	"compress/gzip"
 	"context"
 	"fmt"
 	"os"
@@ -83,7 +81,7 @@ func validateCreateImageConfig(ctx context.Context, baseConfigPath string, confi
 	}
 
 	// Validate mandatory fields for creating a seed image
-	err = validateCreateImageMandatoryFields(baseConfigPath, config, options.RpmsSources, options.ToolsTar)
+	err = validateCreateImageMandatoryFields(baseConfigPath, config, options.RpmsSources, options.ToolsDir)
 	if err != nil {
 		return nil, err
 	}
@@ -114,7 +112,7 @@ func validateCreateImageConfig(ctx context.Context, baseConfigPath string, confi
 }
 
 func validateCreateImageMandatoryFields(baseConfigPath string, config *imagecustomizerapi.Config,
-	rpmsSources []string, toolsTar string,
+	rpmsSources []string, toolsDir string,
 ) error {
 	// check if storage disks is not empty for creating a seed image
 	if len(config.Storage.Disks) == 0 {
@@ -126,7 +124,7 @@ func validateCreateImageMandatoryFields(baseConfigPath string, config *imagecust
 		return fmt.Errorf("rpm sources must be specified for creating a seed image")
 	}
 
-	err := validateToolsTarFile(toolsTar)
+	err := validateToolsDir(toolsDir)
 	if err != nil {
 		return err
 	}
@@ -134,46 +132,21 @@ func validateCreateImageMandatoryFields(baseConfigPath string, config *imagecust
 	return nil
 }
 
-func validateToolsTarFile(toolsTar string) error {
-	// Check if the tools tar file exists
-	if toolsTar == "" {
-		return fmt.Errorf("tools tar file is required for image creation")
+func validateToolsDir(toolsDir string) error {
+	if toolsDir == "" {
+		return fmt.Errorf("tools directory is required for image creation")
 	}
-	if _, err := os.Stat(toolsTar); os.IsNotExist(err) {
-		return fmt.Errorf("tools tar file (%s) does not exist", toolsTar)
+
+	info, err := os.Stat(toolsDir)
+	if os.IsNotExist(err) {
+		return fmt.Errorf("tools directory (%s) does not exist", toolsDir)
 	}
-	// Check if the tools tar file is a valid tar file
-	isValid, err := isValidTarGz(toolsTar)
 	if err != nil {
-		return fmt.Errorf("failed to validate tools tar file (%s): %w", toolsTar, err)
+		return fmt.Errorf("failed to stat tools directory (%s):\n%w", toolsDir, err)
 	}
-	if !isValid {
-		return fmt.Errorf("tools tar file (%s) is not a valid tar.gz file", toolsTar)
+	if !info.IsDir() {
+		return fmt.Errorf("tools path (%s) is not a directory", toolsDir)
 	}
 
 	return nil
-}
-
-func isValidTarGz(path string) (bool, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return false, fmt.Errorf("failed to open file: %w", err)
-	}
-	defer file.Close()
-
-	// Check gzip header
-	gzReader, err := gzip.NewReader(file)
-	if err != nil {
-		return false, fmt.Errorf("not a valid gzip file: %w", err)
-	}
-	defer gzReader.Close()
-
-	// Check tar structure
-	tarReader := tar.NewReader(gzReader)
-	_, err = tarReader.Next()
-	if err != nil {
-		return false, fmt.Errorf("not a valid tar archive: %w", err)
-	}
-
-	return true, nil
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/createimagevalidation_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/createimagevalidation_test.go
@@ -4,8 +4,6 @@
 package imagecustomizerlib
 
 import (
-	"archive/tar"
-	"compress/gzip"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -16,38 +14,6 @@ import (
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/file"
 	"github.com/stretchr/testify/assert"
 )
-
-func createDummyTarGz(filename string) error {
-	// Create the output file
-	outFile, err := os.Create(filename)
-	if err != nil {
-		return fmt.Errorf("failed to create file: %w", err)
-	}
-	defer outFile.Close()
-
-	// Create a gzip writer
-	gzWriter := gzip.NewWriter(outFile)
-	defer gzWriter.Close()
-
-	// Create a tar writer
-	tarWriter := tar.NewWriter(gzWriter)
-	defer tarWriter.Close()
-
-	content := []byte("dummy content")
-	header := &tar.Header{
-		Name: "dummy.txt",
-		Mode: 0o600,
-		Size: int64(len(content)),
-	}
-	if err := tarWriter.WriteHeader(header); err != nil {
-		return fmt.Errorf("failed to write tar header: %w", err)
-	}
-	if _, err := tarWriter.Write(content); err != nil {
-		return fmt.Errorf("failed to write tar content: %w", err)
-	}
-
-	return nil
-}
 
 func TestValidateCreateImageOutput_AcceptsValidPaths(t *testing.T) {
 	for _, vi := range []struct {
@@ -80,8 +46,8 @@ func testValidateCreateImageOutput_AcceptsValidPaths(t *testing.T, name string, 
 	err = imagecustomizerapi.UnmarshalYamlFile(configFile, &config)
 	assert.NoError(t, err)
 
-	toolsFile := filepath.Join(testTmpDir, "tools.tar.gz")
-	err = createDummyTarGz(toolsFile)
+	toolsDir := filepath.Join(testTmpDir, "tools-dir")
+	err = os.MkdirAll(toolsDir, os.ModePerm)
 	assert.NoError(t, err)
 	// just use the base config path as the RPM sources for this test
 	// since we are not testing the RPM sources here.
@@ -111,7 +77,7 @@ func testValidateCreateImageOutput_AcceptsValidPaths(t *testing.T, name string, 
 
 	options := ImageCreateOptions{
 		BuildDir:          buildDir,
-		ToolsTar:          toolsFile,
+		ToolsDir:          toolsDir,
 		RpmsSources:       rpmSources,
 		OutputImageFile:   outputImageFileNew,
 		OutputImageFormat: imagecustomizerapi.ImageFormatType(filepath.Ext(outputImageFileNew)[1:]),
@@ -251,10 +217,10 @@ func testValidateCreateImageConfig_EmptyPackagestoInstall(t *testing.T, name str
 		OutputImageFile:   filepath.Join(testDir, "output.vhdx"),
 		OutputImageFormat: "vhdx",
 		BuildDir:          "./",
-		ToolsTar:          filepath.Join(testTmpDir, "tools.tar.gz"),
+		ToolsDir:          filepath.Join(testTmpDir, "tools-dir"),
 	}
 
-	err = createDummyTarGz(options.ToolsTar)
+	err = os.MkdirAll(options.ToolsDir, os.ModePerm)
 	assert.NoError(t, err)
 	// Set the packages to install to an empty slice
 	config.OS.Packages.Install = []string{}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/imageconnection"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safechroot"
 )
 
 const (
@@ -26,6 +27,7 @@ var ErrUkiKernelModified = NewImageCustomizerError("UKI:KernelModified",
 
 func doOsCustomizations(ctx context.Context, rc *ResolvedConfig, imageConnection *imageconnection.ImageConnection,
 	partitionsCustomized bool, partitionsLayout []fstabEntryPartNum, distroHandler DistroHandler,
+	toolsChroot *safechroot.Chroot,
 ) error {
 	var err error
 
@@ -33,7 +35,14 @@ func doOsCustomizations(ctx context.Context, rc *ResolvedConfig, imageConnection
 
 	buildTime := time.Now().Format(buildTimeFormat)
 
-	resolvConf, err := overrideResolvConf(imageChroot)
+	// When a tools chroot is used, network access (for package downloads) runs
+	// inside it, so resolv.conf must be overridden there. Without a tools chroot,
+	// the package manager runs inside the image chroot directly.
+	resolvConfChroot := imageChroot
+	if toolsChroot != nil {
+		resolvConfChroot = toolsChroot
+	}
+	resolvConf, err := overrideResolvConf(resolvConfChroot)
 	if err != nil {
 		return err
 	}
@@ -78,7 +87,7 @@ func doOsCustomizations(ctx context.Context, rc *ResolvedConfig, imageConnection
 		}
 
 		err = addRemoveAndUpdatePackages(ctx, rc.BuildDirAbs, configWithBase.BaseConfigPath, configWithBase.Config.OS,
-			imageChroot, nil, rc.Options.RpmsSources, rc.Options.UseBaseImageRpmRepos, distroHandler,
+			imageChroot, toolsChroot, rc.Options.RpmsSources, rc.Options.UseBaseImageRpmRepos, distroHandler,
 			snapshotTime)
 		if err != nil {
 			return err
@@ -202,7 +211,7 @@ func doOsCustomizations(ctx context.Context, rc *ResolvedConfig, imageConnection
 		return err
 	}
 
-	err = restoreResolvConf(ctx, resolvConf, imageChroot)
+	err = restoreResolvConf(ctx, resolvConf, resolvConfChroot)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
@@ -35,14 +35,10 @@ func doOsCustomizations(ctx context.Context, rc *ResolvedConfig, imageConnection
 
 	buildTime := time.Now().Format(buildTimeFormat)
 
-	// When a tools chroot is used, network access (for package downloads) runs
-	// inside it, so resolv.conf must be overridden there. Without a tools chroot,
-	// the package manager runs inside the image chroot directly.
-	resolvConfChroot := imageChroot
-	if toolsChroot != nil {
-		resolvConfChroot = toolsChroot
-	}
-	resolvConf, err := overrideResolvConf(resolvConfChroot)
+	// The toolsChroot (when present) has its own resolv.conf overridden at chroot
+	// initialization time; here we override the imageChroot's so that user scripts
+	// (e.g. postCustomization) have network access.
+	resolvConf, err := overrideResolvConf(imageChroot)
 	if err != nil {
 		return err
 	}
@@ -211,7 +207,7 @@ func doOsCustomizations(ctx context.Context, rc *ResolvedConfig, imageConnection
 		return err
 	}
 
-	err = restoreResolvConf(ctx, resolvConf, resolvConfChroot)
+	err = restoreResolvConf(ctx, resolvConf, imageChroot)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
@@ -79,8 +79,7 @@ func (d *aclDistroHandler) ValidateConfig(rc *ResolvedConfig) error {
 			pkgs.UpdateExistingPackages {
 			if rc.Options.ToolsDir == "" {
 				return fmt.Errorf("ACL package operations require --tools-dir: " +
-					"ACL images do not include a package manager; " +
-					"provide a tools directory via --tools-dir")
+					"ACL images do not include a package manager")
 			}
 		}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
@@ -77,10 +77,10 @@ func (d *aclDistroHandler) ValidateConfig(rc *ResolvedConfig) error {
 			len(pkgs.Remove) > 0 || len(pkgs.RemoveLists) > 0 ||
 			len(pkgs.Update) > 0 || len(pkgs.UpdateLists) > 0 ||
 			pkgs.UpdateExistingPackages {
-			if rc.Options.ToolsTar == "" {
-				return fmt.Errorf("ACL package operations require --tools-file: " +
+			if rc.Options.ToolsDir == "" {
+				return fmt.Errorf("ACL package operations require --tools-dir: " +
 					"ACL images do not include a package manager; " +
-					"provide a tools tarball via --tools-file")
+					"provide a tools directory via --tools-dir")
 			}
 		}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
@@ -77,7 +77,11 @@ func (d *aclDistroHandler) ValidateConfig(rc *ResolvedConfig) error {
 			len(pkgs.Remove) > 0 || len(pkgs.RemoveLists) > 0 ||
 			len(pkgs.Update) > 0 || len(pkgs.UpdateLists) > 0 ||
 			pkgs.UpdateExistingPackages {
-			return fmt.Errorf("package operations are not yet supported for ACL")
+			if rc.Options.ToolsTar == "" {
+				return fmt.Errorf("ACL package operations require --tools-file: " +
+					"ACL images do not include a package manager; " +
+					"provide a tools tarball via --tools-file")
+			}
 		}
 
 		if os.Overlays != nil {

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_test.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/targetos"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -112,4 +114,32 @@ func testCustomizeImageDistroVersionNewHelper(t *testing.T, testName string, bas
 	if !assert.NoError(t, err) {
 		return
 	}
+}
+
+func TestAclValidateConfigPackageOpsRequireToolsDir(t *testing.T) {
+	handler := newAclDistroHandler(targetos.TargetOsAzureContainerLinux3)
+
+	rc := &ResolvedConfig{
+		PreviewFeatures: []imagecustomizerapi.PreviewFeature{
+			imagecustomizerapi.PreviewFeatureAzureContainerLinux,
+		},
+		ConfigChain: []*ConfigWithBasePath{
+			{
+				Config: &imagecustomizerapi.Config{
+					OS: &imagecustomizerapi.OS{
+						Packages: imagecustomizerapi.Packages{
+							Install: []string{"vim"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	err := handler.ValidateConfig(rc)
+	assert.ErrorContains(t, err, "ACL package operations require --tools-dir")
+
+	rc.Options.ToolsDir = "/some/tools/dir"
+	err = handler.ValidateConfig(rc)
+	assert.NoError(t, err)
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -17,6 +17,7 @@ import (
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/imageconnection"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/logger"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/osinfo"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safechroot"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/shell"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/vhdutils"
 	"go.opentelemetry.io/otel"
@@ -683,13 +684,11 @@ func customizeImageHelper(ctx context.Context, rc *ResolvedConfig, partitionsCus
 			return nil, nil, nil, "", err
 		}
 		var err error
-		toolsChroot, err = initToolsChroot(rc.Options.ToolsDir)
+		toolsChroot, err = initToolsChroot(ctx, rc.Options.ToolsDir)
 		if err != nil {
 			return nil, nil, nil, "", err
 		}
-		// Close must run AFTER imageConnection.Close so the image unmounts
-		// before the tools chroot directory is torn down.
-		defer toolsChroot.Close(ctx)
+		defer toolsChroot.Close()
 		mountBaseDir = rc.Options.ToolsDir
 		mountPointName = toolsRootImageDir
 	}
@@ -729,7 +728,11 @@ func customizeImageHelper(ctx context.Context, rc *ResolvedConfig, partitionsCus
 	}
 
 	// Do the actual customizations.
-	err = doOsCustomizations(ctx, rc, imageConnection, partitionsCustomized, partitionsLayout, distroHandler, toolsChroot.Chroot())
+	var toolsChrootInner *safechroot.Chroot
+	if toolsChroot != nil {
+		toolsChrootInner = toolsChroot.Chroot()
+	}
+	err = doOsCustomizations(ctx, rc, imageConnection, partitionsCustomized, partitionsLayout, distroHandler, toolsChrootInner)
 
 	// Out of disk space errors can be difficult to diagnose.
 	// So, warn about any partitions with low free space.
@@ -751,7 +754,7 @@ func customizeImageHelper(ctx context.Context, rc *ResolvedConfig, partitionsCus
 	}
 
 	if toolsChroot != nil {
-		err = toolsChroot.CleanClose(ctx)
+		err = toolsChroot.CleanClose()
 		if err != nil {
 			return nil, nil, nil, "", err
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -752,6 +752,13 @@ func customizeImageHelper(ctx context.Context, rc *ResolvedConfig, partitionsCus
 		return nil, nil, nil, "", err
 	}
 
+	if toolsChroot != nil {
+		err = toolsChroot.Close(false)
+		if err != nil {
+			return nil, nil, nil, "", err
+		}
+	}
+
 	return partitionsLayout, baseImageVerityMetadata, readonlyPartUuids, osRelease, nil
 }
 

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -95,7 +95,6 @@ const (
 	diskFreeWarnThresholdBytes   = 500 * diskutils.MiB
 	diskFreeWarnThresholdPercent = 0.05
 	toolsRootImageDir            = "_imageroot"
-	toolsRoot                    = "toolsroot"
 
 	OtelTracerName = "imagecustomizerlib"
 )
@@ -674,18 +673,14 @@ func customizeImageHelper(ctx context.Context, rc *ResolvedConfig, partitionsCus
 
 	readOnlyVerity := rc.Storage.ReinitializeVerity != imagecustomizerapi.ReinitializeVerityTypeAll
 
-	// If a tools directory is provided, copy it to the build directory and initialize a tools chroot from it.
+	// Use the user-supplied tools directory directly as the tools chroot to avoid
+	// the cost of copying it into the build directory. The resolv.conf override
+	// is restored on exit so the directory remains reusable across invocations.
 	var toolsChroot *safechroot.Chroot
 	mountBaseDir := rc.BuildDirAbs
 	mountPointName := "imageroot"
 	if rc.Options.ToolsDir != "" {
-		toolsChrootDir := filepath.Join(rc.BuildDirAbs, toolsRoot)
-		if err := os.MkdirAll(toolsChrootDir, os.ModePerm); err != nil {
-			return nil, nil, nil, "", fmt.Errorf("failed to create tools chroot directory:\n%w", err)
-		}
-		if _, _, err := shell.Execute("cp", "-a", rc.Options.ToolsDir+"/.", toolsChrootDir); err != nil {
-			return nil, nil, nil, "", fmt.Errorf("failed to copy tools directory (%s):\n%w", rc.Options.ToolsDir, err)
-		}
+		toolsChrootDir := rc.Options.ToolsDir
 		toolsChroot = safechroot.NewChroot(toolsChrootDir, true)
 		if err := toolsChroot.Initialize("", nil, nil, true); err != nil {
 			return nil, nil, nil, "", fmt.Errorf("failed to initialize tools chroot from %s:\n%w", rc.Options.ToolsDir, err)
@@ -693,6 +688,16 @@ func customizeImageHelper(ctx context.Context, rc *ResolvedConfig, partitionsCus
 		// toolsChroot must be closed AFTER imageConnection so the image unmounts
 		// before the tools chroot directory is torn down.
 		defer toolsChroot.Close(false)
+		toolsResolvConf, err := overrideResolvConf(toolsChroot)
+		if err != nil {
+			return nil, nil, nil, "", fmt.Errorf("failed to override resolv.conf in tools chroot:\n%w", err)
+		}
+		defer func() {
+			if restoreErr := restoreResolvConf(ctx, toolsResolvConf, toolsChroot); restoreErr != nil {
+				logger.Log.Warnf("Failed to restore resolv.conf in tools chroot (%s): %v",
+					toolsChrootDir, restoreErr)
+			}
+		}()
 		mountBaseDir = toolsChrootDir
 		mountPointName = toolsRootImageDir
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -17,6 +17,7 @@ import (
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/imageconnection"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/logger"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/osinfo"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safechroot"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/shell"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/vhdutils"
 	"go.opentelemetry.io/otel"
@@ -673,8 +674,26 @@ func customizeImageHelper(ctx context.Context, rc *ResolvedConfig, partitionsCus
 
 	readOnlyVerity := rc.Storage.ReinitializeVerity != imagecustomizerapi.ReinitializeVerityTypeAll
 
+	// If a tools tarball is provided, initialize a tools chroot from it.
+	var toolsChroot *safechroot.Chroot
+	mountBaseDir := rc.BuildDirAbs
+	mountPointName := "imageroot"
+	if rc.Options.ToolsTar != "" {
+		toolsChrootDir := filepath.Join(rc.BuildDirAbs, toolsRoot)
+		toolsChroot = safechroot.NewChroot(toolsChrootDir, false)
+		err := toolsChroot.Initialize(rc.Options.ToolsTar, nil, nil, true)
+		if err != nil {
+			return nil, nil, nil, "", fmt.Errorf("failed to initialize tools chroot from %s:\n%w", rc.Options.ToolsTar, err)
+		}
+		// toolsChroot must be closed AFTER imageConnection so the image unmounts
+		// before the tools chroot directory is torn down.
+		defer toolsChroot.Close(false)
+		mountBaseDir = toolsChrootDir
+		mountPointName = toolsRootImageDir
+	}
+
 	imageConnection, partitionsLayout, baseImageVerityMetadata, readonlyPartUuids, _, err := connectToExistingImage(
-		ctx, rc.RawImageFile, rc.BuildDirAbs, "imageroot", true, false, readOnlyVerity, false, distroHandler)
+		ctx, rc.RawImageFile, mountBaseDir, mountPointName, true, false, readOnlyVerity, false, distroHandler)
 	if err != nil {
 		return nil, nil, nil, "", err
 	}
@@ -708,7 +727,7 @@ func customizeImageHelper(ctx context.Context, rc *ResolvedConfig, partitionsCus
 	}
 
 	// Do the actual customizations.
-	err = doOsCustomizations(ctx, rc, imageConnection, partitionsCustomized, partitionsLayout, distroHandler)
+	err = doOsCustomizations(ctx, rc, imageConnection, partitionsCustomized, partitionsLayout, distroHandler, toolsChroot)
 
 	// Out of disk space errors can be difficult to diagnose.
 	// So, warn about any partitions with low free space.

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -17,7 +17,6 @@ import (
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/imageconnection"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/logger"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/osinfo"
-	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safechroot"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/shell"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/vhdutils"
 	"go.opentelemetry.io/otel"
@@ -676,22 +675,21 @@ func customizeImageHelper(ctx context.Context, rc *ResolvedConfig, partitionsCus
 	// Use the user-supplied tools directory directly as the tools chroot to avoid
 	// the cost of copying it into the build directory. The resolv.conf override
 	// is restored on exit so the directory remains reusable across invocations.
-	var toolsChroot *safechroot.Chroot
+	var toolsChroot *ToolsChroot
 	mountBaseDir := rc.BuildDirAbs
 	mountPointName := "imageroot"
 	if rc.Options.ToolsDir != "" {
 		if err := validateToolsDir(rc.Options.ToolsDir); err != nil {
 			return nil, nil, nil, "", err
 		}
-		var cleanup func()
 		var err error
-		toolsChroot, cleanup, err = initToolsChroot(ctx, rc.Options.ToolsDir)
+		toolsChroot, err = initToolsChroot(rc.Options.ToolsDir)
 		if err != nil {
 			return nil, nil, nil, "", err
 		}
-		// cleanup must run AFTER imageConnection.Close so the image unmounts
+		// Close must run AFTER imageConnection.Close so the image unmounts
 		// before the tools chroot directory is torn down.
-		defer cleanup()
+		defer toolsChroot.Close(ctx)
 		mountBaseDir = rc.Options.ToolsDir
 		mountPointName = toolsRootImageDir
 	}
@@ -731,7 +729,7 @@ func customizeImageHelper(ctx context.Context, rc *ResolvedConfig, partitionsCus
 	}
 
 	// Do the actual customizations.
-	err = doOsCustomizations(ctx, rc, imageConnection, partitionsCustomized, partitionsLayout, distroHandler, toolsChroot)
+	err = doOsCustomizations(ctx, rc, imageConnection, partitionsCustomized, partitionsLayout, distroHandler, toolsChroot.Chroot())
 
 	// Out of disk space errors can be difficult to diagnose.
 	// So, warn about any partitions with low free space.
@@ -753,7 +751,7 @@ func customizeImageHelper(ctx context.Context, rc *ResolvedConfig, partitionsCus
 	}
 
 	if toolsChroot != nil {
-		err = toolsChroot.Close(false)
+		err = toolsChroot.CleanClose(ctx)
 		if err != nil {
 			return nil, nil, nil, "", err
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -680,25 +680,19 @@ func customizeImageHelper(ctx context.Context, rc *ResolvedConfig, partitionsCus
 	mountBaseDir := rc.BuildDirAbs
 	mountPointName := "imageroot"
 	if rc.Options.ToolsDir != "" {
-		toolsChrootDir := rc.Options.ToolsDir
-		toolsChroot = safechroot.NewChroot(toolsChrootDir, true)
-		if err := toolsChroot.Initialize("", nil, nil, true); err != nil {
-			return nil, nil, nil, "", fmt.Errorf("failed to initialize tools chroot from %s:\n%w", rc.Options.ToolsDir, err)
+		if err := validateToolsDir(rc.Options.ToolsDir); err != nil {
+			return nil, nil, nil, "", err
 		}
-		// toolsChroot must be closed AFTER imageConnection so the image unmounts
-		// before the tools chroot directory is torn down.
-		defer toolsChroot.Close(false)
-		toolsResolvConf, err := overrideResolvConf(toolsChroot)
+		var cleanup func()
+		var err error
+		toolsChroot, cleanup, err = initToolsChroot(ctx, rc.Options.ToolsDir)
 		if err != nil {
-			return nil, nil, nil, "", fmt.Errorf("failed to override resolv.conf in tools chroot:\n%w", err)
+			return nil, nil, nil, "", err
 		}
-		defer func() {
-			if restoreErr := restoreResolvConf(ctx, toolsResolvConf, toolsChroot); restoreErr != nil {
-				logger.Log.Warnf("Failed to restore resolv.conf in tools chroot (%s): %v",
-					toolsChrootDir, restoreErr)
-			}
-		}()
-		mountBaseDir = toolsChrootDir
+		// cleanup must run AFTER imageConnection.Close so the image unmounts
+		// before the tools chroot directory is torn down.
+		defer cleanup()
+		mountBaseDir = rc.Options.ToolsDir
 		mountPointName = toolsRootImageDir
 	}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -674,16 +674,21 @@ func customizeImageHelper(ctx context.Context, rc *ResolvedConfig, partitionsCus
 
 	readOnlyVerity := rc.Storage.ReinitializeVerity != imagecustomizerapi.ReinitializeVerityTypeAll
 
-	// If a tools tarball is provided, initialize a tools chroot from it.
+	// If a tools directory is provided, copy it to the build directory and initialize a tools chroot from it.
 	var toolsChroot *safechroot.Chroot
 	mountBaseDir := rc.BuildDirAbs
 	mountPointName := "imageroot"
-	if rc.Options.ToolsTar != "" {
+	if rc.Options.ToolsDir != "" {
 		toolsChrootDir := filepath.Join(rc.BuildDirAbs, toolsRoot)
-		toolsChroot = safechroot.NewChroot(toolsChrootDir, false)
-		err := toolsChroot.Initialize(rc.Options.ToolsTar, nil, nil, true)
-		if err != nil {
-			return nil, nil, nil, "", fmt.Errorf("failed to initialize tools chroot from %s:\n%w", rc.Options.ToolsTar, err)
+		if err := os.MkdirAll(toolsChrootDir, os.ModePerm); err != nil {
+			return nil, nil, nil, "", fmt.Errorf("failed to create tools chroot directory:\n%w", err)
+		}
+		if _, _, err := shell.Execute("cp", "-a", rc.Options.ToolsDir+"/.", toolsChrootDir); err != nil {
+			return nil, nil, nil, "", fmt.Errorf("failed to copy tools directory (%s):\n%w", rc.Options.ToolsDir, err)
+		}
+		toolsChroot = safechroot.NewChroot(toolsChrootDir, true)
+		if err := toolsChroot.Initialize("", nil, nil, true); err != nil {
+			return nil, nil, nil, "", fmt.Errorf("failed to initialize tools chroot from %s:\n%w", rc.Options.ToolsDir, err)
 		}
 		// toolsChroot must be closed AFTER imageConnection so the image unmounts
 		// before the tools chroot directory is torn down.

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizeroptions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizeroptions.go
@@ -28,6 +28,7 @@ type ImageCustomizerOptions struct {
 	PackageSnapshotTime     imagecustomizerapi.PackageSnapshotTime
 	ImageCacheDir           string
 	CosiCompressionLevel    *int
+	ToolsTar                string
 
 	// Not provided via the command line. Only used in tests.
 	PreviewFeatures []imagecustomizerapi.PreviewFeature

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizeroptions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizeroptions.go
@@ -28,7 +28,7 @@ type ImageCustomizerOptions struct {
 	PackageSnapshotTime     imagecustomizerapi.PackageSnapshotTime
 	ImageCacheDir           string
 	CosiCompressionLevel    *int
-	ToolsTar                string
+	ToolsDir                string
 
 	// Not provided via the command line. Only used in tests.
 	PreviewFeatures []imagecustomizerapi.PreviewFeature

--- a/toolkit/tools/pkg/imagecustomizerlib/toolschroot.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/toolschroot.go
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerlib
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/logger"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safechroot"
+)
+
+func initToolsChroot(ctx context.Context, toolsDir string) (*safechroot.Chroot, func(), error) {
+	toolsChroot := safechroot.NewChroot(toolsDir, true)
+	if err := toolsChroot.Initialize("", nil, nil, true); err != nil {
+		return nil, nil, fmt.Errorf("failed to initialize tools chroot from %s:\n%w", toolsDir, err)
+	}
+
+	toolsResolvConf, err := overrideResolvConf(toolsChroot)
+	if err != nil {
+		if closeErr := toolsChroot.Close(false); closeErr != nil {
+			logger.Log.Warnf("Failed to close tools chroot (%s) after resolv.conf override failure: %v",
+				toolsDir, closeErr)
+		}
+		return nil, nil, fmt.Errorf("failed to override resolv.conf in tools chroot:\n%w", err)
+	}
+
+	cleanup := func() {
+		if restoreErr := restoreResolvConf(ctx, toolsResolvConf, toolsChroot); restoreErr != nil {
+			logger.Log.Warnf("Failed to restore resolv.conf in tools chroot (%s): %v",
+				toolsDir, restoreErr)
+		}
+		if closeErr := toolsChroot.Close(false); closeErr != nil {
+			logger.Log.Warnf("Failed to close tools chroot (%s): %v", toolsDir, closeErr)
+		}
+	}
+
+	return toolsChroot, cleanup, nil
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/toolschroot.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/toolschroot.go
@@ -11,30 +11,76 @@ import (
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safechroot"
 )
 
-func initToolsChroot(ctx context.Context, toolsDir string) (*safechroot.Chroot, func(), error) {
-	toolsChroot := safechroot.NewChroot(toolsDir, true)
-	if err := toolsChroot.Initialize("", nil, nil, true); err != nil {
-		return nil, nil, fmt.Errorf("failed to initialize tools chroot from %s:\n%w", toolsDir, err)
+// ToolsChroot wraps a safechroot used to run tdnf/dnf against a target image
+// via --installroot. It owns the resolv.conf override on the tools chroot.
+type ToolsChroot struct {
+	chroot     *safechroot.Chroot
+	resolvConf resolvConfInfo
+	toolsDir   string
+	closed     bool
+}
+
+func initToolsChroot(toolsDir string) (*ToolsChroot, error) {
+	chroot := safechroot.NewChroot(toolsDir, true)
+	if err := chroot.Initialize("", nil, nil, true); err != nil {
+		return nil, fmt.Errorf("failed to initialize tools chroot from %s:\n%w", toolsDir, err)
 	}
 
-	toolsResolvConf, err := overrideResolvConf(toolsChroot)
+	resolvConf, err := overrideResolvConf(chroot)
 	if err != nil {
-		if closeErr := toolsChroot.Close(false); closeErr != nil {
+		if closeErr := chroot.Close(false); closeErr != nil {
 			logger.Log.Warnf("Failed to close tools chroot (%s) after resolv.conf override failure: %v",
 				toolsDir, closeErr)
 		}
-		return nil, nil, fmt.Errorf("failed to override resolv.conf in tools chroot:\n%w", err)
+		return nil, fmt.Errorf("failed to override resolv.conf in tools chroot:\n%w", err)
 	}
 
-	cleanup := func() {
-		if restoreErr := restoreResolvConf(ctx, toolsResolvConf, toolsChroot); restoreErr != nil {
-			logger.Log.Warnf("Failed to restore resolv.conf in tools chroot (%s): %v",
-				toolsDir, restoreErr)
-		}
-		if closeErr := toolsChroot.Close(false); closeErr != nil {
-			logger.Log.Warnf("Failed to close tools chroot (%s): %v", toolsDir, closeErr)
-		}
-	}
+	return &ToolsChroot{
+		chroot:     chroot,
+		resolvConf: resolvConf,
+		toolsDir:   toolsDir,
+	}, nil
+}
 
-	return toolsChroot, cleanup, nil
+// Chroot returns the underlying safechroot. Nil-safe.
+func (t *ToolsChroot) Chroot() *safechroot.Chroot {
+	if t == nil {
+		return nil
+	}
+	return t.chroot
+}
+
+// CleanClose restores resolv.conf and closes the chroot, returning the first
+// error. Use this in the success path. Safe to call multiple times.
+func (t *ToolsChroot) CleanClose(ctx context.Context) error {
+	if t == nil || t.closed {
+		return nil
+	}
+	t.closed = true
+
+	if err := restoreResolvConf(ctx, t.resolvConf, t.chroot); err != nil {
+		// Still attempt to close so the chroot mount is not leaked.
+		if closeErr := t.chroot.Close(false); closeErr != nil {
+			logger.Log.Warnf("Failed to close tools chroot (%s) after restoreResolvConf failure: %v",
+				t.toolsDir, closeErr)
+		}
+		return fmt.Errorf("failed to restore resolv.conf in tools chroot:\n%w", err)
+	}
+	return t.chroot.Close(false)
+}
+
+// Close is a best-effort cleanup intended for `defer`. Errors are logged. Safe
+// to call multiple times.
+func (t *ToolsChroot) Close(ctx context.Context) {
+	if t == nil || t.closed {
+		return
+	}
+	t.closed = true
+
+	if err := restoreResolvConf(ctx, t.resolvConf, t.chroot); err != nil {
+		logger.Log.Warnf("Failed to restore resolv.conf in tools chroot (%s): %v", t.toolsDir, err)
+	}
+	if err := t.chroot.Close(false); err != nil {
+		logger.Log.Warnf("Failed to close tools chroot (%s): %v", t.toolsDir, err)
+	}
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/toolschroot.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/toolschroot.go
@@ -14,73 +14,75 @@ import (
 // ToolsChroot wraps a safechroot used to run tdnf/dnf against a target image
 // via --installroot. It owns the resolv.conf override on the tools chroot.
 type ToolsChroot struct {
+	ctx        context.Context
 	chroot     *safechroot.Chroot
-	resolvConf resolvConfInfo
+	resolvConf *resolvConfInfo
 	toolsDir   string
-	closed     bool
 }
 
-func initToolsChroot(toolsDir string) (*ToolsChroot, error) {
-	chroot := safechroot.NewChroot(toolsDir, true)
-	if err := chroot.Initialize("", nil, nil, true); err != nil {
-		return nil, fmt.Errorf("failed to initialize tools chroot from %s:\n%w", toolsDir, err)
+func initToolsChroot(ctx context.Context, toolsDir string) (*ToolsChroot, error) {
+	t := &ToolsChroot{
+		ctx:      ctx,
+		toolsDir: toolsDir,
 	}
 
-	resolvConf, err := overrideResolvConf(chroot)
+	err := t.initToolsChroot()
 	if err != nil {
-		if closeErr := chroot.Close(false); closeErr != nil {
-			logger.Log.Warnf("Failed to close tools chroot (%s) after resolv.conf override failure: %v",
-				toolsDir, closeErr)
-		}
-		return nil, fmt.Errorf("failed to override resolv.conf in tools chroot:\n%w", err)
+		t.Close()
+		return nil, err
 	}
 
-	return &ToolsChroot{
-		chroot:     chroot,
-		resolvConf: resolvConf,
-		toolsDir:   toolsDir,
-	}, nil
+	return t, nil
 }
 
-// Chroot returns the underlying safechroot. Nil-safe.
-func (t *ToolsChroot) Chroot() *safechroot.Chroot {
-	if t == nil {
-		return nil
+func (t *ToolsChroot) initToolsChroot() error {
+	t.chroot = safechroot.NewChroot(t.toolsDir, true)
+	if err := t.chroot.Initialize("", nil, nil, true); err != nil {
+		return fmt.Errorf("failed to initialize tools chroot from %s:\n%w", t.toolsDir, err)
 	}
+
+	resolvConf, err := overrideResolvConf(t.chroot)
+	if err != nil {
+		return fmt.Errorf("failed to override resolv.conf in tools chroot:\n%w", err)
+	}
+	t.resolvConf = &resolvConf
+
+	return nil
+}
+
+// Chroot returns the underlying safechroot.
+func (t *ToolsChroot) Chroot() *safechroot.Chroot {
 	return t.chroot
 }
 
 // CleanClose restores resolv.conf and closes the chroot, returning the first
-// error. Use this in the success path. Safe to call multiple times.
-func (t *ToolsChroot) CleanClose(ctx context.Context) error {
-	if t == nil || t.closed {
-		return nil
-	}
-	t.closed = true
-
-	if err := restoreResolvConf(ctx, t.resolvConf, t.chroot); err != nil {
-		// Still attempt to close so the chroot mount is not leaked.
-		if closeErr := t.chroot.Close(false); closeErr != nil {
-			logger.Log.Warnf("Failed to close tools chroot (%s) after restoreResolvConf failure: %v",
-				t.toolsDir, closeErr)
-		}
+// error. Use this in the success path.
+func (t *ToolsChroot) CleanClose() error {
+	if err := restoreResolvConf(t.ctx, *t.resolvConf, t.chroot); err != nil {
 		return fmt.Errorf("failed to restore resolv.conf in tools chroot:\n%w", err)
 	}
-	return t.chroot.Close(false)
+	t.resolvConf = nil
+
+	if err := t.chroot.Close(true); err != nil {
+		return fmt.Errorf("failed to close tools chroot (%s):\n%w", t.toolsDir, err)
+	}
+
+	return nil
 }
 
-// Close is a best-effort cleanup intended for `defer`. Errors are logged. Safe
-// to call multiple times.
-func (t *ToolsChroot) Close(ctx context.Context) {
-	if t == nil || t.closed {
-		return
+// Close is a best-effort cleanup intended for `defer`. Errors are logged.
+// Safe to call on a partially constructed or partially deconstructed instance.
+func (t *ToolsChroot) Close() {
+	if t.resolvConf != nil {
+		if err := restoreResolvConf(t.ctx, *t.resolvConf, t.chroot); err != nil {
+			logger.Log.Warnf("Failed to restore resolv.conf in tools chroot (%s): %v", t.toolsDir, err)
+		}
+		t.resolvConf = nil
 	}
-	t.closed = true
 
-	if err := restoreResolvConf(ctx, t.resolvConf, t.chroot); err != nil {
-		logger.Log.Warnf("Failed to restore resolv.conf in tools chroot (%s): %v", t.toolsDir, err)
-	}
-	if err := t.chroot.Close(false); err != nil {
-		logger.Log.Warnf("Failed to close tools chroot (%s): %v", t.toolsDir, err)
+	if t.chroot != nil {
+		if err := t.chroot.Close(true); err != nil {
+			logger.Log.Warnf("Failed to close tools chroot (%s): %v", t.toolsDir, err)
+		}
 	}
 }


### PR DESCRIPTION
ACL images do not include a package manager (tdnf/dnf) in the base image
because `/usr` is immutable and verity-protected. The `customize` subcommand
previously had no way to provide an external package manager, making package
operations on ACL images impossible.

This PR mirrors the `--tools-file` support that already exists on the `create`
subcommand, bringing the same capability to `customize`.

