### PR TITLE
Add `--setfiles-context` API.

### DIFF
--- a/docs/imagecustomizer/api/cli/customize.md
+++ b/docs/imagecustomizer/api/cli/customize.md
@@ -298,13 +298,16 @@ This option is useful when running on a build system with SELinux enabled.
 
 Added in v1.5.
 
-### Fedora
+### selinux-policy (e.g. Fedora)
 
-When running on a Fedora system, use the value: `system_u:system_r:setfiles_mac_t:s0`
+When running on a build system with SELinux enabled and that uses the
+[selinux-policy](https://github.com/fedora-selinux/selinux-policy) policy (e.g. Fedora),
+use the value: `system_u:system_r:setfiles_mac_t:s0`
 
-The `setfiles_mac_t` label allows SELinux labels to be applied that aren't present in
-the build host's SELinux rules, which is super useful when customizing images that have
-a different distro / distro version than the build host.
+The `setfiles_mac_t` label is allowed to use the `CAP_MAC_ADMIN` capability, which
+permits SELinux labels to be applied that aren't present in the build host's SELinux
+rules. This is super useful when customizing images that have a different distro /
+distro version than the build host.
 
 Also, you need to run the commands:
 
@@ -315,3 +318,12 @@ Also, you need to run the commands:
 2. `sudo semanage permissive -a systemd_hwdb_t`
 
    `setfiles_mac_t` doesn't have the correct permissions to label `/etc/udev/hwdb.bin`.
+
+### refpolicy
+
+When running on a build system that uses the
+[refpolicy](https://github.com/SELinuxProject/refpolicy) policy (e.g. Azure Linux 3.0),
+the only thing you can do is disable SELinux.
+
+This SELinux policy does not have a label with permissions for the `CAP_MAC_ADMIN`
+capability.

--- a/docs/imagecustomizer/api/cli/customize.md
+++ b/docs/imagecustomizer/api/cli/customize.md
@@ -308,3 +308,5 @@ Also, you need to run the commands:
    This allows transitions from `unconfined_t` to `setfiles_mac_t`.
 
 2. `sudo semanage permissive -a systemd_hwdb_t`
+
+   `setfiles_mac_t` doesn't have the correct permissions to label `/etc/udev/hwdb.bin`.

--- a/docs/imagecustomizer/api/cli/customize.md
+++ b/docs/imagecustomizer/api/cli/customize.md
@@ -287,7 +287,12 @@ Added in v1.5.
 
 ## --setfiles-context
 
-The SELinux context to use when running the `setfiles` command.
+The SELinux context to use when running the `setfiles` command, which is used to apply
+the security context labels on all the files in the OS when SELinux is enabled in the
+target OS.
+
+If omitted, the `setfiles` command is run in the default security context chosen by the
+kernel.
 
 This option is useful when running on a build system with SELinux enabled.
 

--- a/docs/imagecustomizer/api/cli/customize.md
+++ b/docs/imagecustomizer/api/cli/customize.md
@@ -284,3 +284,27 @@ For instructions on how to create this directory, see:
 [How to create the tools directory](../../how-to/create-tools-dir.md)
 
 Added in v1.5.
+
+## --setfiles-context
+
+The SELinux context to use when running the `setfiles` command.
+
+This option is useful when running on a build system with SELinux enabled.
+
+Added in v1.5.
+
+### Fedora
+
+When running on a Fedora system, use the value: `system_u:system_r:setfiles_mac_t:s0`
+
+The `setfiles_mac_t` label allows SELinux labels to be applied that aren't present in
+the build host's SELinux rules, which is super useful when customizing images that have
+a different distro / distro version than the build host.
+
+Also, you need to run the commands:
+
+1. `sudo semanage permissive -a setfiles_mac_t`
+
+   This allows transitions from `unconfined_t` to `setfiles_mac_t`.
+
+2. `sudo semanage permissive -a systemd_hwdb_t`

--- a/toolkit/tools/imagecustomizer/main.go
+++ b/toolkit/tools/imagecustomizer/main.go
@@ -45,6 +45,7 @@ type CustomizeCmd struct {
 	ImageCacheDir            string   `name:"image-cache-dir" help:"The directory to use as the image download cache"`
 	CosiCompressionLevel     *int     `name:"cosi-compression-level" help:"Zstd compression level for COSI output (1-22, default: 9)."`
 	ToolsDir                 string   `name:"tools-dir" help:"Path to a directory containing tdnf/dnf and its dependencies. Required for package operations on images that do not include a package manager (e.g. ACL)."`
+	SetFilesContext          string   `name:"setfiles-context" help:"The SELinux label to use when calling setfiles."`
 }
 
 type InjectFilesCmd struct {
@@ -182,6 +183,7 @@ func customizeImage(ctx context.Context, cmd CustomizeCmd) error {
 			ImageCacheDir:           cmd.ImageCacheDir,
 			CosiCompressionLevel:    cmd.CosiCompressionLevel,
 			ToolsDir:                cmd.ToolsDir,
+			SetFilesContext:         cmd.SetFilesContext,
 		})
 	if err != nil {
 		return err

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -901,17 +900,6 @@ func SELinuxRelabelFiles(installChroot safechroot.ChrootInterface, mountPointToF
 func callSetFiles(targetRootPath string, fileContextPath string, targetPath string, chrootDir string,
 	setFilesContext string,
 ) error {
-	if setFilesContext != "" {
-		runtime.LockOSThread()
-		defer runtime.UnlockOSThread()
-		err := setSELinuxExecContext(setFilesContext)
-		if err != nil {
-			return fmt.Errorf("failed to set setfiles exec context (%s)", setFilesContext)
-		}
-
-		defer resetSELinuxExecContext()
-	}
-
 	// We only want to print basic info, filter out the real output unless at trace level (Execute call handles that)
 	files := 0
 	onStdout := func(line string) {
@@ -925,6 +913,7 @@ func callSetFiles(targetRootPath string, fileContextPath string, targetPath stri
 		LogLevel(logrus.TraceLevel, logrus.WarnLevel).
 		ErrorStderrLines(1).
 		Chroot(chrootDir).
+		SELinuxContext(setFilesContext).
 		Execute()
 	if err != nil {
 		return fmt.Errorf("setfiles failed:\n%w", err)

--- a/toolkit/tools/imagegen/installutils/installutils.go
+++ b/toolkit/tools/imagegen/installutils/installutils.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -807,8 +808,8 @@ func SELinuxUpdateConfig(selinuxMode configuration.SELinux, installChroot safech
 	return
 }
 
-func SELinuxRelabelFiles(installChroot safechroot.ChrootInterface, mountPointToFsTypeMap map[string]string, isRootFS bool,
-	selinuxConfigFile string,
+func SELinuxRelabelFiles(installChroot safechroot.ChrootInterface, mountPointToFsTypeMap map[string]string,
+	isRootFS bool, selinuxConfigFile string, setFilesContext string,
 ) (err error) {
 	const selinuxFileContextsRelPath = "contexts/files/file_contexts"
 
@@ -875,24 +876,10 @@ func SELinuxRelabelFiles(installChroot safechroot.ChrootInterface, mountPointToF
 		}
 		defer bindMount.Close()
 
-		// We only want to print basic info, filter out the real output unless at trace level (Execute call handles that)
-		files := 0
-		onStdout := func(line string) {
-			files++
-			if (files % 1000) == 0 {
-				logger.Log.Debugf("SELinux: labelled %d files", files)
-			}
-		}
-		err = shell.NewExecBuilder("setfiles", "-m", "-v", "-r", targetRootPath, fileContextPath, targetPath).
-			StdoutCallback(onStdout).
-			LogLevel(logrus.TraceLevel, logrus.WarnLevel).
-			ErrorStderrLines(1).
-			Chroot(installChroot.ChrootDir()).
-			Execute()
+		err = callSetFiles(targetRootPath, fileContextPath, targetPath, installChroot.ChrootDir(), setFilesContext)
 		if err != nil {
-			return fmt.Errorf("setfiles failed:\n%w", err)
+			return err
 		}
-		logger.Log.Debugf("SELinux: labelled %d files", files)
 
 		err = bindMount.CleanClose()
 		if err != nil {
@@ -909,6 +896,42 @@ func SELinuxRelabelFiles(installChroot safechroot.ChrootInterface, mountPointToF
 	}
 
 	return
+}
+
+func callSetFiles(targetRootPath string, fileContextPath string, targetPath string, chrootDir string,
+	setFilesContext string,
+) error {
+	if setFilesContext != "" {
+		runtime.LockOSThread()
+		defer runtime.UnlockOSThread()
+		err := setSELinuxExecContext(setFilesContext)
+		if err != nil {
+			return fmt.Errorf("failed to set setfiles exec context (%s)", setFilesContext)
+		}
+
+		defer resetSELinuxExecContext()
+	}
+
+	// We only want to print basic info, filter out the real output unless at trace level (Execute call handles that)
+	files := 0
+	onStdout := func(line string) {
+		files++
+		if (files % 1000) == 0 {
+			logger.Log.Debugf("SELinux: labelled %d files", files)
+		}
+	}
+	err := shell.NewExecBuilder("setfiles", "-m", "-v", "-r", targetRootPath, fileContextPath, targetPath).
+		StdoutCallback(onStdout).
+		LogLevel(logrus.TraceLevel, logrus.WarnLevel).
+		ErrorStderrLines(1).
+		Chroot(chrootDir).
+		Execute()
+	if err != nil {
+		return fmt.Errorf("setfiles failed:\n%w", err)
+	}
+
+	logger.Log.Debugf("SELinux: labelled %d files", files)
+	return nil
 }
 
 func sed(find, replace, delimiter, file string) (err error) {

--- a/toolkit/tools/imagegen/installutils/selinux.go
+++ b/toolkit/tools/imagegen/installutils/selinux.go
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package installutils
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/logger"
+)
+
+// Sets the SELinux context to use for any child processes started by the current OS thread.
+// This is equivalent to using runcon, though with the advantage that it works with safechroot.
+//
+// Note: This function should only be run under the runtime.LockOSThread() lock.
+func setSELinuxExecContext(context string) error {
+	path := selinuxExecContextPath()
+
+	logger.Log.Debugf("Set SELinux context [%s]", path)
+
+	out, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = out.Write([]byte(context))
+	if err != nil {
+		return err
+	}
+
+	err = out.Close()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Clears the explicit override of the SELinux context to use for child processes started by the current OS thread.
+//
+// Note: This function should only be run under the runtime.LockOSThread() lock and on the same thread that called
+// setSELinuxExecContext().
+func resetSELinuxExecContext() error {
+	path := selinuxExecContextPath()
+
+	logger.Log.Debugf("Clean SELinux context [%s]", path)
+
+	out, err := os.OpenFile(path, os.O_WRONLY, 0)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	_, err = out.Write([]byte(nil))
+	if err != nil {
+		return err
+	}
+
+	err = out.Close()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func selinuxExecContextPath() string {
+	taskId := syscall.Gettid()
+	path := fmt.Sprintf("/proc/self/task/%d/attr/exec", taskId)
+	return path
+}

--- a/toolkit/tools/internal/shell/execbuilder.go
+++ b/toolkit/tools/internal/shell/execbuilder.go
@@ -81,7 +81,7 @@ func (b ExecBuilder) Chroot(chrootDir string) ExecBuilder {
 	return b
 }
 
-// Capabilities sets capabilities the command will be be restricted to.
+// Capabilities sets capabilities the command will be restricted to.
 func (b ExecBuilder) Capabilities(capabilities []uintptr) ExecBuilder {
 	b.capabilities = capabilities
 	return b

--- a/toolkit/tools/internal/shell/execbuilder.go
+++ b/toolkit/tools/internal/shell/execbuilder.go
@@ -55,6 +55,7 @@ type ExecBuilder struct {
 	warnLogLines         int
 	chrootDir            string
 	capabilities         []uintptr
+	selinuxContext       string
 }
 
 // NewExecBuilder initializes a new execution builder object.
@@ -74,15 +75,21 @@ func (b ExecBuilder) WorkingDirectory(path string) ExecBuilder {
 	return b
 }
 
-// Chroot sets
+// Chroot sets the root directory to run the command under.
 func (b ExecBuilder) Chroot(chrootDir string) ExecBuilder {
 	b.chrootDir = chrootDir
 	return b
 }
 
-// Chroot sets
+// Capabilities sets capabilities the command will be be restricted to.
 func (b ExecBuilder) Capabilities(capabilities []uintptr) ExecBuilder {
 	b.capabilities = capabilities
+	return b
+}
+
+// SELinuxContext sets the SELinux context to be set on the command.
+func (b ExecBuilder) SELinuxContext(selinuxContext string) ExecBuilder {
+	b.selinuxContext = selinuxContext
 	return b
 }
 
@@ -233,7 +240,7 @@ func (b ExecBuilder) executeHelper(captureOutput bool) (string, string, error) {
 	defer stderrPipe.Close()
 
 	// Start process.
-	err = trackAndStartProcess(cmd, b.capabilities)
+	err = trackAndStartProcess(cmd, b.capabilities, b.selinuxContext)
 	if err != nil {
 		err = fmt.Errorf("failed to start process:\n%w", err)
 		return "", "", err

--- a/toolkit/tools/internal/shell/selinux.go
+++ b/toolkit/tools/internal/shell/selinux.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-package installutils
+package shell
 
 import (
 	"fmt"

--- a/toolkit/tools/internal/shell/selinux.go
+++ b/toolkit/tools/internal/shell/selinux.go
@@ -43,6 +43,9 @@ func setSELinuxExecContext(context string) error {
 //
 // Note: This function should only be run under the runtime.LockOSThread() lock and on the same thread that called
 // setSELinuxExecContext().
+//
+// Future: This function could be used to optimize goStartCmdHelper() to avoid throwing away the OS thread in cases
+// where it isn't necessary.
 func resetSELinuxExecContext() error {
 	path := selinuxExecContextPath()
 

--- a/toolkit/tools/internal/shell/shell.go
+++ b/toolkit/tools/internal/shell/shell.go
@@ -164,7 +164,7 @@ func LookPathChroot(command string, rootDir string) (string, error) {
 	return chrootLookPath(command, rootDir, chrootPathDirs)
 }
 
-func trackAndStartProcess(cmd *exec.Cmd, capabilities []uintptr) (err error) {
+func trackAndStartProcess(cmd *exec.Cmd, capabilities []uintptr, selinuxContext string) (err error) {
 	logger.Log.Debugf("Executing: %v", cmd.Args)
 
 	if cmd.Env == nil && len(currentEnv) > 0 {
@@ -178,8 +178,8 @@ func trackAndStartProcess(cmd *exec.Cmd, capabilities []uintptr) (err error) {
 
 	cmd.SysProcAttr.Setpgid = true
 
-	if capabilities != nil {
-		err = setCapabilitiesAndStartCmd(cmd, capabilities)
+	if capabilities != nil || selinuxContext != "" {
+		err = goStartCmd(cmd, capabilities, selinuxContext)
 	} else {
 		err = startCmd(cmd)
 	}
@@ -187,31 +187,42 @@ func trackAndStartProcess(cmd *exec.Cmd, capabilities []uintptr) (err error) {
 	return
 }
 
-func setCapabilitiesAndStartCmd(cmd *exec.Cmd, capabilities []uintptr) error {
+func goStartCmd(cmd *exec.Cmd, capabilities []uintptr, selinuxContext string) error {
 	result := make(chan error)
-	go setCapabilitiesAndStartCmdWorker(cmd, capabilities, result)
+	go goStartCmdWorker(cmd, capabilities, selinuxContext, result)
 	err := <-result
 	return err
 }
 
-func setCapabilitiesAndStartCmdWorker(cmd *exec.Cmd, capabilities []uintptr, result chan<- error) {
-	err := setCapabilitiesAndStartCmdHelper(cmd, capabilities)
+func goStartCmdWorker(cmd *exec.Cmd, capabilities []uintptr, selinuxContext string, result chan<- error) {
+	err := goStartCmdHelper(cmd, capabilities, selinuxContext)
 	result <- err
 	close(result)
 }
 
-func setCapabilitiesAndStartCmdHelper(cmd *exec.Cmd, capabilities []uintptr) error {
-	// Lock the OS thread so that capabilities can be dropped without affecting other threads.
+func goStartCmdHelper(cmd *exec.Cmd, capabilities []uintptr, selinuxContext string) error {
+	// Lock the OS thread to avoid affecting other goroutines.
 	// Note: Dropping capabilities cannot be undone. Hence, the OS thread needs to be thrown away.
 	// Hence, UnlockOSThread is not called and a goroutine is used.
+	// Also, setting the SELinux context can be technically be undone. But its less code to just throw away the OS
+	// thread.
 	runtime.LockOSThread()
 
-	err := setOSThreadCapabilities(capabilities)
-	if err != nil {
-		return fmt.Errorf("failed to set process capabilities:\n%w", err)
+	if selinuxContext != "" {
+		err := setSELinuxExecContext(selinuxContext)
+		if err != nil {
+			return fmt.Errorf("failed to set process SELinux exec context (%s)\n%w", selinuxContext, err)
+		}
 	}
 
-	err = startCmd(cmd)
+	if capabilities != nil {
+		err := setOSThreadCapabilities(capabilities)
+		if err != nil {
+			return fmt.Errorf("failed to set process capabilities:\n%w", err)
+		}
+	}
+
+	err := startCmd(cmd)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/internal/shell/shell.go
+++ b/toolkit/tools/internal/shell/shell.go
@@ -204,14 +204,14 @@ func goStartCmdHelper(cmd *exec.Cmd, capabilities []uintptr, selinuxContext stri
 	// Lock the OS thread to avoid affecting other goroutines.
 	// Note: Dropping capabilities cannot be undone. Hence, the OS thread needs to be thrown away.
 	// Hence, UnlockOSThread is not called and a goroutine is used.
-	// Also, setting the SELinux context can be technically be undone. But its less code to just throw away the OS
+	// Also, setting the SELinux context can technically be undone. But it's less code to just throw away the OS
 	// thread.
 	runtime.LockOSThread()
 
 	if selinuxContext != "" {
 		err := setSELinuxExecContext(selinuxContext)
 		if err != nil {
-			return fmt.Errorf("failed to set process SELinux exec context (%s)\n%w", selinuxContext, err)
+			return fmt.Errorf("failed to set process SELinux exec context (%s):\n%w", selinuxContext, err)
 		}
 	}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
@@ -212,7 +212,8 @@ func doOsCustomizations(ctx context.Context, rc *ResolvedConfig, imageConnection
 		return err
 	}
 
-	err = selinuxSetFiles(ctx, selinuxMode, imageChroot, distroHandler.GetSELinuxConfigFile())
+	err = selinuxSetFiles(ctx, selinuxMode, imageChroot, distroHandler.GetSELinuxConfigFile(),
+		rc.Options.SetFilesContext)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeselinux.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeselinux.go
@@ -128,7 +128,7 @@ func UpdateSELinuxModeInConfigFile(selinuxMode imagecustomizerapi.SELinuxMode, i
 }
 
 func selinuxSetFiles(ctx context.Context, selinuxMode imagecustomizerapi.SELinuxMode, imageChroot *safechroot.Chroot,
-	selinuxConfigFile string,
+	selinuxConfigFile string, setFilesContext string,
 ) error {
 	if selinuxMode == imagecustomizerapi.SELinuxModeDisabled {
 		// SELinux is disabled in the kernel command line.
@@ -153,7 +153,8 @@ func selinuxSetFiles(ctx context.Context, selinuxMode imagecustomizerapi.SELinux
 	}
 
 	// Set the SELinux config file and relabel all the files.
-	err := installutils.SELinuxRelabelFiles(imageChroot, mountPointToFsTypeMap, false, selinuxConfigFile)
+	err := installutils.SELinuxRelabelFiles(imageChroot, mountPointToFsTypeMap, false, selinuxConfigFile,
+		setFilesContext)
 	if err != nil {
 		return fmt.Errorf("%w:\n%w", ErrSELinuxRelabelFiles, err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer_test.go
@@ -1133,6 +1133,7 @@ func basicCustomizeImageWithConfigFile(ctx context.Context, buildDir string, con
 		OutputImageFormat:    imagecustomizerapi.ImageFormatType(outputImageFormat),
 		UseBaseImageRpmRepos: true,
 		PreviewFeatures:      previewFeatures,
+		SetFilesContext:      *setfilesContext,
 	})
 }
 
@@ -1147,5 +1148,6 @@ func basicCustomizeImage(ctx context.Context, buildDir string, baseConfigPath st
 		OutputImageFormat:    imagecustomizerapi.ImageFormatType(outputImageFormat),
 		UseBaseImageRpmRepos: true,
 		PreviewFeatures:      previewFeatures,
+		SetFilesContext:      *setfilesContext,
 	})
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizeroptions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizeroptions.go
@@ -29,6 +29,7 @@ type ImageCustomizerOptions struct {
 	ImageCacheDir           string
 	CosiCompressionLevel    *int
 	ToolsDir                string
+	SetFilesContext         string
 
 	// Not provided via the command line. Only used in tests.
 	PreviewFeatures []imagecustomizerapi.PreviewFeature

--- a/toolkit/tools/pkg/imagecustomizerlib/main_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/main_test.go
@@ -47,6 +47,7 @@ const (
 	paramBaseImageUbuntu2204AzureCloud = "base-image-azure-cloud-ubuntu2204"
 	paramBaseImageUbuntu2404AzureCloud = "base-image-azure-cloud-ubuntu2404"
 	paramLogLevel                      = "log-level"
+	paramSetFilesContext               = "setfiles-context"
 )
 
 type testBaseImageInfo struct {
@@ -191,6 +192,7 @@ var (
 	baseImageUbuntuAzureCloud2204 = flag.String(paramBaseImageUbuntu2204AzureCloud, "", "An Ubuntu 22.04 Azure cloud image to use as a base image.")
 	baseImageUbuntuAzureCloud2404 = flag.String(paramBaseImageUbuntu2404AzureCloud, "", "An Ubuntu 24.04 Azure cloud image to use as a base image.")
 	logLevel                      = flag.String(paramLogLevel, "info", "The log level (error, warning, info, debug, or trace)")
+	setfilesContext               = flag.String(paramSetFilesContext, "", "The SELinux label to use when calling setfiles.")
 )
 
 var (


### PR DESCRIPTION
Customizing an OS with SELinux on a Fedora dev box currently hits errors because the kernel will block you from applying labels to files that don't exist in the kernel's active policy (among other issues). To fix this problem, the `setfiles` call needs to be run under the `setfiles_mac_t` label, which has special permissions to ignore the active policy. (This label is used by Fedora's Anaconda installer.)

This change exposes a new CLI API that allows the user to specify the label to run the `setfiles` call under. This will allow Fedora users to specify the required `setfiles_mac_t` label.

Exposing this as an API helps keep the design simple since it avoids logic for stuff like detecting if SELinux is enabled, what the correct label to use for the current build host, etc.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
