### PR TITLE
Move sub-process execution log.

### DIFF
--- a/toolkit/tools/internal/shell/execbuilder.go
+++ b/toolkit/tools/internal/shell/execbuilder.go
@@ -169,6 +169,8 @@ func (b ExecBuilder) ExecuteCaptureOutput() (string, string, error) {
 }
 
 func (b ExecBuilder) executeHelper(captureOutput bool) (string, string, error) {
+	logger.Log.Debugf("Executing: %v", append([]string{b.command}, b.args...))
+
 	stdoutLinesChans := []chan string(nil)
 	stdErrLinesChans := []chan string(nil)
 

--- a/toolkit/tools/internal/shell/shell.go
+++ b/toolkit/tools/internal/shell/shell.go
@@ -165,8 +165,6 @@ func LookPathChroot(command string, rootDir string) (string, error) {
 }
 
 func trackAndStartProcess(cmd *exec.Cmd, capabilities []uintptr, selinuxContext string) (err error) {
-	logger.Log.Debugf("Executing: %v", cmd.Args)
-
 	if cmd.Env == nil && len(currentEnv) > 0 {
 		cmd.Env = currentEnv
 	}


### PR DESCRIPTION
Move the sub-process execution log to top so that the log is seen even if there are process start failures.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
