### PR TITLE
Refactor create image functions.

### DIFF
--- a/toolkit/tools/imagecustomizer/main.go
+++ b/toolkit/tools/imagecustomizer/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/exekong"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/logger"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/targetos"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/telemetry"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/timestamp"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/pkg/imagecustomizerlib"
@@ -220,9 +221,16 @@ func convertImage(ctx context.Context, cmd ConvertCmd) error {
 }
 
 func createImage(ctx context.Context, cmd CreateCmd) error {
-	err := imagecustomizerlib.CreateImageWithConfigFile(ctx, cmd.BuildDir, cmd.ConfigFile, cmd.RpmSources,
-		cmd.ToolsTar, cmd.OutputImageFile, cmd.OutputImageFormat, cmd.Distro, cmd.DistroVersion,
-		cmd.PackageSnapshotTime)
+	err := imagecustomizerlib.CreateImageWithConfigFile(ctx, cmd.ConfigFile, imagecustomizerlib.ImageCreateOptions{
+		BuildDir:            cmd.BuildDir,
+		Distro:              targetos.Distro(cmd.Distro),
+		DistroVersion:       cmd.DistroVersion,
+		ToolsTar:            cmd.ToolsTar,
+		RpmsSources:         cmd.RpmSources,
+		OutputImageFile:     cmd.OutputImageFile,
+		OutputImageFormat:   imagecustomizerapi.ImageFormatType(cmd.OutputImageFormat),
+		PackageSnapshotTime: imagecustomizerapi.PackageSnapshotTime(cmd.PackageSnapshotTime),
+	})
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/internal/targetos/targetos.go
+++ b/toolkit/tools/internal/targetos/targetos.go
@@ -80,11 +80,11 @@ var (
 	}
 )
 
