### PR TITLE
Remove shim 16.1 fix note from Azure Linux 4.0 test configs

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
@@ -965,7 +965,6 @@ func TestCustomizeImageLiveOSIsoNoGrubEfi(t *testing.T) {
 		// is not an option because shim is needed for the secure boot chain
 		// (UEFI -> shim -> systemd-boot -> kernel) and its EFI binaries on the ESP
 		// are extracted as build artifacts. Use rpm --nodeps to bypass this.
-		// Fixed in shim 16.1+ (Fedora 44+) which drops the hard grub2 dep.
 		config.Scripts = imagecustomizerapi.Scripts{
 			PostCustomization: []imagecustomizerapi.Script{
 				{Content: "rpm -e --nodeps " + grubPackageName},

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/artifacts-output-amd64-azl4.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/artifacts-output-amd64-azl4.yaml
@@ -68,5 +68,4 @@ scripts:
       # is not an option because shim is needed for the secure boot chain
       # (UEFI -> shim -> systemd-boot -> kernel) and its EFI binaries on the ESP
       # are extracted as build artifacts. Use rpm --nodeps to bypass this.
-      # Fixed in shim 16.1+ (Fedora 44+) which drops the hard grub2 dep.
       rpm -e --nodeps grub2-efi-x64

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/artifacts-output-arm64-azl4.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/artifacts-output-arm64-azl4.yaml
@@ -68,5 +68,4 @@ scripts:
       # is not an option because shim is needed for the secure boot chain
       # (UEFI -> shim -> systemd-boot -> kernel) and its EFI binaries on the ESP
       # are extracted as build artifacts. Use rpm --nodeps to bypass this.
-      # Fixed in shim 16.1+ (Fedora 44+) which drops the hard grub2 dep.
       rpm -e --nodeps grub2-efi-aa64

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/artifacts-output-verity-amd64-azl4.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/artifacts-output-verity-amd64-azl4.yaml
@@ -90,5 +90,4 @@ scripts:
       # is not an option because shim is needed for the secure boot chain
       # (UEFI -> shim -> systemd-boot -> kernel) and its EFI binaries on the ESP
       # are extracted as build artifacts. Use rpm --nodeps to bypass this.
-      # Fixed in shim 16.1+ (Fedora 44+) which drops the hard grub2 dep.
       rpm -e --nodeps grub2-efi-x64

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/artifacts-output-verity-arm64-azl4.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/artifacts-output-verity-arm64-azl4.yaml
@@ -90,5 +90,4 @@ scripts:
       # is not an option because shim is needed for the secure boot chain
       # (UEFI -> shim -> systemd-boot -> kernel) and its EFI binaries on the ESP
       # are extracted as build artifacts. Use rpm --nodeps to bypass this.
-      # Fixed in shim 16.1+ (Fedora 44+) which drops the hard grub2 dep.
       rpm -e --nodeps grub2-efi-aa64

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/hierarchical-config-amd64-azl4.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/hierarchical-config-amd64-azl4.yaml
@@ -100,7 +100,6 @@ scripts:
       # is not an option because shim is needed for the secure boot chain
       # (UEFI -> shim -> systemd-boot -> kernel) and its EFI binaries on the ESP
       # are extracted as build artifacts. Use rpm --nodeps to bypass this.
-      # Fixed in shim 16.1+ (Fedora 44+) which drops the hard grub2 dep.
       rpm -e --nodeps grub2-efi-x64
   - content: |
       set -eux

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/hierarchical-config-arm64-azl4.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/hierarchical-config-arm64-azl4.yaml
@@ -100,7 +100,6 @@ scripts:
       # is not an option because shim is needed for the secure boot chain
       # (UEFI -> shim -> systemd-boot -> kernel) and its EFI binaries on the ESP
       # are extracted as build artifacts. Use rpm --nodeps to bypass this.
-      # Fixed in shim 16.1+ (Fedora 44+) which drops the hard grub2 dep.
       rpm -e --nodeps grub2-efi-aa64
   - content: |
       set -eux

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-root-inline-uki-amd64-azl4.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-root-inline-uki-amd64-azl4.yaml
@@ -102,7 +102,6 @@ scripts:
       # is not an option because shim is needed for the secure boot chain
       # (UEFI -> shim -> systemd-boot -> kernel) and its EFI binaries on the ESP
       # are extracted as build artifacts. Use rpm --nodeps to bypass this.
-      # Fixed in shim 16.1+ (Fedora 44+) which drops the hard grub2 dep.
       rpm -e --nodeps grub2-efi-x64
 
     # Move the SSH host keys off of the read-only /etc directory, so that sshd can run.

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-root-inline-uki-arm64-azl4.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-root-inline-uki-arm64-azl4.yaml
@@ -102,7 +102,6 @@ scripts:
       # is not an option because shim is needed for the secure boot chain
       # (UEFI -> shim -> systemd-boot -> kernel) and its EFI binaries on the ESP
       # are extracted as build artifacts. Use rpm --nodeps to bypass this.
-      # Fixed in shim 16.1+ (Fedora 44+) which drops the hard grub2 dep.
       rpm -e --nodeps grub2-efi-aa64
     # Move the SSH host keys off of the read-only /etc directory, so that sshd can run.
   - path: scripts/ssh-move-host-keys.sh

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-root-uki-amd64-azl4.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-root-uki-amd64-azl4.yaml
@@ -77,7 +77,6 @@ scripts:
       # is not an option because shim is needed for the secure boot chain
       # (UEFI -> shim -> systemd-boot -> kernel) and its EFI binaries on the ESP
       # are extracted as build artifacts. Use rpm --nodeps to bypass this.
-      # Fixed in shim 16.1+ (Fedora 44+) which drops the hard grub2 dep.
       rpm -e --nodeps grub2-efi-x64
   - content: |
       set -eux

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-root-uki-arm64-azl4.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-root-uki-arm64-azl4.yaml
@@ -77,7 +77,6 @@ scripts:
       # is not an option because shim is needed for the secure boot chain
       # (UEFI -> shim -> systemd-boot -> kernel) and its EFI binaries on the ESP
       # are extracted as build artifacts. Use rpm --nodeps to bypass this.
-      # Fixed in shim 16.1+ (Fedora 44+) which drops the hard grub2 dep.
       rpm -e --nodeps grub2-efi-aa64
   - content: |
       set -eux

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-uki-amd64-azl4.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-uki-amd64-azl4.yaml
@@ -86,5 +86,4 @@ scripts:
       # is not an option because shim is needed for the secure boot chain
       # (UEFI -> shim -> systemd-boot -> kernel) and its EFI binaries on the ESP
       # are extracted as build artifacts. Use rpm --nodeps to bypass this.
-      # Fixed in shim 16.1+ (Fedora 44+) which drops the hard grub2 dep.
       rpm -e --nodeps grub2-efi-x64

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-uki-arm64-azl4.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-uki-arm64-azl4.yaml
@@ -86,5 +86,4 @@ scripts:
       # is not an option because shim is needed for the secure boot chain
       # (UEFI -> shim -> systemd-boot -> kernel) and its EFI binaries on the ESP
       # are extracted as build artifacts. Use rpm --nodeps to bypass this.
-      # Fixed in shim 16.1+ (Fedora 44+) which drops the hard grub2 dep.
       rpm -e --nodeps grub2-efi-aa64


### PR DESCRIPTION
The Azure Linux 4.0 configs that work around the shim to grub2-efi dependency carried a forward-looking note claiming the issue is "Fixed in shim 16.1+ (Fedora 44+)". That claim is unverified and risks misleading readers, so this removes it. The surrounding comment block still documents why the `rpm -e --nodeps` workaround is needed today.

The note is dropped from the 12 Azure Linux 4.0 testdata configs and from the matching workaround comment in `liveosisobuilder_test.go`, so it is gone everywhere.

---

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [x] Code conforms to style guidelines