### PR TITLE
Enable serial console and 1s timeout in azl4 grub defaults

### DIFF
--- a/toolkit/tools/internal/resources/assets/azurelinux/azurelinux-4.0/grub2/grub
+++ b/toolkit/tools/internal/resources/assets/azurelinux/azurelinux-4.0/grub2/grub
@@ -1,8 +1,8 @@
 GRUB_CMDLINE_LINUX="{{.LuksUUID}} {{.LVM}} {{.IMAPolicy}} {{.SELinux}} {{.FIPS}} {{.CGroup}}"
-GRUB_CMDLINE_LINUX_DEFAULT="console=ttyS0 rd.shell=0 {{.ExtraCommandLine}}"
+GRUB_CMDLINE_LINUX_DEFAULT="console=ttyS0 earlyprintk=ttyS0 rd.shell=0 {{.ExtraCommandLine}}"
 GRUB_ENABLE_BLSCFG=true
 GRUB_GFXMODE=auto
-GRUB_TERMINAL_INPUT="console"
-GRUB_TERMINAL_OUTPUT="gfxterm"
-GRUB_TIMEOUT=0
+GRUB_TERMINAL_INPUT="serial"
+GRUB_TERMINAL_OUTPUT="serial"
+GRUB_TIMEOUT=1
 GRUB_DEFAULT=saved


### PR DESCRIPTION
The Azure Linux 4.0 vm-base image (built with kiwi) boots with a serial console grub menu and a 1-second timeout. This updates the image-customizer azl4 `/etc/default/grub` asset to match, so images produced by the customizer share the same serial-console boot behavior as stock AZL4 images.

| Setting | Before | After |
|---|---|---|
| `GRUB_CMDLINE_LINUX_DEFAULT` | `console=ttyS0 rd.shell=0` | `console=ttyS0 earlyprintk=ttyS0 rd.shell=0` |
| `GRUB_TERMINAL_INPUT` | `console` | `serial` |
| `GRUB_TERMINAL_OUTPUT` | `gfxterm` | `serial` |
| `GRUB_TIMEOUT` | `0` | `1` |

These mirror microsoft/azurelinux `base/images/vm-base/vm-base.kiwi`, where each setting was introduced by:

- earlyprintk: microsoft/azurelinux#17026
- `GRUB_TERMINAL_INPUT` and `GRUB_TERMINAL_OUTPUT` (kiwi `console="serial"`): microsoft/azurelinux#16880
- `GRUB_TIMEOUT` (kiwi `timeout="1"`): microsoft/azurelinux#16937