-func New(distroId string, versionId string) TargetOs {
+func New(distroId Distro, versionId string) TargetOs {
 	version, _ := version.ParseBasicVersion(versionId)
 
 	return TargetOs{
-		Distro:    Distro(distroId),
+		Distro:    distroId,
 		VersionId: versionId,
 		Version:   version,
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/createimage.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/createimage.go
@@ -19,10 +19,21 @@ const (
 	setupRoot = "/setuproot"
 )
 
-func CreateImageWithConfigFile(ctx context.Context, buildDir string, configFile string, rpmsSources []string,
-	toolsTar string, outputImageFile string, outputImageFormat string, distro string, distroVersion string,
-	packageSnapshotTime string,
-) error {
+type ImageCreateOptions struct {
+	BuildDir            string
+	Distro              targetos.Distro
+	DistroVersion       string
+	ToolsTar            string
+	RpmsSources         []string
+	OutputImageFile     string
+	OutputImageFormat   imagecustomizerapi.ImageFormatType
+	PackageSnapshotTime imagecustomizerapi.PackageSnapshotTime
+
+	// Not provided via the command line. Only used in tests.
+	PreviewFeatures []imagecustomizerapi.PreviewFeature
+}
+
+func CreateImageWithConfigFile(ctx context.Context, configFile string, options ImageCreateOptions) error {
 	var config imagecustomizerapi.Config
 	err := imagecustomizerapi.UnmarshalYamlFile(configFile, &config)
 	if err != nil {
@@ -36,9 +47,7 @@ func CreateImageWithConfigFile(ctx context.Context, buildDir string, configFile 
 		return fmt.Errorf("failed to get absolute path of config file directory:\n%w", err)
 	}
 
-	err = createNewImage(
-		ctx, buildDir, absBaseConfigPath, config, rpmsSources, outputImageFile,
-		outputImageFormat, toolsTar, distro, distroVersion, packageSnapshotTime)
+	err = CreateImage(ctx, absBaseConfigPath, config, options)
 	if err != nil {
 		return err
 	}
@@ -46,13 +55,10 @@ func CreateImageWithConfigFile(ctx context.Context, buildDir string, configFile 
 	return nil
 }
 
-func createNewImage(ctx context.Context, buildDir string, baseConfigPath string, config imagecustomizerapi.Config,
-	rpmsSources []string, outputImageFile string, outputImageFormat string, toolsTar string, distro string,
-	distroVersion string, packageSnapshotTime string,
+func CreateImage(ctx context.Context, baseConfigPath string, config imagecustomizerapi.Config,
+	options ImageCreateOptions,
 ) error {
-	rc, err := validateCreateImageConfig(
-		ctx, baseConfigPath, &config, rpmsSources, toolsTar, outputImageFile,
-		outputImageFormat, packageSnapshotTime, buildDir)
+	rc, err := validateCreateImageConfig(ctx, baseConfigPath, &config, options)
 	if err != nil {
 		return err
 	}
@@ -79,7 +85,7 @@ func createNewImage(ctx context.Context, buildDir string, baseConfigPath string,
 	logger.Log.Infof("Creating new image with parameters: %+v\n", rc)
 
 	// Create distro config from distro name and version
-	distroHandler, err := NewDistroHandler(targetos.New(distro, distroVersion))
+	distroHandler, err := NewDistroHandler(targetos.New(options.Distro, options.DistroVersion))
 	if err != nil {
 		return err
 	}
@@ -101,7 +107,7 @@ func createNewImage(ctx context.Context, buildDir string, baseConfigPath string,
 	logger.Log.Debugf("Part id to part uuid map %v\n", partIdToPartUuid)
 	logger.Log.Infof("Image UUID: %s", rc.ImageUuidStr)
 
-	partUuidToFstabEntry, osRelease, err := CustomizeImageHelperCreate(ctx, rc, toolsTar,
+	partUuidToFstabEntry, osRelease, err := CustomizeImageHelperCreate(ctx, rc, options.ToolsTar,
 		distroHandler)
 	if err != nil {
 		return err

--- a/toolkit/tools/pkg/imagecustomizerlib/createimage_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/createimage_test.go
@@ -4,6 +4,7 @@
 package imagecustomizerlib
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/diskutils"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/targetos"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/testutils"
 	"github.com/stretchr/testify/assert"
 )
@@ -48,9 +50,9 @@ func testCreateImageRaw(t *testing.T, name string, version string, configFile st
 	rpmSources := []string{downloadedRpmsRepoFile}
 	toolsFile := testutils.GetDownloadedToolsFile(t, testutilsDir, "azurelinux", version, true)
 
-	err := CreateImageWithConfigFile(
+	err := basicCreateImageWithConfigFile(
 		t.Context(), buildDir, partitionsConfigFile, rpmSources, toolsFile,
-		outputImageFilePath, outputImageFormat, "azurelinux", version, "")
+		outputImageFilePath, outputImageFormat, "azurelinux", version)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -114,9 +116,9 @@ func testCreateImageBtrfs(t *testing.T, name string, version string, configFile 
 	rpmSources := []string{downloadedRpmsRepoFile}
 	toolsFile := testutils.GetDownloadedToolsFile(t, testutilsDir, "azurelinux", version, true)
 
-	err := CreateImageWithConfigFile(
+	err := basicCreateImageWithConfigFile(
 		t.Context(), buildDir, partitionsConfigFile, rpmSources, toolsFile,
-		outputImageFilePath, outputImageFormat, "azurelinux", version, "")
+		outputImageFilePath, outputImageFormat, "azurelinux", version)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -182,8 +184,8 @@ func testCreateImageRawNoTar(t *testing.T, name string, version string, configFi
 	downloadedRpmsRepoFile := testutils.GetDownloadedRpmsRepoFile(t, testutilsDir, "azurelinux", version, false, true)
 	rpmSources := []string{downloadedRpmsRepoFile}
 
-	err := CreateImageWithConfigFile(t.Context(), buildDir, partitionsConfigFile, rpmSources, "",
-		outputImageFilePath, "raw", "azurelinux", version, "")
+	err := basicCreateImageWithConfigFile(t.Context(), buildDir, partitionsConfigFile, rpmSources, "",
+		outputImageFilePath, "raw", "azurelinux", version)
 
 	assert.ErrorContains(t, err, "tools tar file is required for image creation")
 }
@@ -198,12 +200,12 @@ func TestCreateImageEmptyConfig(t *testing.T) {
 	// create an empty config file
 	emptyConfigFile := filepath.Join(testDir, "empty-config.yaml")
 
-	err := CreateImageWithConfigFile(t.Context(), buildDir, "", []string{}, "", outputImageFilePath, "raw",
-		"azurelinux", "3.0", "")
+	err := basicCreateImageWithConfigFile(t.Context(), buildDir, "", []string{}, "", outputImageFilePath, "raw",
+		"azurelinux", "3.0")
 	assert.ErrorContains(t, err, "failed to unmarshal config file")
 
-	err = CreateImageWithConfigFile(t.Context(), buildDir, emptyConfigFile, []string{}, "", outputImageFilePath, "raw",
-		"azurelinux", "3.0", "")
+	err = basicCreateImageWithConfigFile(t.Context(), buildDir, emptyConfigFile, []string{}, "", outputImageFilePath, "raw",
+		"azurelinux", "3.0")
 	assert.ErrorContains(t, err, "failed to unmarshal config file")
 }
 
@@ -250,8 +252,8 @@ func testCreateImage_OutputImageFileAsRelativePath(t *testing.T, name string, ve
 
 	// Pass the output image file relative to the current working directory through the argument.
 	// This will create the file at the absolute path.
-	err = createNewImage(t.Context(), buildDir, baseConfigPath, config, rpmSources, outputImageFile,
-		outputImageFormat, toolsFile, "azurelinux", version, "")
+	err = basicCreateNewImage(t.Context(), buildDir, baseConfigPath, config, rpmSources, outputImageFile,
+		outputImageFormat, toolsFile, "azurelinux", version)
 	assert.NoError(t, err)
 	assert.FileExists(t, outputImageFileAbsolute)
 	err = os.Remove(outputImageFileAbsolute)
@@ -262,10 +264,39 @@ func testCreateImage_OutputImageFileAsRelativePath(t *testing.T, name string, ve
 
 	// Pass the output image file relative to the config file through the config. This will create
 	// the file at the absolute path.
-	err = createNewImage(t.Context(), buildDir, baseConfigPath, config, rpmSources, outputImageFile,
-		outputImageFormat, toolsFile, "azurelinux", version, "")
+	err = basicCreateNewImage(t.Context(), buildDir, baseConfigPath, config, rpmSources, outputImageFile,
+		outputImageFormat, toolsFile, "azurelinux", version)
 	assert.NoError(t, err)
 	assert.FileExists(t, outputImageFileAbsolute)
 	err = os.Remove(outputImageFileAbsolute)
 	assert.NoError(t, err)
+}
+
+func basicCreateImageWithConfigFile(ctx context.Context, buildDir string, configFile string, rpmsSources []string,
+	toolsTar string, outputImageFile string, outputImageFormat string, distro string, distroVersion string,
+) error {
+	return CreateImageWithConfigFile(ctx, configFile, ImageCreateOptions{
+		BuildDir:          buildDir,
+		RpmsSources:       rpmsSources,
+		ToolsTar:          toolsTar,
+		OutputImageFile:   outputImageFile,
+		OutputImageFormat: imagecustomizerapi.ImageFormatType(outputImageFormat),
+		Distro:            targetos.Distro(distro),
+		DistroVersion:     distroVersion,
+	})
+}
+
+func basicCreateNewImage(ctx context.Context, buildDir string, baseConfigPath string, config imagecustomizerapi.Config,
+	rpmsSources []string, outputImageFile string, outputImageFormat string, toolsTar string, distro string,
+	distroVersion string,
+) error {
+	return CreateImage(ctx, baseConfigPath, config, ImageCreateOptions{
+		BuildDir:          buildDir,
+		RpmsSources:       rpmsSources,
+		ToolsTar:          toolsTar,
+		OutputImageFile:   outputImageFile,
+		OutputImageFormat: imagecustomizerapi.ImageFormatType(outputImageFormat),
+		Distro:            targetos.Distro(distro),
+		DistroVersion:     distroVersion,
+	})
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/createimage_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/createimage_test.go
@@ -252,7 +252,7 @@ func testCreateImage_OutputImageFileAsRelativePath(t *testing.T, name string, ve
 
 	// Pass the output image file relative to the current working directory through the argument.
 	// This will create the file at the absolute path.
-	err = basicCreateNewImage(t.Context(), buildDir, baseConfigPath, config, rpmSources, outputImageFile,
+	err = basicCreateImage(t.Context(), buildDir, baseConfigPath, config, rpmSources, outputImageFile,
 		outputImageFormat, toolsFile, "azurelinux", version)
 	assert.NoError(t, err)
 	assert.FileExists(t, outputImageFileAbsolute)
@@ -264,7 +264,7 @@ func testCreateImage_OutputImageFileAsRelativePath(t *testing.T, name string, ve
 
 	// Pass the output image file relative to the config file through the config. This will create
 	// the file at the absolute path.
-	err = basicCreateNewImage(t.Context(), buildDir, baseConfigPath, config, rpmSources, outputImageFile,
+	err = basicCreateImage(t.Context(), buildDir, baseConfigPath, config, rpmSources, outputImageFile,
 		outputImageFormat, toolsFile, "azurelinux", version)
 	assert.NoError(t, err)
 	assert.FileExists(t, outputImageFileAbsolute)
@@ -286,7 +286,7 @@ func basicCreateImageWithConfigFile(ctx context.Context, buildDir string, config
 	})
 }
 
-func basicCreateNewImage(ctx context.Context, buildDir string, baseConfigPath string, config imagecustomizerapi.Config,
+func basicCreateImage(ctx context.Context, buildDir string, baseConfigPath string, config imagecustomizerapi.Config,
 	rpmsSources []string, outputImageFile string, outputImageFormat string, toolsTar string, distro string,
 	distroVersion string,
 ) error {

--- a/toolkit/tools/pkg/imagecustomizerlib/createimagevalidation.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/createimagevalidation.go
@@ -99,6 +99,7 @@ func validateCreateImageConfig(ctx context.Context, baseConfigPath string, confi
 			OutputImageFormat:   options.OutputImageFormat,
 			PackageSnapshotTime: options.PackageSnapshotTime,
 			BuildDir:            options.BuildDir,
+			PreviewFeatures:     options.PreviewFeatures,
 		})
 	if err != nil {
 		return nil, err

--- a/toolkit/tools/pkg/imagecustomizerlib/createimagevalidation.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/createimagevalidation.go
@@ -70,8 +70,7 @@ func validateCreateImageSupportedOsFields(osConfig *imagecustomizerapi.OS) error
 }
 
 func validateCreateImageConfig(ctx context.Context, baseConfigPath string, config *imagecustomizerapi.Config,
-	rpmsSources []string, toolsTar string, outputImageFile, outputImageFormat string, packageSnapshotTime string,
-	buildDir string,
+	options ImageCreateOptions,
 ) (*ResolvedConfig, error) {
 	if !slices.Contains(config.PreviewFeatures, imagecustomizerapi.PreviewFeatureCreate) {
 		return nil, fmt.Errorf(
@@ -84,7 +83,7 @@ func validateCreateImageConfig(ctx context.Context, baseConfigPath string, confi
 	}
 
 	// Validate mandatory fields for creating a seed image
-	err = validateCreateImageMandatoryFields(baseConfigPath, config, rpmsSources, toolsTar)
+	err = validateCreateImageMandatoryFields(baseConfigPath, config, options.RpmsSources, options.ToolsTar)
 	if err != nil {
 		return nil, err
 	}
@@ -95,11 +94,11 @@ func validateCreateImageConfig(ctx context.Context, baseConfigPath string, confi
 			imagecustomizerapi.ValidateResourceTypeAll,
 		},
 		ImageCustomizerOptions{
-			RpmsSources:         rpmsSources,
-			OutputImageFile:     outputImageFile,
-			OutputImageFormat:   imagecustomizerapi.ImageFormatType(outputImageFormat),
-			PackageSnapshotTime: imagecustomizerapi.PackageSnapshotTime(packageSnapshotTime),
-			BuildDir:            buildDir,
+			RpmsSources:         options.RpmsSources,
+			OutputImageFile:     options.OutputImageFile,
+			OutputImageFormat:   options.OutputImageFormat,
+			PackageSnapshotTime: options.PackageSnapshotTime,
+			BuildDir:            options.BuildDir,
 		})
 	if err != nil {
 		return nil, err

--- a/toolkit/tools/pkg/imagecustomizerlib/createimagevalidation_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/createimagevalidation_test.go
@@ -109,110 +109,100 @@ func testValidateCreateImageOutput_AcceptsValidPaths(t *testing.T, name string, 
 	outputImageFileExistsRelativeConfig, err := filepath.Rel(baseConfigPath, outputImageFileExists)
 	assert.NoError(t, err)
 
-	outputImageFile := outputImageFileNew
-	outputImageFormat := filepath.Ext(outputImageFile)[1:]
-	packageSnapshotTime := ""
+	options := ImageCreateOptions{
+		BuildDir:          buildDir,
+		ToolsTar:          toolsFile,
+		RpmsSources:       rpmSources,
+		OutputImageFile:   outputImageFileNew,
+		OutputImageFormat: imagecustomizerapi.ImageFormatType(filepath.Ext(outputImageFileNew)[1:]),
+	}
 
 	// The output image file can be specified as an argument without being in specified the config.
-	_, err = validateCreateImageConfig(t.Context(), baseConfigPath, &config, rpmSources, toolsFile, outputImageFile,
-		outputImageFormat, packageSnapshotTime, buildDir)
+	_, err = validateCreateImageConfig(t.Context(), baseConfigPath, &config, options)
 	assert.NoError(t, err)
 
-	outputImageFile = outputImageFileNewRelativeCwd
+	options.OutputImageFile = outputImageFileNewRelativeCwd
 
 	// The output image file can be specified as an argument relative to the current working directory.
-	_, err = validateCreateImageConfig(t.Context(), baseConfigPath, &config, rpmSources, toolsFile, outputImageFile,
-		outputImageFormat, packageSnapshotTime, buildDir)
+	_, err = validateCreateImageConfig(t.Context(), baseConfigPath, &config, options)
 	assert.NoError(t, err)
 
-	outputImageFile = outputImageDir
+	options.OutputImageFile = outputImageDir
 
 	// The output image file, specified as an argument, must not be a directory.
-	_, err = validateCreateImageConfig(t.Context(), baseConfigPath, &config, rpmSources, toolsFile, outputImageFile,
-		outputImageFormat, packageSnapshotTime, buildDir)
+	_, err = validateCreateImageConfig(t.Context(), baseConfigPath, &config, options)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "is a directory")
 
-	outputImageFile = outputImageDirRelativeCwd
+	options.OutputImageFile = outputImageDirRelativeCwd
 
 	// The above is also true for relative paths.
-	_, err = validateCreateImageConfig(t.Context(), baseConfigPath, &config, rpmSources, toolsFile, outputImageFile,
-		outputImageFormat, packageSnapshotTime, buildDir)
+	_, err = validateCreateImageConfig(t.Context(), baseConfigPath, &config, options)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "is a directory")
 
-	outputImageFile = outputImageFileExists
+	options.OutputImageFile = outputImageFileExists
 
 	// The output image file, specified as an argument, may be a file that already exists.
-	_, err = validateCreateImageConfig(t.Context(), baseConfigPath, &config, rpmSources, toolsFile, outputImageFile,
-		outputImageFormat, packageSnapshotTime, buildDir)
+	_, err = validateCreateImageConfig(t.Context(), baseConfigPath, &config, options)
 	assert.NoError(t, err)
 
-	outputImageFile = outputImageFileExistsRelativeCwd
+	options.OutputImageFile = outputImageFileExistsRelativeCwd
 
 	// The above is also true for relative paths.
-	_, err = validateCreateImageConfig(t.Context(), baseConfigPath, &config, rpmSources, toolsFile, outputImageFile,
-		outputImageFormat, packageSnapshotTime, buildDir)
+	_, err = validateCreateImageConfig(t.Context(), baseConfigPath, &config, options)
 	assert.NoError(t, err)
 
-	outputImageFile = ""
+	options.OutputImageFile = ""
 	config.Output.Image.Path = outputImageFileNew
 
 	// The output image file can be specified in the config without being specified as an argument.
-	_, err = validateCreateImageConfig(t.Context(), baseConfigPath, &config, rpmSources, toolsFile, outputImageFile,
-		outputImageFormat, packageSnapshotTime, buildDir)
+	_, err = validateCreateImageConfig(t.Context(), baseConfigPath, &config, options)
 	assert.NoError(t, err)
 
 	config.Output.Image.Path = outputImageFileNewRelativeConfig
 
 	// The output image file can be specified in the config relative to the base config path.
-	_, err = validateCreateImageConfig(t.Context(), baseConfigPath, &config, rpmSources, toolsFile, outputImageFile,
-		outputImageFormat, packageSnapshotTime, buildDir)
+	_, err = validateCreateImageConfig(t.Context(), baseConfigPath, &config, options)
 	assert.NoError(t, err)
 
 	config.Output.Image.Path = outputImageDir
 
 	// The output image file, specified in the config, must not be a directory.
-	_, err = validateCreateImageConfig(t.Context(), baseConfigPath, &config, rpmSources, toolsFile, outputImageFile,
-		outputImageFormat, packageSnapshotTime, buildDir)
+	_, err = validateCreateImageConfig(t.Context(), baseConfigPath, &config, options)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "is a directory")
 
 	config.Output.Image.Path = outputImageDirRelativeConfig
 
 	// The above is also true for relative paths.
-	_, err = validateCreateImageConfig(t.Context(), baseConfigPath, &config, rpmSources, toolsFile, outputImageFile,
-		outputImageFormat, packageSnapshotTime, buildDir)
+	_, err = validateCreateImageConfig(t.Context(), baseConfigPath, &config, options)
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "is a directory")
 
 	config.Output.Image.Path = outputImageFileExists
 
 	// The output image file, specified in the config, may be a file that already exists.
-	_, err = validateCreateImageConfig(t.Context(), baseConfigPath, &config, rpmSources, toolsFile, outputImageFile,
-		outputImageFormat, packageSnapshotTime, buildDir)
+	_, err = validateCreateImageConfig(t.Context(), baseConfigPath, &config, options)
 	assert.NoError(t, err)
 
 	config.Output.Image.Path = outputImageFileExistsRelativeConfig
 
 	// The above is also true for relative paths.
-	_, err = validateCreateImageConfig(t.Context(), baseConfigPath, &config, rpmSources, toolsFile, outputImageFile,
-		outputImageFormat, packageSnapshotTime, buildDir)
+	_, err = validateCreateImageConfig(t.Context(), baseConfigPath, &config, options)
 	assert.NoError(t, err)
 
-	outputImageFile = outputImageFileNew
+	options.OutputImageFile = outputImageFileNew
 	config.Output.Image.Path = outputImageFileNew
 
 	// The output image file can be specified both as an argument and in the config.
-	_, err = validateCreateImageConfig(t.Context(), baseConfigPath, &config, rpmSources, toolsFile, outputImageFile,
-		outputImageFormat, packageSnapshotTime, buildDir)
+	_, err = validateCreateImageConfig(t.Context(), baseConfigPath, &config, options)
 	assert.NoError(t, err)
 
 	config.Output.Image.Path = outputImageDir
 
 	// The output image file can even be invalid in the config if it is specified as an argument.
-	_, err = validateCreateImageConfig(t.Context(), baseConfigPath, &config, rpmSources, toolsFile, outputImageFile,
-		outputImageFormat, packageSnapshotTime, buildDir)
+	_, err = validateCreateImageConfig(t.Context(), baseConfigPath, &config, options)
 	assert.NoError(t, err)
 }
 
@@ -221,15 +211,13 @@ func TestValidateCreateImageConfig_EmptyConfig(t *testing.T) {
 	config := &imagecustomizerapi.Config{
 		PreviewFeatures: []imagecustomizerapi.PreviewFeature{imagecustomizerapi.PreviewFeatureCreate},
 	}
-	rpmSources := []string{}
 
-	outputImageFile := ""
-	outputImageFormat := "vhdx"
-	packageSnapshotTime := ""
-	buildDir := "./"
+	options := ImageCreateOptions{
+		OutputImageFormat: "vhdx",
+		BuildDir:          "./",
+	}
 
-	_, err := validateCreateImageConfig(t.Context(), baseConfigPath, config, rpmSources, "", outputImageFile,
-		outputImageFormat, packageSnapshotTime, buildDir)
+	_, err := validateCreateImageConfig(t.Context(), baseConfigPath, config, options)
 	assert.ErrorContains(t, err, "storage.disks field is required in the config file")
 }
 
@@ -258,19 +246,20 @@ func testValidateCreateImageConfig_EmptyPackagestoInstall(t *testing.T, name str
 	err = imagecustomizerapi.UnmarshalYamlFile(configFile, &config)
 	assert.NoError(t, err)
 
-	rpmSources := []string{testDir} // Use the test directory as a dummy RPM source
-	outputImageFile := filepath.Join(testDir, "output.vhdx")
-	outputImageFormat := "vhdx"
-	packageSnapshotTime := ""
-	buildDir := "./"
-	toolsFile := filepath.Join(testTmpDir, "tools.tar.gz")
-	err = createDummyTarGz(toolsFile)
+	options := ImageCreateOptions{
+		RpmsSources:       []string{testDir}, // Use the test directory as a dummy RPM source
+		OutputImageFile:   filepath.Join(testDir, "output.vhdx"),
+		OutputImageFormat: "vhdx",
+		BuildDir:          "./",
+		ToolsTar:          filepath.Join(testTmpDir, "tools.tar.gz"),
+	}
+
+	err = createDummyTarGz(options.ToolsTar)
 	assert.NoError(t, err)
 	// Set the packages to install to an empty slice
 	config.OS.Packages.Install = []string{}
 	config.OS.Packages.InstallLists = []string{}
-	_, err = validateCreateImageConfig(t.Context(), testDir, &config, rpmSources, toolsFile, outputImageFile,
-		outputImageFormat, packageSnapshotTime, buildDir)
+	_, err = validateCreateImageConfig(t.Context(), testDir, &config, options)
 	assert.ErrorContains(t, err, "no packages to install specified, please specify at least one package to install for a new image")
 }
 
@@ -281,14 +270,13 @@ func TestValidateCreateImageConfig_InvalidFieldsVerityConfig(t *testing.T) {
 	err := imagecustomizerapi.UnmarshalYamlFile(configFile, &config)
 	assert.NoError(t, err)
 
-	rpmSources := []string{testDir} // Use the test directory as a dummy RPM source
-	outputImageFile := ""
-	outputImageFormat := "vhdx"
-	packageSnapshotTime := ""
-	buildDir := "./"
+	options := ImageCreateOptions{
+		RpmsSources:       []string{testDir}, // Use the test directory as a dummy RPM source
+		OutputImageFormat: "vhdx",
+		BuildDir:          "./",
+	}
 
-	_, err = validateCreateImageConfig(t.Context(), testDir, &config, rpmSources, "", outputImageFile,
-		outputImageFormat, packageSnapshotTime, buildDir)
+	_, err = validateCreateImageConfig(t.Context(), testDir, &config, options)
 	assert.ErrorContains(t, err, "storage verity field is not supported by the create subcommand")
 }
 
@@ -299,13 +287,12 @@ func TestValidateCreateImageConfig_InvalidFieldsOverlaysConfig(t *testing.T) {
 	err := imagecustomizerapi.UnmarshalYamlFile(configFile, &config)
 	assert.NoError(t, err)
 
-	rpmSources := []string{testDir} // Use the test directory as a dummy RPM source
-	outputImageFile := ""
-	outputImageFormat := "vhdx"
-	packageSnapshotTime := ""
-	buildDir := "./"
+	options := ImageCreateOptions{
+		RpmsSources:       []string{testDir}, // Use the test directory as a dummy RPM source
+		OutputImageFormat: "vhdx",
+		BuildDir:          "./",
+	}
 
-	_, err = validateCreateImageConfig(t.Context(), testDir, &config, rpmSources, "", outputImageFile,
-		outputImageFormat, packageSnapshotTime, buildDir)
+	_, err = validateCreateImageConfig(t.Context(), testDir, &config, options)
 	assert.ErrorContains(t, err, "overlay field is not supported by the create subcommand")
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/main_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/main_test.go
@@ -329,5 +329,5 @@ func checkSkipForCustomizeDefaultImages(t *testing.T) []testBaseImageInfo {
 }
 
 func (i *testBaseImageInfo) TargetOs() targetos.TargetOs {
-	return targetos.New(i.Distro, i.Version)
+	return targetos.New(targetos.Distro(i.Distro), i.Version)
 }


### PR DESCRIPTION
Add a new `ImageCreateOptions` struct and modify `CreateImageWithConfigFile` to use it instead of a bunch of params. Also, rename `createNewImage` to `CreateImage`. This makes it more consistent with the CustomizeImage functions.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
