### PR TITLE
Align Fedora LiveOS ISO bootloader paths with the efi/boot directory

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
@@ -34,9 +34,8 @@ const (
 	shimPackageFedoraAmd64    = "shim-x64"
 	shimPackageFedoraArm64    = "shim-aa64"
 
-	isoBootloaderDirFedora = "/EFI/BOOT"
-	bootx64BinaryFedora    = "BOOTX64.EFI"
-	bootAA64BinaryFedora   = "BOOTAA64.EFI"
+	bootx64BinaryFedora  = "BOOTX64.EFI"
+	bootAA64BinaryFedora = "BOOTAA64.EFI"
 
 	grubToolsPackageFedora     = "grub2-tools"
 	grubPcModulesPackageFedora = "grub2-pc-modules"
@@ -56,8 +55,8 @@ var bootloaderFilesConfigFedora = map[string]BootFilesArchConfig{
 		osEspBootBinaryPath:         osEspBootloaderDir + "/" + bootx64BinaryFedora,
 		osEspGrubBinaryPath:         osEspBootloaderDir + "/" + grubx64Binary,
 		osEspGrubNoPrefixBinaryPath: "",
-		isoBootBinaryPath:           isoBootloaderDirFedora + "/" + bootx64BinaryFedora,
-		isoGrubBinaryPath:           isoBootloaderDirFedora + "/" + grubx64Binary,
+		isoBootBinaryPath:           isoBootloaderDir + "/" + bootx64BinaryFedora,
+		isoGrubBinaryPath:           isoBootloaderDir + "/" + grubx64Binary,
 		ukiEfiStubBinary:            ukiEfiStubx64Binary,
 		ukiEfiStubBinaryPath:        ukiEfiStubDir + "/" + ukiEfiStubx64Binary,
 		ukiAddonStubBinary:          ukiAddonStubx64Binary,
@@ -72,8 +71,8 @@ var bootloaderFilesConfigFedora = map[string]BootFilesArchConfig{
 		osEspBootBinaryPath:         osEspBootloaderDir + "/" + bootAA64BinaryFedora,
 		osEspGrubBinaryPath:         osEspBootloaderDir + "/" + grubAA64Binary,
 		osEspGrubNoPrefixBinaryPath: "",
-		isoBootBinaryPath:           isoBootloaderDirFedora + "/" + bootAA64BinaryFedora,
-		isoGrubBinaryPath:           isoBootloaderDirFedora + "/" + grubAA64Binary,
+		isoBootBinaryPath:           isoBootloaderDir + "/" + bootAA64BinaryFedora,
+		isoGrubBinaryPath:           isoBootloaderDir + "/" + grubAA64Binary,
 		ukiEfiStubBinary:            ukiEfiStubAA64Binary,
 		ukiEfiStubBinaryPath:        ukiEfiStubDir + "/" + ukiEfiStubAA64Binary,
 		ukiAddonStubBinary:          ukiAddonStubAA64Binary,


### PR DESCRIPTION
Fedora LiveOS ISO bootloader paths now point at the lowercase `efi/boot` directory, so reading a Fedora LiveOS ISO back in can actually find its boot and grub EFI files.

`bootloaderFilesConfigFedora` built `isoBootBinaryPath` / `isoGrubBinaryPath` from an uppercase `isoBootloaderDirFedora` (`/EFI/BOOT`). The ISO generator's Rufus workaround stages those binaries into the lowercase `efi/boot` directory instead. On the case-sensitive ISO9660/Rock Ridge filesystem the two never match, so an ISO-to-ISO repackage fails with "failed to find the boot efi file".

This drops `isoBootloaderDirFedora` and derives the ISO paths from the shared `isoBootloaderDir` constant. The same one the Azure Linux config uses and the directory the generator actually writes to.

| Field | Before | After |
|-------|--------|-------|
| `isoBootBinaryPath` | `/EFI/BOOT/BOOTX64.EFI` | `/efi/boot/BOOTX64.EFI` |
| `isoGrubBinaryPath` | `/EFI/BOOT/grubx64.efi` | `/efi/boot/grubx64.efi` |

The uppercase `BOOTX64.EFI` / `BOOTAA64.EFI` file names are unchanged.

---

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [x] Code conforms to style guidelines