### PR TITLE
Preserve artifact subpaths when staging LiveOS files

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoartifactstore.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoartifactstore.go
@@ -150,6 +150,14 @@ func storeIfKernelSpecificFile(filesStore *IsoFilesStore, targetPath string, ker
 		return scheduleAdditionalFile
 	}
 
+	// Only files that live directly under boot/ are treated as kernel-specific. A file in a subdirectory of boot/
+	// (e.g. a Boot Loader Specification entry under boot/loader/entries) merely happens to contain the kernel version
+	// in its name. Leave it to be staged as an additional file so its subpath is preserved rather than flattened into
+	// boot/.
+	if filepath.Dir(targetPath) != filepath.Join(filesStore.artifactsDir, "boot") {
+		return scheduleAdditionalFile
+	}
+
 	if strings.Contains(baseFileName, "kdump.img") {
 		// Ensure we have an entry in the map for it
 		kdumpBootFiles, exists := filesStore.kdumpBootFiles[kernelVersion]

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoartifactstore_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoartifactstore_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerlib
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestIsoFilesStore(artifactsDir string) *IsoFilesStore {
+	return &IsoFilesStore{
+		artifactsDir:    artifactsDir,
+		additionalFiles: make(map[string]string),
+		kernelBootFiles: make(map[string]*KernelBootFiles),
+		kdumpBootFiles:  make(map[string]*KdumpBootFiles),
+	}
+}
+
+// Files directly under boot/ that carry the kernel version are captured as kernel-specific (the kernel binary and its
+// companion config/System.map/symvers files), so they are not scheduled as additional files.
+func TestStoreIfKernelSpecificFileCapturesBootFiles(t *testing.T) {
+	const kernelVersion = "6.18.5-1.azl4.x86_64"
+	artifactsDir := t.TempDir()
+	bootDir := filepath.Join(artifactsDir, "boot")
+	filesStore := newTestIsoFilesStore(artifactsDir)
+
+	vmlinuzPath := filepath.Join(bootDir, vmLinuzPrefix+kernelVersion)
+	scheduleAdditional := storeIfKernelSpecificFile(filesStore, vmlinuzPath, []string{kernelVersion})
+
+	assert.False(t, scheduleAdditional)
+	if assert.Contains(t, filesStore.kernelBootFiles, kernelVersion) {
+		assert.Equal(t, vmlinuzPath, filesStore.kernelBootFiles[kernelVersion].vmlinuzPath)
+	}
+
+	configPath := filepath.Join(bootDir, "config-"+kernelVersion)
+	scheduleAdditional = storeIfKernelSpecificFile(filesStore, configPath, []string{kernelVersion})
+
+	assert.False(t, scheduleAdditional)
+	if assert.Contains(t, filesStore.kernelBootFiles, kernelVersion) {
+		assert.Contains(t, filesStore.kernelBootFiles[kernelVersion].otherFiles, configPath)
+	}
+}
+
+// A Boot Loader Specification entry lives under boot/loader/entries rather than directly under boot/, even though its
+// name contains the kernel version. It must not be captured as a kernel file; it stays an additional file so its
+// subpath is preserved when staged, instead of being flattened into boot/.
+func TestStoreIfKernelSpecificFileLeavesBlsEntriesAsAdditionalFiles(t *testing.T) {
+	const kernelVersion = "6.18.5-1.azl4.x86_64"
+	artifactsDir := t.TempDir()
+	filesStore := newTestIsoFilesStore(artifactsDir)
+
+	blsEntryPath := filepath.Join(artifactsDir, "boot", "loader", "entries", "abc123-"+kernelVersion+".conf")
+	scheduleAdditional := storeIfKernelSpecificFile(filesStore, blsEntryPath, []string{kernelVersion})
+
+	assert.True(t, scheduleAdditional)
+	assert.NotContains(t, filesStore.kernelBootFiles, kernelVersion)
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoimages.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoimages.go
@@ -278,10 +278,16 @@ func stageLiveOSFiles(initramfsType imagecustomizerapi.InitramfsImageType, outpu
 			})
 
 		for _, otherKernelFile := range kernelFiles.otherFiles {
+			// Preserve each file's path relative to the artifacts tree so that files in subdirectories (e.g. the
+			// BLS entries under boot/loader/entries on Azure Linux 4.0) are not flattened into boot/.
+			relPath, err := filepath.Rel(filesStore.artifactsDir, otherKernelFile)
+			if err != nil {
+				return fmt.Errorf("failed to determine the relative path of (%s):\n%w", otherKernelFile, err)
+			}
 			artifactsToLiveOSMap = append(artifactsToLiveOSMap,
 				StageFile{
 					sourcePath:    otherKernelFile,
-					targetRelPath: "boot",
+					targetRelPath: filepath.Dir(relPath),
 				})
 		}
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoimages.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoimages.go
@@ -278,16 +278,10 @@ func stageLiveOSFiles(initramfsType imagecustomizerapi.InitramfsImageType, outpu
 			})
 
 		for _, otherKernelFile := range kernelFiles.otherFiles {
-			// Preserve each file's path relative to the artifacts tree so that files in subdirectories (e.g. the
-			// BLS entries under boot/loader/entries on Azure Linux 4.0) are not flattened into boot/.
-			relPath, err := filepath.Rel(filesStore.artifactsDir, otherKernelFile)
-			if err != nil {
-				return fmt.Errorf("failed to determine the relative path of (%s):\n%w", otherKernelFile, err)
-			}
 			artifactsToLiveOSMap = append(artifactsToLiveOSMap,
 				StageFile{
 					sourcePath:    otherKernelFile,
-					targetRelPath: filepath.Dir(relPath),
+					targetRelPath: "boot",
 				})
 		}
 	}


### PR DESCRIPTION
LiveOS staging copied every one of a kernel's non-kernel boot files straight into `boot/`, discarding any subdirectory the file originally lived in.

The root cause is in `storeIfKernelSpecificFile`. It classified any file whose name contains the kernel version as a kernel file, including Boot Loader Specification entries under `boot/loader/entries`, whose names embed the kernel version. Those entries were then staged flat under `boot/`. This change only treats a file as kernel-specific when it lives directly under `boot/`. A versioned file in a subdirectory of `boot/` stays an additional file, and additional-file staging already preserves each file's subpath.

This is behavior-preserving for the currently supported distros. Their versioned boot files (`config-<ver>`, `System.map-<ver>`, `symvers-<ver>`) already live directly in `boot/`, so they are still captured as kernel files. It is groundwork for Boot Loader Specification distros, whose per-kernel entries live under `boot/loader/entries` and must keep that subpath on the LiveOS media.

### **Checklist**
- [x] Tests added/updated
- [ ] Documentation updated (if needed)
- [x] Code conforms to style guidelines