### PR TITLE
Remove requirement to bind mount /dev for container.

### DIFF
--- a/docs/imagecustomizer/how-to/azure-vm/azure-vm.md
+++ b/docs/imagecustomizer/how-to/azure-vm/azure-vm.md
@@ -155,7 +155,6 @@ in front of any HTTP endpoints.
    docker run \
      --rm \
      --privileged=true \
-     -v /dev:/dev \
      -v "$STAGE_DIR:/mnt/staging:z" \
      "$IMG_CUSTOMIZER_TAG" \
        --image-file "/mnt/staging/image.vhd" \

--- a/docs/imagecustomizer/how-to/create-image.md
+++ b/docs/imagecustomizer/how-to/create-image.md
@@ -241,7 +241,6 @@ As such, the example configuration files below must specify `create` in the [pre
     docker run \
       --rm \
       --privileged=true \
-      -v /dev:/dev \
       -v "$HOME/staging:/mnt/staging:z" \
       mcr.microsoft.com/azurelinux/imagecustomizer:latest create \
         --distro azurelinux \
@@ -260,7 +259,6 @@ As such, the example configuration files below must specify `create` in the [pre
     docker run \
       --rm \
       --privileged=true \
-      -v /dev:/dev \
       -v "$HOME/staging:/mnt/staging:z" \
       mcr.microsoft.com/azurelinux/imagecustomizer:latest create \
         --distro fedora \
@@ -276,15 +274,11 @@ As such, the example configuration files below must specify `create` in the [pre
     Docker options:
 
     - `run`: Runs the container.
-    
+
     - `--rm`: Cleans up the container once the program has completed.
 
     - `--privileged=true`: Gives the container root permissions, which is needed to mount
       loopback devices (i.e. disk files) and partitions.
-
-    - `-v /dev:/dev`: When mounting loopback devices, the container needs the partition
-      device nodes to be populated under `/dev`. But the udevd service runs in the host not
-      the container. So, the container doesn't receive udev updates.
 
       This option maps in the host's version of `/dev` into the container, instead of the
       container getting its own `/dev`.
@@ -295,6 +289,12 @@ As such, the example configuration files below must specify `create` in the [pre
     - `mcr.microsoft.com/azurelinux/imagecustomizer:latest`: The container to run.
 
     - `create`: Specifies the subcommand to run within the container.
+
+    For v1.4 and below, you must also add the docker option:
+
+    - `-v /dev:/dev`: When mounting loopback devices, the container needs the partition
+      device nodes to be populated under `/dev`. But the container only has a copy of
+      `/dev` at the time of the container's creation.
 
     Image Customizer options for the ([create subcommand](../api/cli/create.md)):
 

--- a/docs/imagecustomizer/quick-start/quick-start.md
+++ b/docs/imagecustomizer/quick-start/quick-start.md
@@ -72,7 +72,6 @@ The container is published to both:
     docker run \
       --rm \
       --privileged=true \
-      -v /dev:/dev \
       -v "$HOME/staging:/mnt/staging:z" \
       mcr.microsoft.com/azurelinux/imagecustomizer:latest \
         --image-file "/mnt/staging/image.vhdx" \
@@ -90,10 +89,6 @@ The container is published to both:
     - `--privileged=true`: Gives the container root permissions, which is needed to mount
       loopback devices (i.e. disk files) and partitions.
 
-    - `-v /dev:/dev`: When mounting loopback devices, the container needs the partition
-      device nodes to be populated under `/dev`. But the udevd service runs in the host not
-      the container. So, the container doesn't receive udev updates.
-
       This option maps in the host's version of `/dev` into the container, instead of the
       container getting its own `/dev`.
 
@@ -103,6 +98,12 @@ The container is published to both:
     - `mcr.microsoft.com/azurelinux/imagecustomizer:latest`: The container to run.
 
     - `imagecustomizer`: Specifies the executable to run within the container.
+
+    For v1.4 and below, you must also add the docker option:
+
+    - `-v /dev:/dev`: When mounting loopback devices, the container needs the partition
+      device nodes to be populated under `/dev`. But the container only has a copy of
+      `/dev` at the time of the container's creation.
 
     Image Customizer options ([CLI API](../api/cli/cli.md)):
 

--- a/docs/imagecustomizer/telemetry.md
+++ b/docs/imagecustomizer/telemetry.md
@@ -29,7 +29,6 @@ the flag `--disable-telemetry`. Here is a sample command:
 docker run \
    --rm \
    --privileged=true \
-   -v /dev:/dev \
    -v "$HOME/staging:/mnt/staging:z" \
    mcr.microsoft.com/azurelinux/imagecustomizer:latest \
      --image-file "/mnt/staging/image.vhdx" \

--- a/test/vmtests/vmtests/utils/imagecustomizer.py
+++ b/test/vmtests/vmtests/utils/imagecustomizer.py
@@ -62,7 +62,6 @@ def run_image_customizer(
     volumes = [
         f"{config_dir}:{container_config_dir}:z",
         f"{output_image_dir}:{container_output_image_dir}:z",
-        "/dev:/dev",
     ]
 
     if image_file:

--- a/toolkit/tools/imagecustomizer/container/entrypoint.sh
+++ b/toolkit/tools/imagecustomizer/container/entrypoint.sh
@@ -26,4 +26,8 @@ if [[ "$ENABLE_TELEMETRY" == "true" ]] && [[ -n "$AZURE_MONITOR_CONNECTION_STRIN
     sleep 1
 fi
 
+# containerd by default creates /dev as a tmpfs and populates it with a copy of the host's /dev at the time of container
+# creation. Replace it with a real devtmpfs so that partitions are populated when a virtual disk is mounted.
+mount -t devtmpfs devtmpfs /dev
+
 imagecustomizer "$@"

--- a/toolkit/tools/imagecustomizer/container/run-container.sh
+++ b/toolkit/tools/imagecustomizer/container/run-container.sh
@@ -90,7 +90,6 @@ docker run --rm \
    -v $inputImageDir:$containerInputImageDir:z \
    -v $inputConfigDir:$containerInputConfigDir:z \
    -v $outputImageDir:$containerOutputDir:z \
-   -v /dev:/dev \
    "$containerTag" \
       --image-file $containerInputImage \
       --config-file $containerInputConfig \

--- a/toolkit/tools/imagecustomizer/container/test-container.sh
+++ b/toolkit/tools/imagecustomizer/container/test-container.sh
@@ -27,7 +27,6 @@ docker run --rm \
     --privileged=true \
     -v "$inputConfigDir":"$containerInputConfigDir":z \
     -v "$outputImageDir":"$containerOutputDir":z \
-    -v /dev:/dev \
     --entrypoint /usr/lib/imagecustomizer/run.sh \
     "$containerTag" \
         "3.0.latest" \


### PR DESCRIPTION
Currently, the Image Customizer container requires the user to bind mount the host's `/dev` into the container. This is because containerd creates `/dev` as a tmpfs and then populates the tmpfs with the contents of the host's `/dev` at the time of the container creation.

A privlidged container can workaround this by overwriting its `/dev` with a proper `devtmpfs` like so:

```bash
mount -t devtmpfs devtmpfs /dev
```

This change modifies IC's `entrypoint.sh` script to include this override so that users no longer need to bind mount /dev.

Note: It doesn't cause any harm if users continue to bind mount `/dev`. It just won't do anything meaningful now.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
