### PR TITLE
Fix name of `resetType` in error messages.

### DIFF
--- a/docs/imagecustomizer/api/configuration/config.md
+++ b/docs/imagecustomizer/api/configuration/config.md
@@ -64,7 +64,7 @@ Supported options:
 - `uki`: Enables the Unified Kernel Image (UKI) feature.
 
   When this option is specified, the `os.uki` configuration becomes available. A
-  valid `os.bootloader.reset` value of `hard-reset` is required when `os.uki` is
+  valid `os.bootloader.resetType` value of `hard-reset` is required when `os.uki` is
   configured.
 
   Added in v0.8.

--- a/toolkit/tools/imagecustomizerapi/config.go
+++ b/toolkit/tools/imagecustomizerapi/config.go
@@ -103,11 +103,11 @@ func (c *Config) IsValid() (err error) {
 	}
 
 	if c.CustomizePartitions() && !hasResetBootLoader {
-		return fmt.Errorf("'os.bootloader.reset' must be specified if 'storage.disks' is specified")
+		return fmt.Errorf("'os.bootloader.resetType' must be specified if 'storage.disks' is specified")
 	}
 
 	if hasResetPartitionsUuids && !hasResetBootLoader {
-		return fmt.Errorf("'os.bootloader.reset' must be specified if 'storage.resetPartitionsUuidsType' is specified")
+		return fmt.Errorf("'os.bootloader.resetType' must be specified if 'storage.resetPartitionsUuidsType' is specified")
 	}
 
 	err = c.Output.IsValid()

--- a/toolkit/tools/imagecustomizerapi/config_test.go
+++ b/toolkit/tools/imagecustomizerapi/config_test.go
@@ -153,7 +153,7 @@ func TestConfigIsValidMissingBootLoaderReset(t *testing.T) {
 
 	err := config.IsValid()
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "'os.bootloader.reset' must be specified if 'storage.disks' is specified")
+	assert.ErrorContains(t, err, "'os.bootloader.resetType' must be specified if 'storage.disks' is specified")
 }
 
 func TestConfigIsValidWithPreviewFeaturesAndUki(t *testing.T) {
@@ -220,7 +220,7 @@ func TestConfigIsValidResetUuidsMissingBootLoaderReset(t *testing.T) {
 
 	err := config.IsValid()
 	assert.Error(t, err)
-	assert.ErrorContains(t, err, "'os.bootloader.reset' must be specified if 'storage.resetPartitionsUuidsType' is specified")
+	assert.ErrorContains(t, err, "'os.bootloader.resetType' must be specified if 'storage.resetPartitionsUuidsType' is specified")
 }
 
 func TestConfigIsValidMultipleDisks(t *testing.T) {


### PR DESCRIPTION
Some of the error messages are still using the old name for the `resetType` API.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
