### PR TITLE
Preserve symlinks when staging LiveOS ISO/PXE boot files

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoimages.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoimages.go
@@ -236,7 +236,13 @@ func stageLiveOSFile(stageDirPath string, stageFile StageFile) error {
 		return fmt.Errorf("failed to create destination directory (%s):\n%w", targetDir, err)
 	}
 
-	err = file.Copy(stageFile.sourcePath, targetPath)
+	// Preserve symlinks rather than dereferencing them. Some kernel boot files (e.g. Azure Linux 4.0's
+	// symvers-<ver>.xz) are symlinks into the rootfs that dangle in the flattened artifacts directory. The
+	// artifacts were copied in with --no-dereference, so stage them the same way; mkisofs records the symlinks
+	// via Rock Ridge. Regular files fall through to a normal copy.
+	err = file.NewFileCopyBuilder(stageFile.sourcePath, targetPath).
+		SetNoDereference().
+		Run()
 	if err != nil {
 		return fmt.Errorf("failed to stage file from (%s) to (%s):\n%w", stageFile.sourcePath, targetPath, err)
 	}


### PR DESCRIPTION
Stage LiveOS ISO/PXE boot files without dereferencing symlinks, so symlinked kernel boot files (e.g. Azure Linux 4.0's `symvers-<ver>.xz`) no longer break ISO/PXE generation.

`stageLiveOSFile` used `file.Copy`, which follows symlinks. Some boot files are themselves symlinks into the rootfs, and they dangle once the boot files are flattened into the artifacts directory, so dereferencing them fails.

Example (AZL4, kernel `6.18.31-1.5.azl4.x86_64`, verified on the published azure-linux-core-efi-4.0-amd64 image):

```
/boot/symvers-6.18.31-1.5.azl4.x86_64.xz -> /lib/modules/6.18.31-1.5.azl4.x86_64/symvers.xz
```

The target lives in the rootfs. The flattened artifacts directory holds only `boot/`, with no `/lib/modules` tree, so the symlink does not resolve there.

The artifacts are flattened by `createIsoFilesStoreFromMountedImage` in `liveosisoartifactstore.go`, which already copies them with `SetNoDereference()`. This change makes staging match.

| | Before | After |
|---|---|---|
| Copy call | `file.Copy(src, dst)` | `file.NewFileCopyBuilder(src, dst).SetNoDereference().Run()` |
| Symlinks | dereferenced (fails on dangling targets) | preserved, recorded by mkisofs via Rock Ridge |
| Regular files | normal copy | normal copy (unchanged) |

Non-AZL4 inputs are unaffected.

---

### **Checklist**
- [ ] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines