### PR TITLE
Make CI apt steps wait for the dpkg lock to fix flaky installs

### DIFF
--- a/.github/workflows/binary-build.yml
+++ b/.github/workflows/binary-build.yml
@@ -108,10 +108,11 @@ jobs:
       run: |
         set -eux
 
-        sudo apt -y update
+        # Wait for the dpkg lock (held by the runner's background unattended-upgrades) rather than failing.
+        sudo apt -o DPkg::Lock::Timeout=600 -y update
 
         # qemu-utils (qemu-img) is required to run tests later during the build
-        sudo apt -y install libvirt-dev qemu-utils
+        sudo apt -o DPkg::Lock::Timeout=600 -y install libvirt-dev qemu-utils
 
         pushd repo/test/vmtests
 

--- a/.github/workflows/tests-functional.yml
+++ b/.github/workflows/tests-functional.yml
@@ -82,10 +82,11 @@ jobs:
         set -eux
 
         # Install Image Customizer prerequisities.
+        # Wait for the dpkg lock (held by the runner's background unattended-upgrades) rather than failing.
         sudo apt list --installed
-        sudo apt update -y
+        sudo apt -o DPkg::Lock::Timeout=600 update -y
 
-        sudo apt -y install qemu-utils rpm coreutils util-linux mount fdisk udev openssl \
+        sudo apt -o DPkg::Lock::Timeout=600 -y install qemu-utils rpm coreutils util-linux mount fdisk udev openssl \
           sed createrepo-c squashfs-tools genisoimage e2fsprogs dosfstools \
           xfsprogs btrfs-progs zstd cryptsetup-bin grub2-common binutils lsof systemd-ukify
 

--- a/.github/workflows/tests-vmtests-osmodifier.yml
+++ b/.github/workflows/tests-vmtests-osmodifier.yml
@@ -64,14 +64,15 @@ jobs:
         run: |
           set -eux
 
-          sudo apt update -y
-          sudo apt -y install python3-venv python3-pip python3-dev \
+          # Wait for the dpkg lock (held by the runner's background unattended-upgrades) rather than failing.
+          sudo apt -o DPkg::Lock::Timeout=600 update -y
+          sudo apt -o DPkg::Lock::Timeout=600 -y install python3-venv python3-pip python3-dev \
               libvirt-dev libvirt-daemon libvirt-daemon-system libvirt-clients \
               qemu-kvm virt-manager
 
           # Install arm64 specific
           if [[ "$HOST_ARCH" == "arm64" ]]; then
-            sudo apt -y install qemu-system-arm qemu-efi-aarch64 ovmf seabios
+            sudo apt -o DPkg::Lock::Timeout=600 -y install qemu-system-arm qemu-efi-aarch64 ovmf seabios
           fi
 
           sudo apt list --installed

--- a/.github/workflows/tests-vmtests.yml
+++ b/.github/workflows/tests-vmtests.yml
@@ -64,14 +64,15 @@ jobs:
       run: |
         set -eux
 
-        sudo apt update -y
-        sudo apt -y install python3-venv python3-pip python3-dev \
+        # Wait for the dpkg lock (held by the runner's background unattended-upgrades) rather than failing.
+        sudo apt -o DPkg::Lock::Timeout=600 update -y
+        sudo apt -o DPkg::Lock::Timeout=600 -y install python3-venv python3-pip python3-dev \
             libvirt-dev libvirt-daemon libvirt-daemon-system libvirt-clients \
             qemu-kvm virt-manager
 
         # Install arm64 specific
         if [[ "$HOST_ARCH" == "arm64" ]]; then
-          sudo apt -y install qemu-system-arm qemu-efi-aarch64 ovmf seabios
+          sudo apt -o DPkg::Lock::Timeout=600 -y install qemu-system-arm qemu-efi-aarch64 ovmf seabios
         fi
 
         sudo apt list --installed


### PR DESCRIPTION
The "Install prerequisites (Ubuntu 24.04)" steps intermittently fail with:

    E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process N (apt-get)
    E: Unable to acquire the dpkg frontend lock, is another process using it?

This happens when the runner's background apt activity (unattended-upgrades / apt-daily) holds the dpkg lock while our `apt update`/`apt install` runs. Without a lock wait, apt exits immediately with code 100 and fails the whole job before any test runs, so the job produces no test artifacts.

Pass `-o DPkg::Lock::Timeout=600` to every `apt update`/`apt install` so apt waits up to 10 minutes for the lock to be released instead of failing immediately. The AZL3 prerequisite steps already wrap tdnf in retry.sh and are unaffected.

Applied to the Ubuntu prerequisite steps in tests-functional.yml, tests-vmtests.yml, tests-vmtests-osmodifier.yml and binary-build.yml.

---

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [x] Code conforms to style guidelines
