### PR TITLE
Update tests to AZL4 beta

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizebootloader_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizebootloader_test.go
@@ -23,10 +23,6 @@ func TestCustomizeImageMultiKernel(t *testing.T) {
 }
 
 func testCustomizeImageMultiKernel(t *testing.T, testName string, baseImageInfo testBaseImageInfo) {
-	if baseImageInfo.Version == baseImageVersionAzl4 {
-		t.Skip("AZL4 repos currently only have one kernel version available")
-	}
-
 	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
 	testTmpDir := filepath.Join(tmpDir, testName)
@@ -78,8 +74,13 @@ func testCustomizeImageMultiKernel(t *testing.T, testName string, baseImageInfo 
 		assert.GreaterOrEqual(t, len(matches), 2, "grub.cfg:\n%s", grubCfgContents)
 
 	case baseImageVersionAzl4:
-		// AZL4 uses BLS (Boot Loader Specification) entries instead of inline linux lines in grub.cfg.
-		assert.GreaterOrEqual(t, len(matches), 1, "grub.cfg:\n%s", grubCfgContents)
+		// AZL4 uses BLS (Boot Loader Specification) entries instead of inline linux
+		// lines in grub.cfg, so there are no `linux ... console=...` lines to match.
+		// The kernel command line instead lives in the grub.cfg `kernelopts` fallback
+		// and in each per-kernel BLS entry (checked below). Verify the extraCommandLine
+		// made it into kernelopts.
+		kernelOptsRegex := regexp.MustCompile(`(?m)^\s*set kernelopts=.* console=tty0 console=ttyS0`)
+		assert.Regexp(t, kernelOptsRegex, grubCfgContents, "grub.cfg:\n%s", grubCfgContents)
 
 		// One BLS entry per kernel.
 		blsEntriesDir := filepath.Join(imageConnection.Chroot().RootDir(), "/boot/loader/entries")

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
@@ -58,12 +58,12 @@ var (
 		},
 	}
 
-	// Azure Linux 4.0 core-efi base image has a 12 GiB virtual disk and tags the
+	// Azure Linux 4.0 core-efi base image has a 15 GiB virtual disk and tags the
 	// rootfs with the discoverable-partitions arch-specific root GUID instead of
 	// the legacy linux-filesystem GUID used by AzL2/AzL3.
 	expectedCosiMetadataForAzl4CoreEfi = MetadataJson{
 		Disk: Disk{
-			Size:       12 * diskutils.GiB,
+			Size:       15 * diskutils.GiB,
 			GptRegions: newTestCosiGptSections([]int{1, 2}),
 		},
 		Images: []FileSystem{

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
@@ -54,7 +54,7 @@ func createConfig(t *testing.T, baseImageVersion string, fileNames, kernelParame
 		case baseImageVersionAzl3:
 			kernelPackageName = "kernel-6.6.57.1-6.azl3"
 		case baseImageVersionAzl4:
-			kernelPackageName = "kernel-6.18.5-1.8.azl4~20260420"
+			kernelPackageName = "kernel-6.18.5-1.8.azl4"
 		default:
 			assert.NoError(t, fmt.Errorf("undefined image version"), "unsupported distro version")
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/iso-bootstrap-vm-azl4.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/iso-bootstrap-vm-azl4.yaml
@@ -9,7 +9,7 @@ os:
   packages:
     install:
     # multi-kernel test
-    - kernel-6.18.5-1.8.azl4~20260420
+    - kernel-6.18.5-1.8.azl4
     # iso required packages
     - squashfs-tools
     - tar

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/iso-full-os-vm-azl4.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/iso-full-os-vm-azl4.yaml
@@ -13,7 +13,7 @@ os:
   packages:
     install:
     # multi-kernel test
-    - kernel-6.18.5-1.8.azl4~20260420
+    - kernel-6.18.5-1.8.azl4
     # iso required packages
     - squashfs-tools
     - tar

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/multikernel-azl4.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/multikernel-azl4.yaml
@@ -29,7 +29,7 @@ os:
 
   packages:
     install:
-    - kernel-6.18.5-1.8.azl4~20260420
+    - kernel-6.18.5-1.8.azl4
 
   kernelCommandLine:
     extraCommandLine:

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/os-vm-config-azl4.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/os-vm-config-azl4.yaml
@@ -7,4 +7,4 @@ os:
   packages:
     install:
     # multi-kernel test
-    - kernel-6.18.5-1.8.azl4~20260420
+    - kernel-6.18.5-1.8.azl4


### PR DESCRIPTION
Update the Image Customizer test suite to run against the Azure Linux 4.0 beta release.

- **Enable the AZL4 multi-kernel test.** AZL4 now ships multiple kernels, so the `TestCustomizeImageMultiKernel` AZL4 skip is removed. AZL4 boots via BLS entries, so the assertion checks grub.cfg `kernelopts` plus the per-kernel BLS entries instead of nonexistent inline `linux` lines.
- **Re-pin the AZL4 kernel** from the dropped pre-release snapshot to the released build.
- **Bump the expected AZL4 core-efi disk size** from 12 GiB to 15 GiB to match the grown base image.

| AZL4 kernel package | Before | After |
|---|---|---|
| all test data + `liveosisobuilder_test.go` | `kernel-6.18.5-1.8.azl4~20260420` | `kernel-6.18.5-1.8.azl4` |

---

### **Checklist**
- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
