### PR TITLE
Remove unused jq --arg in download-image.sh

### DIFF
--- a/.github/workflows/scripts/download-image.sh
+++ b/.github/workflows/scripts/download-image.sh
@@ -34,7 +34,6 @@ CONTAINERS_JSON=$(
 LATEST_IMAGE=$(
     jq \
     -r \
-    --arg image "$IMAGE_NAME" \
     '[.[].name | select(endswith("/image.vhdx") or endswith("/image.vhd"))] | sort | last' \
     <<< "$CONTAINERS_JSON" \
 )


### PR DESCRIPTION
Removes the unused `--arg image "$IMAGE_NAME"` from the `jq` call in `download-image.sh`. The filter never references `$image`, so passing the argument had no effect. No behavior change.

---

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [x] Code conforms to style guidelines