### PR TITLE
Ignore fewer errors in DistroHandler.IsPackageInstalled.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_deb.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_deb.go
@@ -5,8 +5,10 @@ package imagecustomizerlib
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -327,15 +329,23 @@ func cleanDebCache(ctx context.Context, imageChroot *safechroot.Chroot) error {
 }
 
 // isPackageInstalledDeb checks if a package is installed using dpkg-query.
-func isPackageInstalledDeb(imageChroot safechroot.ChrootInterface, packageName string) bool {
+func isPackageInstalledDeb(imageChroot safechroot.ChrootInterface, packageName string) (bool, error) {
 	err := shell.NewExecBuilder("dpkg-query", "-W", "-f='${Status}'", packageName).
 		LogLevel(logrus.TraceLevel, logrus.DebugLevel).
 		Chroot(imageChroot.ChrootDir()).
 		Execute()
 	if err != nil {
-		return false
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			// The command ran and failed.
+			return false, nil
+		}
+
+		// The command failed to start.
+		return false, err
 	}
-	return true
+
+	return true, nil
 }
 
 // getAllPackagesFromChrootDeb retrieves all installed packages from a DEB-based system.

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
@@ -128,7 +128,7 @@ func (d *aclDistroHandler) IsPackageInstalled(imageChroot safechroot.ChrootInter
 	if toolsChroot == nil {
 		return false, fmt.Errorf("ACL cannot query rpmdb for package (%q) without --tools-dir", packageName)
 	}
-	return d.packageManager.isPackageInstalled(imageChroot, toolsChroot, packageName), nil
+	return d.packageManager.isPackageInstalled(imageChroot, toolsChroot, packageName)
 }
 
 func (d *aclDistroHandler) GetPackageInformation(imageChroot *safechroot.Chroot, packageName string,

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux.go
@@ -82,7 +82,7 @@ func (d *azureLinuxDistroHandler) ManagePackages(ctx context.Context, buildDir s
 func (d *azureLinuxDistroHandler) IsPackageInstalled(imageChroot safechroot.ChrootInterface,
 	toolsChroot *safechroot.Chroot, packageName string,
 ) (bool, error) {
-	return d.packageManager.isPackageInstalled(imageChroot, toolsChroot, packageName), nil
+	return d.packageManager.isPackageInstalled(imageChroot, toolsChroot, packageName)
 }
 
 func (d *azureLinuxDistroHandler) GetPackageInformation(imageChroot *safechroot.Chroot, packageName string,

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux4.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux4.go
@@ -99,7 +99,7 @@ func (d *azureLinux4DistroHandler) ManagePackages(ctx context.Context, buildDir 
 func (d *azureLinux4DistroHandler) IsPackageInstalled(imageChroot safechroot.ChrootInterface,
 	toolsChroot *safechroot.Chroot, packageName string,
 ) (bool, error) {
-	return d.packageManager.isPackageInstalled(imageChroot, toolsChroot, packageName), nil
+	return d.packageManager.isPackageInstalled(imageChroot, toolsChroot, packageName)
 }
 
 func (d *azureLinux4DistroHandler) GetPackageInformation(imageChroot *safechroot.Chroot, packageName string,

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
@@ -141,7 +141,7 @@ func (d *fedoraDistroHandler) ManagePackages(ctx context.Context, buildDir strin
 func (d *fedoraDistroHandler) IsPackageInstalled(imageChroot safechroot.ChrootInterface,
 	toolsChroot *safechroot.Chroot, packageName string,
 ) (bool, error) {
-	return d.packageManager.isPackageInstalled(imageChroot, toolsChroot, packageName), nil
+	return d.packageManager.isPackageInstalled(imageChroot, toolsChroot, packageName)
 }
 
 func (d *fedoraDistroHandler) GetPackageInformation(imageChroot *safechroot.Chroot, packageName string,

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_ubuntu.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_ubuntu.go
@@ -111,7 +111,7 @@ func (d *ubuntuDistroHandler) ManagePackages(ctx context.Context, buildDir strin
 func (d *ubuntuDistroHandler) IsPackageInstalled(imageChroot safechroot.ChrootInterface,
 	toolsChroot *safechroot.Chroot, packageName string,
 ) (bool, error) {
-	return isPackageInstalledDeb(imageChroot, packageName), nil
+	return isPackageInstalledDeb(imageChroot, packageName)
 }
 
 func (d *ubuntuDistroHandler) GetPackageInformation(imageChroot *safechroot.Chroot, packageName string,

--- a/toolkit/tools/pkg/imagecustomizerlib/packagemanager_dnf.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/packagemanager_dnf.go
@@ -4,7 +4,9 @@
 package imagecustomizerlib
 
 import (
+	"errors"
 	"fmt"
+	"os/exec"
 	"regexp"
 	"strings"
 
@@ -183,7 +185,7 @@ func (pm *dnfPackageManager) createOutputCallback() func(string) {
 
 func (pm *dnfPackageManager) isPackageInstalled(imageChroot safechroot.ChrootInterface,
 	toolsChroot *safechroot.Chroot, packageName string,
-) bool {
+) (bool, error) {
 	// Use `rpm -q` rather than `dnf info --installed` here: it queries the local rpm database directly without
 	// opening any log files for writing, so it works on read-only chroots and avoids the security concerns of
 	// pointing dnf's logdir at a fixed, predictable path inside the chroot. `rpm` is guaranteed to be present in any
@@ -202,9 +204,17 @@ func (pm *dnfPackageManager) isPackageInstalled(imageChroot safechroot.ChrootInt
 		Chroot(chroot.ChrootDir()).
 		Execute()
 	if err != nil {
-		return false
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			// The command ran and failed.
+			return false, nil
+		}
+
+		// The command failed to start.
+		return false, err
 	}
-	return true
+
+	return true, nil
 }
 
 func (pm *dnfPackageManager) getPackageInformation(imageChroot *safechroot.Chroot, packageName string,

--- a/toolkit/tools/pkg/imagecustomizerlib/packagemanager_rpm.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/packagemanager_rpm.go
@@ -25,7 +25,7 @@ type rpmPackageManagerHandler interface {
 	// isPackageInstalled reports whether packageName is installed. When toolsChroot is non-nil, the query is issued
 	// from inside toolsChroot against installroot=/_imageroot (the bind-mounted image root), so it works on images
 	// that ship no in-image package manager.
-	isPackageInstalled(imageChroot safechroot.ChrootInterface, toolsChroot *safechroot.Chroot, packageName string) bool
+	isPackageInstalled(imageChroot safechroot.ChrootInterface, toolsChroot *safechroot.Chroot, packageName string) (bool, error)
 
 	// getPackageInformation queries the package database for packageName and returns its parsed version,
 	// release, and distro fields.

--- a/toolkit/tools/pkg/imagecustomizerlib/packagemanager_tdnf.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/packagemanager_tdnf.go
@@ -4,7 +4,9 @@
 package imagecustomizerlib
 
 import (
+	"errors"
 	"fmt"
+	"os/exec"
 	"regexp"
 	"slices"
 	"strings"
@@ -108,7 +110,7 @@ func (pm *tdnfPackageManager) createOutputCallback() func(string) {
 
 func (pm *tdnfPackageManager) isPackageInstalled(imageChroot safechroot.ChrootInterface,
 	toolsChroot *safechroot.Chroot, packageName string,
-) bool {
+) (bool, error) {
 	args := []string{"info", packageName, "--repo", "@system"}
 	chroot := imageChroot
 	if toolsChroot != nil {
@@ -126,9 +128,17 @@ func (pm *tdnfPackageManager) isPackageInstalled(imageChroot safechroot.ChrootIn
 		Chroot(chroot.ChrootDir()).
 		Execute()
 	if err != nil {
-		return false
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			// The command ran and failed.
+			return false, nil
+		}
+
+		// The command failed to start.
+		return false, err
 	}
-	return true
+
+	return true, nil
 }
 
 func (pm *tdnfPackageManager) getPackageInformation(imageChroot *safechroot.Chroot, packageName string,


### PR DESCRIPTION
For the `DistroHandler.IsPackageInstalled` implementations, don't ignore the error where the package query command fails to start. For example, when tdnf/dnf/dpkg-query is not installed.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
