### PR TITLE
Make package-information retrieval distro-aware

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler.go
@@ -44,6 +44,9 @@ type DistroHandler interface {
 
 	IsPackageInstalled(imageChroot safechroot.ChrootInterface, packageName string) bool
 
+	// GetPackageInformation queries the installed-package database for packageName and returns its parsed information.
+	GetPackageInformation(imageChroot *safechroot.Chroot, packageName string) (*PackageVersionInformation, error)
+
 	// Get all installed packages from the chroot
 	GetAllPackagesFromChroot(imageChroot safechroot.ChrootInterface) ([]OsPackage, error)
 

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
@@ -101,6 +101,11 @@ func (d *aclDistroHandler) IsPackageInstalled(imageChroot safechroot.ChrootInter
 	return d.packageManager.isPackageInstalled(imageChroot, packageName)
 }
 
+func (d *aclDistroHandler) GetPackageInformation(imageChroot *safechroot.Chroot, packageName string,
+) (*PackageVersionInformation, error) {
+	return d.packageManager.getPackageInformation(imageChroot, packageName)
+}
+
 func (d *aclDistroHandler) GetAllPackagesFromChroot(imageChroot safechroot.ChrootInterface) ([]OsPackage, error) {
 	// This function is only used for metadata within a COSI file.
 	// So, it doesn't matter too much if the package list can't be provided.

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux.go
@@ -83,6 +83,11 @@ func (d *azureLinuxDistroHandler) IsPackageInstalled(imageChroot safechroot.Chro
 	return d.packageManager.isPackageInstalled(imageChroot, packageName)
 }
 
+func (d *azureLinuxDistroHandler) GetPackageInformation(imageChroot *safechroot.Chroot, packageName string,
+) (*PackageVersionInformation, error) {
+	return d.packageManager.getPackageInformation(imageChroot, packageName)
+}
+
 func (d *azureLinuxDistroHandler) GetAllPackagesFromChroot(imageChroot safechroot.ChrootInterface) ([]OsPackage, error) {
 	return getAllPackagesFromChrootRpm(imageChroot)
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux4.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux4.go
@@ -60,12 +60,6 @@ func (d *azureLinux4DistroHandler) ValidateConfig(rc *ResolvedConfig) error {
 		}
 	}
 
-	switch rc.OutputImageFormat {
-	case imagecustomizerapi.ImageFormatTypeIso, imagecustomizerapi.ImageFormatTypePxeDir,
-		imagecustomizerapi.ImageFormatTypePxeTar:
-		return fmt.Errorf("ISO and PXE output formats are not supported for Azure Linux 4.0")
-	}
-
 	return nil
 }
 
@@ -80,6 +74,11 @@ func (d *azureLinux4DistroHandler) ManagePackages(ctx context.Context, buildDir 
 
 func (d *azureLinux4DistroHandler) IsPackageInstalled(imageChroot safechroot.ChrootInterface, packageName string) bool {
 	return d.packageManager.isPackageInstalled(imageChroot, packageName)
+}
+
+func (d *azureLinux4DistroHandler) GetPackageInformation(imageChroot *safechroot.Chroot, packageName string,
+) (*PackageVersionInformation, error) {
+	return d.packageManager.getPackageInformation(imageChroot, packageName)
 }
 
 func (d *azureLinux4DistroHandler) GetAllPackagesFromChroot(imageChroot safechroot.ChrootInterface,

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux4.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux4.go
@@ -60,6 +60,12 @@ func (d *azureLinux4DistroHandler) ValidateConfig(rc *ResolvedConfig) error {
 		}
 	}
 
+	switch rc.OutputImageFormat {
+	case imagecustomizerapi.ImageFormatTypeIso, imagecustomizerapi.ImageFormatTypePxeDir,
+		imagecustomizerapi.ImageFormatTypePxeTar:
+		return fmt.Errorf("ISO and PXE output formats are not supported for Azure Linux 4.0")
+	}
+
 	return nil
 }
 

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
@@ -88,6 +88,11 @@ func (d *fedoraDistroHandler) IsPackageInstalled(imageChroot safechroot.ChrootIn
 	return d.packageManager.isPackageInstalled(imageChroot, packageName)
 }
 
+func (d *fedoraDistroHandler) GetPackageInformation(imageChroot *safechroot.Chroot, packageName string,
+) (*PackageVersionInformation, error) {
+	return d.packageManager.getPackageInformation(imageChroot, packageName)
+}
+
 func (d *fedoraDistroHandler) GetAllPackagesFromChroot(imageChroot safechroot.ChrootInterface) ([]OsPackage, error) {
 	return getAllPackagesFromChrootRpm(imageChroot)
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_ubuntu.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_ubuntu.go
@@ -100,7 +100,7 @@ func (d *ubuntuDistroHandler) IsPackageInstalled(imageChroot safechroot.ChrootIn
 
 func (d *ubuntuDistroHandler) GetPackageInformation(imageChroot *safechroot.Chroot, packageName string,
 ) (*PackageVersionInformation, error) {
-	return nil, fmt.Errorf("Getting package information is not supported for Ubuntu images:\n%w",
+	return nil, fmt.Errorf("Getting package information is not supported yet for Ubuntu images:\n%w",
 		ErrUnsupportedUbuntuFeature)
 }
 

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_ubuntu.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_ubuntu.go
@@ -98,6 +98,12 @@ func (d *ubuntuDistroHandler) IsPackageInstalled(imageChroot safechroot.ChrootIn
 	return isPackageInstalledDeb(imageChroot, packageName)
 }
 
+func (d *ubuntuDistroHandler) GetPackageInformation(imageChroot *safechroot.Chroot, packageName string,
+) (*PackageVersionInformation, error) {
+	return nil, fmt.Errorf("Getting package information is not supported for Ubuntu images:\n%w",
+		ErrUnsupportedUbuntuFeature)
+}
+
 func (d *ubuntuDistroHandler) GetAllPackagesFromChroot(imageChroot safechroot.ChrootInterface) ([]OsPackage, error) {
 	return getAllPackagesFromChrootDeb(imageChroot)
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoartifactstore.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoartifactstore.go
@@ -408,7 +408,7 @@ func createIsoInfoStoreFromMountedImage(buildDir string, imageRootDir string, di
 	}
 	infoStore.seLinuxMode = imageSELinuxMode
 
-	infoStore.dracutPackageInfo, err = getPackageInformation(chroot, "dracut")
+	infoStore.dracutPackageInfo, err = distroHandler.GetPackageInformation(chroot, "dracut")
 	if err != nil {
 		return nil, fmt.Errorf("failed to determine package information for dracut under (%s):\n%w", imageRootDir, err)
 	}
@@ -417,7 +417,7 @@ func createIsoInfoStoreFromMountedImage(buildDir string, imageRootDir string, di
 	// So, the absence of selinux-policy does not mean that there are no selinux
 	// policy packages.
 	if distroHandler.IsPackageInstalled(chroot, "selinux-policy") {
-		infoStore.selinuxPolicyPackageInfo, err = getPackageInformation(chroot, "selinux-policy")
+		infoStore.selinuxPolicyPackageInfo, err = distroHandler.GetPackageInformation(chroot, "selinux-policy")
 		if err != nil {
 			return nil, fmt.Errorf("failed to determine package information for selinux-policy under (%s):\n%w", imageRootDir, err)
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/packageinformation.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/packageinformation.go
@@ -8,10 +8,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-
-	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safechroot"
-	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/shell"
-	"github.com/sirupsen/logrus"
 )
 
 type PackageVersionInformation struct {
@@ -139,23 +135,16 @@ func parseVersionString(version string) ([]uint64, error) {
 	return versionComponents, nil
 }
 
-func getPackageInformation(imageChroot *safechroot.Chroot, packageName string) (info *PackageVersionInformation, err error) {
-	packageInfo, _, err := shell.NewExecBuilder("tdnf", "info", packageName, "--repo", "@system").
-		LogLevel(logrus.TraceLevel, logrus.DebugLevel).
-		Chroot(imageChroot.ChrootDir()).
-		ExecuteCaptureOutput()
-	if err != nil {
-		return nil, fmt.Errorf("failed to query (%s) package information:\n%w", packageName, err)
-	}
-
+// parsePackageInfoOutput extracts the package version, release, distro name, and distro version from the
+// `Name: ... / Version: ... / Release: ...` text emitted by `tdnf info`.
+func parsePackageInfoOutput(packageName, packageInfo string) (*PackageVersionInformation, error) {
 	// Regular expressions to match Version and Release
 	versionRegex := regexp.MustCompile(`(?m)^Version\s+:\s+(\S+)`)
 	versionMatch := versionRegex.FindStringSubmatch(packageInfo)
-	var packageVersion string
 	if len(versionMatch) != 2 {
-		return nil, fmt.Errorf("failed to extract version information from the (%s) package information (\n%s\n):\n%w", packageName, packageInfo, err)
+		return nil, fmt.Errorf("failed to extract version information from the (%s) package information (\n%s\n)", packageName, packageInfo)
 	}
-	packageVersion = versionMatch[1]
+	packageVersion := versionMatch[1]
 
 	versionComponents, err := parseVersionString(packageVersion)
 	if err != nil {
@@ -165,24 +154,21 @@ func getPackageInformation(imageChroot *safechroot.Chroot, packageName string) (
 	// Extract Release
 	releaseRegex := regexp.MustCompile(`(?m)^Release\s+:\s+(\S+)`)
 	releaseMatch := releaseRegex.FindStringSubmatch(packageInfo)
-	var releaseInfo string
 	if len(releaseMatch) != 2 {
-		return nil, fmt.Errorf("failed to extract release information from the (%s) package information (\n%s\n):\n%w", packageName, packageInfo, err)
+		return nil, fmt.Errorf("failed to extract release information from the (%s) package information (\n%s\n)", packageName, packageInfo)
 	}
-	releaseInfo = releaseMatch[1]
+	releaseInfo := releaseMatch[1]
 
 	packageRelease, distroName, distroVersion, err := parseReleaseString(releaseInfo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse release information for package (%s)\n%w", packageName, err)
 	}
 
-	// Set return values
-	info = &PackageVersionInformation{
+	info := &PackageVersionInformation{
 		PackageVersionComponents: versionComponents,
 		PackageRelease:           packageRelease,
 		DistroName:               distroName,
 		DistroVersion:            distroVersion,
 	}
-
 	return info, nil
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/packagemanager_dnf.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/packagemanager_dnf.go
@@ -210,7 +210,12 @@ func (pm *dnfPackageManager) getPackageInformation(imageChroot *safechroot.Chroo
 	if err != nil {
 		return nil, fmt.Errorf("failed to query (%s) package information via rpm:\n%w", packageName, err)
 	}
-	return parsePackageInfoOutput(packageName, packageInfo)
+
+	info, err := parsePackageInfoOutput(packageName, packageInfo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse (%s) package information from rpm:\n%w", packageName, err)
+	}
+	return info, nil
 }
 
 func (pm *dnfPackageManager) importGpgKeys(imageChroot *safechroot.Chroot, toolsChroot *safechroot.Chroot,

--- a/toolkit/tools/pkg/imagecustomizerlib/packagemanager_dnf.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/packagemanager_dnf.go
@@ -4,6 +4,7 @@
 package imagecustomizerlib
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -193,6 +194,23 @@ func (pm *dnfPackageManager) isPackageInstalled(imageChroot safechroot.ChrootInt
 		return false
 	}
 	return true
+}
+
+func (pm *dnfPackageManager) getPackageInformation(imageChroot *safechroot.Chroot, packageName string,
+) (*PackageVersionInformation, error) {
+	// Use `rpm -q --queryformat` rather than `dnf info --installed` here for the same reason as in isPackageInstalled.
+	//
+	// Use `--queryformat` to get a single-line, parser-friendly output that matches what parsePackageInfoOutput
+	// already expects from `tdnf info` (Name/Version/Release labels), so we share the parser.
+	packageInfo, _, err := shell.NewExecBuilder("rpm", "-q", "--queryformat",
+		"Name : %{NAME}\nVersion : %{VERSION}\nRelease : %{RELEASE}\n", "--", packageName).
+		LogLevel(logrus.TraceLevel, logrus.DebugLevel).
+		Chroot(imageChroot.ChrootDir()).
+		ExecuteCaptureOutput()
+	if err != nil {
+		return nil, fmt.Errorf("failed to query (%s) package information via rpm:\n%w", packageName, err)
+	}
+	return parsePackageInfoOutput(packageName, packageInfo)
 }
 
 func (pm *dnfPackageManager) importGpgKeys(imageChroot *safechroot.Chroot, toolsChroot *safechroot.Chroot,

--- a/toolkit/tools/pkg/imagecustomizerlib/packagemanager_rpm.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/packagemanager_rpm.go
@@ -24,6 +24,10 @@ type rpmPackageManagerHandler interface {
 
 	isPackageInstalled(imageChroot safechroot.ChrootInterface, packageName string) bool
 
+	// getPackageInformation queries the package database for packageName and returns its parsed version,
+	// release, and distro fields.
+	getPackageInformation(imageChroot *safechroot.Chroot, packageName string) (*PackageVersionInformation, error)
+
 	importGpgKeys(imageChroot *safechroot.Chroot, toolsChroot *safechroot.Chroot, chrootGpgKeys []string,
 		uriGpgKeys []string,
 	) error

--- a/toolkit/tools/pkg/imagecustomizerlib/packagemanager_tdnf.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/packagemanager_tdnf.go
@@ -117,6 +117,18 @@ func (pm *tdnfPackageManager) isPackageInstalled(imageChroot safechroot.ChrootIn
 	return true
 }
 
+func (pm *tdnfPackageManager) getPackageInformation(imageChroot *safechroot.Chroot, packageName string,
+) (*PackageVersionInformation, error) {
+	packageInfo, _, err := shell.NewExecBuilder(packageManagerTDNF, "info", packageName, "--repo", "@system").
+		LogLevel(logrus.TraceLevel, logrus.DebugLevel).
+		Chroot(imageChroot.ChrootDir()).
+		ExecuteCaptureOutput()
+	if err != nil {
+		return nil, fmt.Errorf("failed to query (%s) package information via tdnf:\n%w", packageName, err)
+	}
+	return parsePackageInfoOutput(packageName, packageInfo)
+}
+
 func (pm *tdnfPackageManager) importGpgKeys(imageChroot *safechroot.Chroot, toolsChroot *safechroot.Chroot,
 	chrootGpgKeys []string, uriGpgKeys []string,
 ) error {


### PR DESCRIPTION
Package version/release information was retrieved with a single hard-coded
`tdnf info` call, which only works on Azure Linux 2.0/3.0. This routes it through
the `DistroHandler` so each distro queries its native package database. It
unblocks package-version lookups (e.g. `dracut`, `selinux-policy`) needed by the
LiveOS/ISO path on Azure Linux 4.0 and Fedora.

### Changes

- **`DistroHandler` interface:** add
  `GetPackageInformation(imageChroot, packageName) (*PackageVersionInformation, error)`.
  - Azure Linux 2.0/3.0, Azure Linux 4.0, Fedora, and Azure Container Linux
    delegate to their package manager.
  - Ubuntu returns an "unsupported" error. The RPM-style
    `PackageVersionInformation` has no Debian equivalent.
- **`rpmPackageManagerHandler` interface:** add `getPackageInformation(...)`.
  - **tdnf** — `tdnf info <pkg> --repo @system` (the previous behavior).
  - **dnf** — `rpm -q --queryformat 'Name : … Version : … Release : …'`, which
    reads the local rpm DB directly (works on read-only chroots, no dnf logdir
    writes) and reuses the same parser.
- **`packageinformation.go`:** extract the pure `parsePackageInfoOutput` parser
  from the old shell-invoking `getPackageInformation` so both package managers
  share it. Also fixes error messages that formatted a `nil` error with `%w`.
- **Caller (`liveosisoartifactstore.go`):** use
  `distroHandler.GetPackageInformation(...)` instead of the package-global helper.
- **Azure Linux 4.0:** remove the `ValidateConfig` guard that hard-rejected ISO
  and PXE output formats, as part of enabling those formats for AZL 4.0.