### PR TITLE
Set the apt dpkg lock timeout globally so the Azure CLI installer waits too

### DIFF
--- a/.github/workflows/binary-build.yml
+++ b/.github/workflows/binary-build.yml
@@ -108,11 +108,16 @@ jobs:
       run: |
         set -eux
 
-        # Wait for the dpkg lock (held by the runner's background unattended-upgrades) rather than failing.
-        sudo apt -o DPkg::Lock::Timeout=600 -y update
+        # Wait for the dpkg lock (held by the runner's background unattended-upgrades) rather than
+        # failing. Set it globally so apt invocations inside the Azure CLI install script wait too.
+        # Create the apt.conf.d directory if missing; append so an existing config isn't clobbered.
+        sudo mkdir -p /etc/apt/apt.conf.d
+        echo 'DPkg::Lock::Timeout "600";' | sudo tee -a /etc/apt/apt.conf.d/99lock-timeout
+
+        sudo apt -y update
 
         # qemu-utils (qemu-img) is required to run tests later during the build
-        sudo apt -o DPkg::Lock::Timeout=600 -y install libvirt-dev qemu-utils
+        sudo apt -y install libvirt-dev qemu-utils
 
         pushd repo/test/vmtests
 

--- a/.github/workflows/tests-functional.yml
+++ b/.github/workflows/tests-functional.yml
@@ -81,12 +81,17 @@ jobs:
       run: |
         set -eux
 
-        # Install Image Customizer prerequisities.
-        # Wait for the dpkg lock (held by the runner's background unattended-upgrades) rather than failing.
-        sudo apt list --installed
-        sudo apt -o DPkg::Lock::Timeout=600 update -y
+        # Wait for the dpkg lock (held by the runner's background unattended-upgrades) rather than
+        # failing. Set it globally so apt invocations inside the Azure CLI install script wait too.
+        # Create the apt.conf.d directory if missing; append so an existing config isn't clobbered.
+        sudo mkdir -p /etc/apt/apt.conf.d
+        echo 'DPkg::Lock::Timeout "600";' | sudo tee -a /etc/apt/apt.conf.d/99lock-timeout
 
-        sudo apt -o DPkg::Lock::Timeout=600 -y install qemu-utils rpm coreutils util-linux mount fdisk udev openssl \
+        # Install Image Customizer prerequisities.
+        sudo apt list --installed
+        sudo apt update -y
+
+        sudo apt -y install qemu-utils rpm coreutils util-linux mount fdisk udev openssl \
           sed createrepo-c squashfs-tools genisoimage e2fsprogs dosfstools \
           xfsprogs btrfs-progs zstd cryptsetup-bin grub2-common binutils lsof systemd-ukify
 

--- a/.github/workflows/tests-vmtests-osmodifier.yml
+++ b/.github/workflows/tests-vmtests-osmodifier.yml
@@ -64,15 +64,20 @@ jobs:
         run: |
           set -eux
 
-          # Wait for the dpkg lock (held by the runner's background unattended-upgrades) rather than failing.
-          sudo apt -o DPkg::Lock::Timeout=600 update -y
-          sudo apt -o DPkg::Lock::Timeout=600 -y install python3-venv python3-pip python3-dev \
+          # Wait for the dpkg lock (held by the runner's background unattended-upgrades) rather than
+          # failing. Set it globally so apt invocations inside the Azure CLI install script wait too.
+          # Create the apt.conf.d directory if missing; append so an existing config isn't clobbered.
+          sudo mkdir -p /etc/apt/apt.conf.d
+          echo 'DPkg::Lock::Timeout "600";' | sudo tee -a /etc/apt/apt.conf.d/99lock-timeout
+
+          sudo apt update -y
+          sudo apt -y install python3-venv python3-pip python3-dev \
               libvirt-dev libvirt-daemon libvirt-daemon-system libvirt-clients \
               qemu-kvm virt-manager
 
           # Install arm64 specific
           if [[ "$HOST_ARCH" == "arm64" ]]; then
-            sudo apt -o DPkg::Lock::Timeout=600 -y install qemu-system-arm qemu-efi-aarch64 ovmf seabios
+            sudo apt -y install qemu-system-arm qemu-efi-aarch64 ovmf seabios
           fi
 
           sudo apt list --installed

--- a/.github/workflows/tests-vmtests.yml
+++ b/.github/workflows/tests-vmtests.yml
@@ -64,15 +64,20 @@ jobs:
       run: |
         set -eux
 
-        # Wait for the dpkg lock (held by the runner's background unattended-upgrades) rather than failing.
-        sudo apt -o DPkg::Lock::Timeout=600 update -y
-        sudo apt -o DPkg::Lock::Timeout=600 -y install python3-venv python3-pip python3-dev \
+        # Wait for the dpkg lock (held by the runner's background unattended-upgrades) rather than
+        # failing. Set it globally so apt invocations inside the Azure CLI install script wait too.
+        # Create the apt.conf.d directory if missing; append so an existing config isn't clobbered.
+        sudo mkdir -p /etc/apt/apt.conf.d
+        echo 'DPkg::Lock::Timeout "600";' | sudo tee -a /etc/apt/apt.conf.d/99lock-timeout
+
+        sudo apt update -y
+        sudo apt -y install python3-venv python3-pip python3-dev \
             libvirt-dev libvirt-daemon libvirt-daemon-system libvirt-clients \
             qemu-kvm virt-manager
 
         # Install arm64 specific
         if [[ "$HOST_ARCH" == "arm64" ]]; then
-          sudo apt -o DPkg::Lock::Timeout=600 -y install qemu-system-arm qemu-efi-aarch64 ovmf seabios
+          sudo apt -y install qemu-system-arm qemu-efi-aarch64 ovmf seabios
         fi
 
         sudo apt list --installed


### PR DESCRIPTION
Follow-up to #795 that fixes the remaining flaky dpkg-lock failures in the Ubuntu CI prerequisite steps by setting the apt lock timeout globally so the Azure CLI installer's internal apt waits for the lock too.

#795 added `-o DPkg::Lock::Timeout=600` to the explicit apt commands, but each prerequisite step also runs the Azure CLI installer (`curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash`), which runs its own apt with no lock timeout. When the runner's background unattended-upgrades held the dpkg lock, that internal apt still failed immediately and killed the job before any test ran, as in [this Build (dev) failure](https://github.com/microsoft/azure-linux-image-tools/actions/runs/28047198897/job/83029219491) (`build / VMTests osmodifier Ubuntu24.04 AMD64`):

```
E: Could not get lock /var/lib/dpkg/lock-frontend. It is held by process N (apt-get)
E: Unable to acquire the dpkg frontend lock, is another process using it?
```

Each prerequisite step now creates `/etc/apt/apt.conf.d/` if missing and appends `DPkg::Lock::Timeout "600";` to `99lock-timeout`, so every apt/apt-get in the step (including the ones inside the installer) waits up to 10 minutes for the lock. The now-redundant per-command flags are removed.

Applied to `tests-functional.yml`, `tests-vmtests.yml`, `tests-vmtests-osmodifier.yml`, and `binary-build.yml`.

---

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [x] Code conforms to style guidelines