### PR TITLE
Support pinning an image version in download-image.sh

### DIFF
--- a/.github/workflows/scripts/download-image.sh
+++ b/.github/workflows/scripts/download-image.sh
@@ -13,6 +13,9 @@
 #       IMAGE_NAME typically has the format "<DISTRO>/<IMAGE-TYPE>".
 #       For example, "azure-linux/core-efi-vhdx-3.0-amd64/3.0.20250702/image.vhdx".
 #     OUTPUT_DIR: The directory to output files to.
+#     VERSION: Optional pinned version. When set, the image is downloaded from
+#       "<IMAGE_NAME>/<VERSION>/image.vhdx" (or .vhd) directly without listing
+#       blobs. When omitted, the lex-last blob under "<IMAGE_NAME>/" is picked.
 
 set -eu
 
@@ -20,32 +23,65 @@ ACCOUNT="$1"
 CONTAINER="$2"
 IMAGE_NAME="$3"
 OUTPUT_DIR="$4"
+VERSION="${5:-}"
 
 mkdir -p "$OUTPUT_DIR"
 
-CONTAINERS_JSON=$(
-    az storage blob list \
-        --auth-mode login \
-        --account-name "$ACCOUNT" \
-        --container-name "$CONTAINER" \
-        --prefix "$IMAGE_NAME/"
-)
+if [[ -n "$VERSION" ]]; then
+    # Pinned version: try .vhdx first, fall back to .vhd. Use blob list
+    # restricted to the pinned version's directory so we don't have to guess
+    # the extension and so we still get a clear error if neither exists.
+    CONTAINERS_JSON=$(
+        az storage blob list \
+            --auth-mode login \
+            --account-name "$ACCOUNT" \
+            --container-name "$CONTAINER" \
+            --prefix "$IMAGE_NAME/$VERSION/"
+    )
 
-LATEST_IMAGE=$(
-    jq \
-    -r \
-    '[.[].name | select(endswith("/image.vhdx") or endswith("/image.vhd"))] | sort | last' \
-    <<< "$CONTAINERS_JSON" \
-)
+    BLOB=$(
+        jq \
+        -r \
+        '[.[].name | select(endswith("/image.vhdx") or endswith("/image.vhd"))] | sort | last' \
+        <<< "$CONTAINERS_JSON" \
+    )
 
-echo "Latest: $LATEST_IMAGE"
+    if [[ -z "$BLOB" || "$BLOB" == "null" ]]; then
+        echo "ERROR: no image.vhdx or image.vhd found at $IMAGE_NAME/$VERSION/" >&2
+        exit 1
+    fi
 
-FILENAME="$(basename "$LATEST_IMAGE")"
+    echo "Pinned: $BLOB"
+else
+    CONTAINERS_JSON=$(
+        az storage blob list \
+            --auth-mode login \
+            --account-name "$ACCOUNT" \
+            --container-name "$CONTAINER" \
+            --prefix "$IMAGE_NAME/"
+    )
+
+    BLOB=$(
+        jq \
+        -r \
+        '[.[].name | select(endswith("/image.vhdx") or endswith("/image.vhd"))] | sort | last' \
+        <<< "$CONTAINERS_JSON" \
+    )
+
+    if [[ -z "$BLOB" || "$BLOB" == "null" ]]; then
+        echo "ERROR: no image.vhdx or image.vhd found at $IMAGE_NAME/" >&2
+        exit 1
+    fi
+
+    echo "Latest: $BLOB"
+fi
+
+FILENAME="$(basename "$BLOB")"
 
 az storage blob download \
     --auth-mode login \
     --account-name "$ACCOUNT" \
     --container-name "$CONTAINER" \
-    --name "$LATEST_IMAGE" \
+    --name "$BLOB" \
     --file "$OUTPUT_DIR/$FILENAME" \
     --output none


### PR DESCRIPTION
Pinning a specific image version makes `download-image.sh` reproducible for testing and local development, so you can rerun against the exact image that produced a failure instead of whatever happens to be latest.

This adds an optional fifth `VERSION` argument. When set, the script fetches `<IMAGE_NAME>/<VERSION>/image.vhdx` (or `image.vhd`) directly. When omitted, behavior is unchanged and the lex-last blob under `<IMAGE_NAME>/` is used.

Both paths now print a clear error and exit non-zero when no `image.vhdx` or `image.vhd` is found. The argument is optional, so existing four-argument callers are unaffected.

### Checklist
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [x] Code conforms to style guidelines