### PR TITLE
Fix build directory when using tools directory.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput.go
@@ -461,12 +461,13 @@ func injectFilesIntoImage(buildDir string, baseConfigPath string, rawImageFile s
 }
 
 func prepareImageConversionData(ctx context.Context, rawImageFile string, buildDir string,
-	chrootDir string,
 ) ([]fstabEntryPartNum, []verityDeviceMetadata, string,
 	[]OsPackage, [randomization.UuidSize]byte, string, *CosiBootloader, []string, error,
 ) {
+	imageMountPoint := filepath.Join(buildDir, "imageroot")
+
 	imageConnection, partitionsLayout, baseImageVerityMetadata, readonlyPartUuids, distroHandler, err :=
-		connectToExistingImage(ctx, rawImageFile, buildDir, chrootDir, true, true, true, true, nil)
+		connectToExistingImage(ctx, rawImageFile, buildDir, imageMountPoint, true, true, true, true, nil)
 	if err != nil {
 		err = fmt.Errorf("%w:\n%w", ErrArtifactImageConnectionForExtraction, err)
 		return nil, nil, "", nil, [randomization.UuidSize]byte{}, "", nil, nil, err

--- a/toolkit/tools/pkg/imagecustomizerlib/convertimage.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/convertimage.go
@@ -128,7 +128,7 @@ func convertRawImageToOutputFormat(ctx context.Context, buildDirAbs string, rawI
 	if outputFormat == imagecustomizerapi.ImageFormatTypeCosi || outputFormat == imagecustomizerapi.ImageFormatTypeBareMetalImage {
 		// Convert subcommand doesn't support preview features - pass empty slice
 		partitionsLayout, baseImageVerityMetadata, osRelease, osPackages, imageUuid, imageUuidStr, cosiBootMetadata,
-			readonlyPartUuids, err := prepareImageConversionData(ctx, rawImageFile, buildDirAbs, "imageroot")
+			readonlyPartUuids, err := prepareImageConversionData(ctx, rawImageFile, buildDirAbs)
 		if err != nil {
 			return fmt.Errorf("%w:\n%w", ErrArtifactCosiImageInfoCollect, err)
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/createimagehelper.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/createimagehelper.go
@@ -6,6 +6,7 @@ package imagecustomizerlib
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"time"
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/installutils"
@@ -25,8 +26,10 @@ func CustomizeImageHelperCreate(ctx context.Context, rc *ResolvedConfig, toolsDi
 	}
 	defer toolsChroot.Close()
 
-	imageConnection, partitionsLayout, _, _, _, err := connectToExistingImage(ctx, rc.RawImageFile, toolsDir,
-		toolsRootImageDir, true, false, false, false, distroHandler)
+	imageMountPoint := filepath.Join(toolsDir, toolsRootImageDir)
+
+	imageConnection, partitionsLayout, _, _, _, err := connectToExistingImage(ctx, rc.RawImageFile, rc.BuildDirAbs,
+		imageMountPoint, true, false, false, false, distroHandler)
 	if err != nil {
 		return nil, "", err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitionsfilecopy.go
@@ -6,6 +6,7 @@ package imagecustomizerlib
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safechroot"
@@ -23,8 +24,10 @@ var (
 func customizePartitionsUsingFileCopy(ctx context.Context, buildDir string, storage imagecustomizerapi.Storage,
 	buildImageFile string, newBuildImageFile string, distroHandler DistroHandler,
 ) (map[string]string, error) {
-	existingImageConnection, _, _, _, _, err := connectToExistingImage(ctx, buildImageFile, buildDir, "imageroot", false,
-		true, false, false, distroHandler)
+	imageMountPoint := filepath.Join(buildDir, "imageroot")
+
+	existingImageConnection, _, _, _, _, err := connectToExistingImage(ctx, buildImageFile, buildDir, imageMountPoint,
+		false, true, false, false, distroHandler)
 	if err != nil {
 		return nil, err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -696,15 +696,13 @@ func customizeImageHelper(ctx context.Context, rc *ResolvedConfig, partitionsCus
 
 	// When a tools chroot is supplied, the image must be mounted inside it so that tdnf running inside the tools chroot
 	// can reach the image at /_imageroot. Otherwise mount it at the build dir.
-	mountBaseDir := rc.BuildDirAbs
-	mountPointName := "imageroot"
+	imageMountPoint := filepath.Join(rc.BuildDirAbs, "imageroot")
 	if toolsChroot != nil {
-		mountBaseDir = rc.Options.ToolsDir
-		mountPointName = toolsRootImageDir
+		imageMountPoint = filepath.Join(rc.Options.ToolsDir, toolsRootImageDir)
 	}
 
 	imageConnection, partitionsLayout, baseImageVerityMetadata, readonlyPartUuids, _, err := connectToExistingImage(
-		ctx, rc.RawImageFile, mountBaseDir, mountPointName, true, false, readOnlyVerity, false, distroHandler)
+		ctx, rc.RawImageFile, rc.BuildDirAbs, imageMountPoint, true, false, readOnlyVerity, false, distroHandler)
 	if err != nil {
 		return nil, nil, nil, "", err
 	}
@@ -765,8 +763,9 @@ func customizeImageHelper(ctx context.Context, rc *ResolvedConfig, partitionsCus
 func collectOSInfo(ctx context.Context, buildDir string, rawImageFile string, partitionsLayout []fstabEntryPartNum,
 	distroHandler DistroHandler, toolsChroot *safechroot.Chroot,
 ) ([]OsPackage, *CosiBootloader, error) {
-	var err error
-	imageConnection, _, err := reconnectToExistingImage(ctx, rawImageFile, buildDir, "imageroot", true, true, false,
+	imageMountPoint := filepath.Join(buildDir, "imageroot")
+
+	imageConnection, _, err := reconnectToExistingImage(ctx, rawImageFile, buildDir, imageMountPoint, true, true, false,
 		partitionsLayout, distroHandler)
 	if err != nil {
 		return nil, nil, err
@@ -899,8 +898,10 @@ func CheckEnvironmentVars() error {
 // features enabled. Returns the detected target OS.
 func validateTargetOs(ctx context.Context, rc *ResolvedConfig,
 ) (DistroHandler, error) {
+	imageMountPoint := filepath.Join(rc.BuildDirAbs, "imageroot")
+
 	existingImageConnection, _, _, _, distroHandler, err := connectToExistingImage(ctx, rc.RawImageFile, rc.BuildDirAbs,
-		"imageroot", false /* include-default-mounts */, true, /* read-only */
+		imageMountPoint, false /* include-default-mounts */, true, /* read-only */
 		false /* read-only-verity */, false /* ignore-overlays */, nil /* distroHandler */)
 	if err != nil {
 		return nil, err

--- a/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
@@ -32,7 +32,7 @@ import (
 
 type installOSFunc func(imageChroot *safechroot.Chroot) error
 
-func connectToExistingImage(ctx context.Context, imageFilePath string, buildDir string, chrootDirName string,
+func connectToExistingImage(ctx context.Context, imageFilePath string, buildDir string, mountPath string,
 	includeDefaultMounts bool, readonly bool, readOnlyVerity bool, ignoreOverlays bool,
 	distroHandler DistroHandler,
 ) (*imageconnection.ImageConnection, []fstabEntryPartNum, []verityDeviceMetadata, []string, DistroHandler, error) {
@@ -41,7 +41,7 @@ func connectToExistingImage(ctx context.Context, imageFilePath string, buildDir 
 	imageConnection := imageconnection.NewImageConnection()
 
 	partitionsLayout, verityMetadata, readonlyPartUuids, distroHandler, err := connectToExistingImageHelper(imageConnection,
-		imageFilePath, buildDir, chrootDirName, includeDefaultMounts, readonly, readOnlyVerity, ignoreOverlays,
+		imageFilePath, buildDir, mountPath, includeDefaultMounts, readonly, readOnlyVerity, ignoreOverlays,
 		distroHandler)
 	if err != nil {
 		imageConnection.Close()
@@ -52,7 +52,7 @@ func connectToExistingImage(ctx context.Context, imageFilePath string, buildDir 
 }
 
 func connectToExistingImageHelper(imageConnection *imageconnection.ImageConnection, imageFilePath string,
-	buildDir string, chrootDirName string, includeDefaultMounts bool, readonly bool, readOnlyVerity bool,
+	buildDir string, mountPath string, includeDefaultMounts bool, readonly bool, readOnlyVerity bool,
 	ignoreOverlays bool, distroHandler DistroHandler,
 ) ([]fstabEntryPartNum, []verityDeviceMetadata, []string, DistroHandler, error) {
 	// Connect to image file using loopback device.
@@ -118,9 +118,7 @@ func connectToExistingImageHelper(imageConnection *imageconnection.ImageConnecti
 	imageConnection.AddOwnedDirectories(tempDirectories...)
 
 	// Create chroot environment.
-	imageChrootDir := filepath.Join(buildDir, chrootDirName)
-
-	err = imageConnection.ConnectChroot(imageChrootDir, false, []string(nil), mountPoints, includeDefaultMounts)
+	err = imageConnection.ConnectChroot(mountPath, false, []string(nil), mountPoints, includeDefaultMounts)
 	if err != nil {
 		return nil, nil, nil, nil, err
 	}
@@ -128,7 +126,7 @@ func connectToExistingImageHelper(imageConnection *imageconnection.ImageConnecti
 	return partitionsLayout, verityMetadata, readonlyPartUuids, distroHandler, nil
 }
 
-func reconnectToExistingImage(ctx context.Context, imageFilePath string, buildDir string, chrootDirName string,
+func reconnectToExistingImage(ctx context.Context, imageFilePath string, buildDir string, mountPath string,
 	includeDefaultMounts bool, readonly bool, readOnlyVerity bool, partitionsLayout []fstabEntryPartNum,
 	distroHandler DistroHandler,
 ) (*imageconnection.ImageConnection, []string, error) {
@@ -136,14 +134,14 @@ func reconnectToExistingImage(ctx context.Context, imageFilePath string, buildDi
 	defer span.End()
 
 	imageConnection, readonlyPartUuids, err := reconnectToExistingImageHelper(imageFilePath, buildDir,
-		chrootDirName, includeDefaultMounts, readonly, readOnlyVerity, partitionsLayout, distroHandler)
+		mountPath, includeDefaultMounts, readonly, readOnlyVerity, partitionsLayout, distroHandler)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to connect to OS image file:\n%w", err)
 	}
 	return imageConnection, readonlyPartUuids, nil
 }
 
-func reconnectToExistingImageHelper(imageFilePath string, buildDir string, chrootDirName string,
+func reconnectToExistingImageHelper(imageFilePath string, buildDir string, mountPath string,
 	includeDefaultMounts bool, readonly bool, readOnlyVerity bool, partitionsLayout []fstabEntryPartNum,
 	distroHandler DistroHandler,
 ) (*imageconnection.ImageConnection, []string, error) {
@@ -176,9 +174,7 @@ func reconnectToExistingImageHelper(imageFilePath string, buildDir string, chroo
 	imageConnection.AddOwnedDirectories(tempDirectories...)
 
 	// Create chroot environment.
-	imageChrootDir := filepath.Join(buildDir, chrootDirName)
-
-	err = imageConnection.ConnectChroot(imageChrootDir, false, []string(nil), mountPoints, includeDefaultMounts)
+	err = imageConnection.ConnectChroot(mountPath, false, []string(nil), mountPoints, includeDefaultMounts)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -197,10 +197,12 @@ func createLiveOSFromRawHelper(ctx context.Context, buildDir string, inputArtifa
 		}
 	}()
 
+	imageMountPoint := filepath.Join(buildDir, "readonly-rootfs-mount")
+
 	logger.Log.Debugf("Connecting to raw image (%s)", rawImageFile)
-	rawImageConnection, _, _, _, distroHandler, err := connectToExistingImage(ctx, rawImageFile, isoBuildDir, "readonly-rootfs-mount",
-		false /*includeDefaultMounts*/, false /*readonly*/, false /*readonlyVerity*/, false, /*ignoreOverlays*/
-		distroHandler)
+	rawImageConnection, _, _, _, distroHandler, err := connectToExistingImage(ctx, rawImageFile, isoBuildDir,
+		imageMountPoint, false /*includeDefaultMounts*/, false /*readonly*/, false, /*readonlyVerity*/
+		false /*ignoreOverlays*/, distroHandler)
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -197,7 +197,7 @@ func createLiveOSFromRawHelper(ctx context.Context, buildDir string, inputArtifa
 		}
 	}()
 
-	imageMountPoint := filepath.Join(buildDir, "readonly-rootfs-mount")
+	imageMountPoint := filepath.Join(isoBuildDir, "readonly-rootfs-mount")
 
 	logger.Log.Debugf("Connecting to raw image (%s)", rawImageFile)
 	rawImageConnection, _, _, _, distroHandler, err := connectToExistingImage(ctx, rawImageFile, isoBuildDir,

--- a/toolkit/tools/pkg/imagecustomizerlib/selinuxpolicyoutput.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/selinuxpolicyoutput.go
@@ -63,7 +63,9 @@ func outputSelinuxPolicy(ctx context.Context, outputDir string, buildDir string,
 
 	// Connect to the image with read-only mounts.
 	// Use connectToExistingImage which automatically mounts all partitions based on fstab.
-	imageConnection, _, err := reconnectToExistingImage(ctx, buildImage, buildDir, "selinux-extract",
+	imageMountPoint := filepath.Join(buildDir, "selinux-extract")
+
+	imageConnection, _, err := reconnectToExistingImage(ctx, buildImage, buildDir, imageMountPoint,
 		false /*includeDefaultMounts*/, true /*readonly*/, true /*readOnlyVerity*/, partitionsLayout, distroHandler)
 	if err != nil {
 		return fmt.Errorf("%w:\n%w", ErrSelinuxPolicyImageConnection, err)


### PR DESCRIPTION
When using the tools directory, the image needs to be mounted in the tools directory so that the tools directory chroot has access to the image mounts. But the tools directory should not be used as the build directory. This change fixes this.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
