### PR TITLE
Add preview features flag for --tools-dir.

### DIFF
--- a/docs/imagecustomizer/api/cli/create.md
+++ b/docs/imagecustomizer/api/cli/create.md
@@ -123,6 +123,11 @@ Added in v1.2.
 
 Required.
 
+This is a preview feature.
+Its API and behavior is subject to change.
+You must enable this feature by specifying `tools-dir` in the
+[previewFeatures](../configuration/config.md#previewfeatures-string) API.
+
 Specifies the path to a directory that provides the tools (tdnf/dnf and their
 dependencies) needed to install packages during image creation.
 

--- a/docs/imagecustomizer/api/cli/customize.md
+++ b/docs/imagecustomizer/api/cli/customize.md
@@ -271,6 +271,11 @@ Added in v1.1.
 
 Optional.
 
+This is a preview feature.
+Its API and behavior is subject to change.
+You must enable this feature by specifying `tools-dir` in the
+[previewFeatures](../configuration/config.md#previewfeatures-string) API.
+
 Specifies the path to a directory that provides an external package manager (tdnf/dnf).
 Required when performing package operations on images that do not include a package
 manager in the base image.

--- a/docs/imagecustomizer/api/configuration/config.md
+++ b/docs/imagecustomizer/api/configuration/config.md
@@ -158,6 +158,11 @@ Supported options:
 
   Added in v1.5.
 
+- `tools-dir`: Enables support for the
+  [--tools-dir](../cli/customize.md#--tools-dirdirectory-path) API.
+
+  Added in v1.5.
+
 ## output [[output](./output.md)]
 
 Specifies the configuration for the output image and artifacts.

--- a/docs/imagecustomizer/how-to/create-image.md
+++ b/docs/imagecustomizer/how-to/create-image.md
@@ -31,6 +31,7 @@ As such, the example configuration files below must specify `create` in the [pre
     ```yaml
     previewFeatures:
     - create
+    - tools-dir
 
     storage:
       disks:
@@ -104,6 +105,7 @@ As such, the example configuration files below must specify `create` in the [pre
     ```yaml
     previewFeatures:
     - create
+    - tools-dir
     - preview-distro-version
 
     storage:

--- a/toolkit/tools/imagecustomizerapi/previewfeaturetype.go
+++ b/toolkit/tools/imagecustomizerapi/previewfeaturetype.go
@@ -47,6 +47,9 @@ const (
 
 	// PreviewFeatureUnsupportedDistroVersion allows distro versions that are not supported yet.
 	PreviewFeatureUnsupportedDistroVersion PreviewFeature = "unsupported-distro-version"
+
+	// PreviewFeatureToolsDir enables support for specifying a tools directory.
+	PreviewFeatureToolsDir PreviewFeature = "tools-dir"
 )
 
 func (pf PreviewFeature) IsValid() error {
@@ -54,7 +57,7 @@ func (pf PreviewFeature) IsValid() error {
 	case PreviewFeatureUki, PreviewFeatureOutputArtifacts, PreviewFeatureInjectFiles, PreviewFeatureReinitializeVerity,
 		PreviewFeaturePackageSnapshotTime, PreviewFeatureKdumpBootFiles, PreviewFeatureDistroVersion,
 		PreviewFeatureBaseConfigs, PreviewFeatureInputImageOci, PreviewFeatureOutputSelinuxPolicy, PreviewFeatureBtrfs,
-		PreviewFeatureCreate, PreviewFeatureUnsupportedDistroVersion:
+		PreviewFeatureCreate, PreviewFeatureUnsupportedDistroVersion, PreviewFeatureToolsDir:
 		return nil
 	default:
 		return fmt.Errorf("invalid preview feature: %s", pf)

--- a/toolkit/tools/pkg/imagecustomizerlib/createimagevalidation.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/createimagevalidation.go
@@ -97,6 +97,7 @@ func validateCreateImageConfig(ctx context.Context, baseConfigPath string, confi
 			OutputImageFormat:   options.OutputImageFormat,
 			PackageSnapshotTime: options.PackageSnapshotTime,
 			BuildDir:            options.BuildDir,
+			ToolsDir:            options.ToolsDir,
 			PreviewFeatures:     options.PreviewFeatures,
 		})
 	if err != nil {

--- a/toolkit/tools/pkg/imagecustomizerlib/createimagevalidation.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/createimagevalidation.go
@@ -70,11 +70,6 @@ func validateCreateImageSupportedOsFields(osConfig *imagecustomizerapi.OS) error
 func validateCreateImageConfig(ctx context.Context, baseConfigPath string, config *imagecustomizerapi.Config,
 	options ImageCreateOptions,
 ) (*ResolvedConfig, error) {
-	if !slices.Contains(config.PreviewFeatures, imagecustomizerapi.PreviewFeatureCreate) {
-		return nil, fmt.Errorf(
-			"the 'create' feature is currently in preview; please add 'create' to 'previewFeatures' to enable it")
-	}
-
 	err := validateCreateImageSupportedFields(config)
 	if err != nil {
 		return nil, fmt.Errorf("invalid config file (%s):\n%w", baseConfigPath, err)
@@ -102,6 +97,11 @@ func validateCreateImageConfig(ctx context.Context, baseConfigPath string, confi
 		})
 	if err != nil {
 		return nil, err
+	}
+
+	if !slices.Contains(rc.PreviewFeatures, imagecustomizerapi.PreviewFeatureCreate) {
+		return nil, fmt.Errorf(
+			"the 'create' feature is currently in preview; please add 'create' to 'previewFeatures' to enable it")
 	}
 
 	if len(config.OS.Packages.Install) == 0 {

--- a/toolkit/tools/pkg/imagecustomizerlib/createimagevalidation_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/createimagevalidation_test.go
@@ -240,6 +240,10 @@ func TestValidateCreateImageConfig_InvalidFieldsVerityConfig(t *testing.T) {
 		RpmsSources:       []string{testDir}, // Use the test directory as a dummy RPM source
 		OutputImageFormat: "vhdx",
 		BuildDir:          "./",
+		PreviewFeatures: []imagecustomizerapi.PreviewFeature{
+			imagecustomizerapi.PreviewFeatureCreate,
+			imagecustomizerapi.PreviewFeatureToolsDir,
+		},
 	}
 
 	_, err = validateCreateImageConfig(t.Context(), testDir, &config, options)
@@ -257,6 +261,10 @@ func TestValidateCreateImageConfig_InvalidFieldsOverlaysConfig(t *testing.T) {
 		RpmsSources:       []string{testDir}, // Use the test directory as a dummy RPM source
 		OutputImageFormat: "vhdx",
 		BuildDir:          "./",
+		PreviewFeatures: []imagecustomizerapi.PreviewFeature{
+			imagecustomizerapi.PreviewFeatureCreate,
+			imagecustomizerapi.PreviewFeatureToolsDir,
+		},
 	}
 
 	_, err = validateCreateImageConfig(t.Context(), testDir, &config, options)

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
@@ -44,6 +44,9 @@ func testCustomizeImageVerityUsrUkiHelper(t *testing.T, baseImageInfo testBaseIm
 	outImageFilePath := filepath.Join(testTempDir, "image.raw")
 	configFile := filepath.Join(testDir, verityUsrUkiConfigFile(t, baseImageInfo))
 
+	previewFeatures := []imagecustomizerapi.PreviewFeature{imagecustomizerapi.PreviewFeatureToolsDir}
+	previewFeatures = append(previewFeatures, baseImageInfo.PreviewFeatures...)
+
 	// --tools-dir exercises the toolsChroot path in isPackageInstalled used by UKI 'create' validation.
 	err = CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
 		BuildDir:             buildDir,
@@ -51,7 +54,7 @@ func testCustomizeImageVerityUsrUkiHelper(t *testing.T, baseImageInfo testBaseIm
 		OutputImageFile:      outImageFilePath,
 		OutputImageFormat:    imagecustomizerapi.ImageFormatType("raw"),
 		UseBaseImageRpmRepos: true,
-		PreviewFeatures:      baseImageInfo.PreviewFeatures,
+		PreviewFeatures:      previewFeatures,
 		SetFilesContext:      *setfilesContext,
 		ToolsDir:             toolsDir,
 	})

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_test.go
@@ -123,6 +123,7 @@ func TestAclValidateConfigPackageOpsRequireToolsDir(t *testing.T) {
 	rc := &ResolvedConfig{
 		PreviewFeatures: []imagecustomizerapi.PreviewFeature{
 			imagecustomizerapi.PreviewFeatureDistroVersion,
+			imagecustomizerapi.PreviewFeatureToolsDir,
 		},
 		ConfigChain: []*ConfigWithBasePath{
 			{

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -41,6 +41,7 @@ var (
 	ErrVerityPreviewFeatureRequired        = NewImageCustomizerError("Validation:VerityPreviewFeatureRequired", fmt.Sprintf("preview feature '%s' required to customize verity enabled base image", imagecustomizerapi.PreviewFeatureReinitializeVerity))
 	ErrPreviewDistroVersionFeatureRequired = NewImageCustomizerError("Validation:PreviewDistroVersionFeatureRequired", fmt.Sprintf("preview feature '%s' required to customize a preview distro or distro version base image", imagecustomizerapi.PreviewFeatureDistroVersion))
 	ErrInputImageOciPreviewRequired        = NewImageCustomizerError("Validation:InputImageOciPreviewRequired", fmt.Sprintf("preview feature '%s' required to specify OCI input image", imagecustomizerapi.PreviewFeatureInputImageOci))
+	ErrToolsDirPreviewRequired             = NewImageCustomizerError("Validation:ToolsDirPreviewRequired", fmt.Sprintf("preview feature '%s' required to specify tools directory", imagecustomizerapi.PreviewFeatureToolsDir))
 	ErrConvertUnsupportedInputFormat       = NewImageCustomizerError("Validation:ConvertUnsupportedInputFormat", "input image format is not supported")
 	ErrConvertBuildDirRequired             = NewImageCustomizerError("Validation:ConvertBuildDirRequired", "build directory is required for cosi and baremetal-image output formats")
 

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizeroptions.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizeroptions.go
@@ -80,6 +80,12 @@ func (o *ImageCustomizerOptions) verifyPreviewFeatures(previewFeatures []imagecu
 		}
 	}
 
+	if o.ToolsDir != "" {
+		if !slices.Contains(previewFeatures, imagecustomizerapi.PreviewFeatureToolsDir) {
+			return ErrToolsDirPreviewRequired
+		}
+	}
+
 	return nil
 }
 

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizeroptions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizeroptions_test.go
@@ -4,6 +4,8 @@
 package imagecustomizerlib
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
@@ -62,4 +64,28 @@ func TestOptionsIsValid_CosiCompressionLevel_Fail(t *testing.T) {
 		err := options.IsValid()
 		assert.ErrorIs(t, err, imagecustomizerapi.ErrInvalidCosiCompressionLevelArg, "level %d should be invalid", level)
 	}
+}
+
+func TestCustomizeImageToolsDirMissingPreviewFlag(t *testing.T) {
+	baseImage, baseImageInfo := checkSkipForCustomizeDefaultAzureLinuxImage(t)
+
+	testTmpDir := filepath.Join(tmpDir, "TestCustomizeImageToolsDirMissingPreviewFlag")
+	defer os.RemoveAll(testTmpDir)
+
+	buildDir := filepath.Join(testTmpDir, "build")
+	configFile := filepath.Join(testDir, "nochange-config.yaml")
+	outImageFilePath := filepath.Join(testTmpDir, "out/image.vhd")
+
+	// Customize image to vhd.
+	err := CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
+		BuildDir:             buildDir,
+		InputImageFile:       baseImage,
+		OutputImageFile:      outImageFilePath,
+		OutputImageFormat:    "raw",
+		UseBaseImageRpmRepos: true,
+		PreviewFeatures:      baseImageInfo.PreviewFeatures,
+		SetFilesContext:      *setfilesContext,
+		ToolsDir:             buildDir,
+	})
+	assert.ErrorIs(t, err, ErrToolsDirPreviewRequired)
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/create-azl4-amd64.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/create-azl4-amd64.yaml
@@ -1,6 +1,7 @@
 previewFeatures:
 - create
 - preview-distro-version
+- tools-dir
 
 storage:
   disks:

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/create-azl4-arm64.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/create-azl4-arm64.yaml
@@ -2,6 +2,7 @@
 previewFeatures:
 - create
 - preview-distro-version
+- tools-dir
 
 storage:
   disks:

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/create-azl4-btrfs-amd64.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/create-azl4-btrfs-amd64.yaml
@@ -3,6 +3,7 @@ previewFeatures:
 - create
 - preview-distro-version
 - btrfs
+- tools-dir
 
 storage:
   disks:

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/create-azl4-btrfs-arm64.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/create-azl4-btrfs-arm64.yaml
@@ -3,6 +3,7 @@ previewFeatures:
 - create
 - preview-distro-version
 - btrfs
+- tools-dir
 
 storage:
   disks:

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/create-fedora-amd64.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/create-fedora-amd64.yaml
@@ -2,6 +2,7 @@
 previewFeatures:
 - create
 - preview-distro-version
+- tools-dir
 
 storage:
   disks:

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/create-fedora-arm64.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/create-fedora-arm64.yaml
@@ -2,6 +2,7 @@
 previewFeatures:
 - create
 - preview-distro-version
+- tools-dir
 
 storage:
   disks:

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/create-fedora-btrfs-amd64.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/create-fedora-btrfs-amd64.yaml
@@ -3,6 +3,7 @@ previewFeatures:
 - create
 - preview-distro-version
 - btrfs
+- tools-dir
 
 storage:
   disks:

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/create-fedora-btrfs-arm64.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/create-fedora-btrfs-arm64.yaml
@@ -3,6 +3,7 @@ previewFeatures:
 - create
 - preview-distro-version
 - btrfs
+- tools-dir
 
 storage:
   disks:

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/create-minimal-os-btrfs.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/create-minimal-os-btrfs.yaml
@@ -1,6 +1,7 @@
 previewFeatures:
 - create
 - btrfs
+- tools-dir
 
 storage:
   disks:

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/create-minimal-os.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/create-minimal-os.yaml
@@ -1,5 +1,6 @@
 previewFeatures:
 - create
+- tools-dir
 
 storage:
   disks:

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/overlays-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/overlays-config.yaml
@@ -1,6 +1,3 @@
-previewFeatures:
-- create
-
 storage:
   disks:
   - partitionTableType: gpt

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-config.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-config.yaml
@@ -1,6 +1,3 @@
-previewFeatures:
-- create
-
 storage:
   bootType: efi
   disks:


### PR DESCRIPTION
The tools directory needs to be used in other places, including COSI generation, LiveOS generation, user/group modification, and SELinux labelling. So, place the API behind a preview feature flag so we can make behavior changes in the future, without it being considered a breaking change.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
