### PR TITLE
Add Azure Linux 4.0 ISO LiveOS bootstrap support

### DIFF
--- a/test/vmtests/vmtests/imagecustomizer/test_min_change.py
+++ b/test/vmtests/vmtests/imagecustomizer/test_min_change.py
@@ -417,7 +417,6 @@ def test_min_change_efi_azl3_iso_bootstrap_output(
     )
 
 
-@pytest.mark.skip(reason="Azure Linux 4.0 ISO bootstrap output is not yet supported")
 def test_min_change_efi_azl4_iso_bootstrap_output(
     docker_client: DockerClient,
     image_customizer_container_url: str,
@@ -431,6 +430,7 @@ def test_min_change_efi_azl4_iso_bootstrap_output(
 ) -> None:
     azl_release = 4
     config_path = TEST_CONFIGS_DIR.joinpath("iso-bootstrap-vm-azl4.yaml")
+    config_path = add_preview_features_to_config(config_path, "preview-distro-version", close_list)
     output_format = "iso"
 
     run_min_change_test(
@@ -480,7 +480,6 @@ def test_min_change_efi_azl3_iso_full_os_output(
     )
 
 
-@pytest.mark.skip(reason="Azure Linux 4.0 ISO full OS output is not yet supported")
 def test_min_change_efi_azl4_iso_full_os_output(
     docker_client: DockerClient,
     image_customizer_container_url: str,
@@ -494,6 +493,7 @@ def test_min_change_efi_azl4_iso_full_os_output(
 ) -> None:
     azl_release = 4
     config_path = TEST_CONFIGS_DIR.joinpath("iso-full-os-vm-azl4.yaml")
+    config_path = add_preview_features_to_config(config_path, "preview-distro-version", close_list)
     output_format = "iso"
 
     run_min_change_test(
@@ -577,7 +577,6 @@ def test_min_change_legacy_azl3_iso_output(
 
 
 @pytest.mark.skipif(platform.machine() != "x86_64", reason="no arm64 legacy boot input images are available")
-@pytest.mark.skip(reason="Azure Linux 4.0 ISO bootstrap output is not yet supported")
 def test_min_change_legacy_azl4_iso_output(
     docker_client: DockerClient,
     image_customizer_container_url: str,
@@ -591,6 +590,7 @@ def test_min_change_legacy_azl4_iso_output(
 ) -> None:
     azl_release = 4
     config_path = TEST_CONFIGS_DIR.joinpath("iso-bootstrap-vm-azl4.yaml")
+    config_path = add_preview_features_to_config(config_path, "preview-distro-version", close_list)
     output_format = "iso"
 
     run_min_change_test(

--- a/toolkit/tools/pkg/imagecustomizerlib/blsutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/blsutils.go
@@ -263,3 +263,119 @@ func updateBLSEntryOptions(content string, argsToRemove []string, newArgs []stri
 
 	return result
 }
+
+// forEachBLSEntry rewrites every non-rescue BLS .conf file under {bootDir}/loader/entries by passing its content
+// through edit.
+func forEachBLSEntry(bootDir string, edit func(content string) (string, error)) error {
+	entriesDir := filepath.Join(bootDir, "loader", "entries")
+	entries, err := os.ReadDir(entriesDir)
+	if err != nil {
+		return fmt.Errorf("failed to read BLS entries directory (%s):\n%w", entriesDir, err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".conf") {
+			continue
+		}
+
+		absPath := filepath.Join(entriesDir, entry.Name())
+		contentBytes, err := os.ReadFile(absPath)
+		if err != nil {
+			return fmt.Errorf("failed to read BLS entry file (%s):\n%w", absPath, err)
+		}
+		content := string(contentBytes)
+
+		title := ""
+		for _, field := range bls.ParseFields(content) {
+			if field.Key == "title" {
+				title = field.Value
+				break
+			}
+		}
+		if bls.IsRescueEntryTitle(title) {
+			continue
+		}
+
+		updatedContent, err := edit(content)
+		if err != nil {
+			return fmt.Errorf("failed to update BLS entry file (%s):\n%w", absPath, err)
+		}
+
+		if updatedContent == content {
+			continue
+		}
+
+		err = os.WriteFile(absPath, []byte(updatedContent), 0o644)
+		if err != nil {
+			return fmt.Errorf("failed to write BLS entry file (%s):\n%w", absPath, err)
+		}
+	}
+
+	return nil
+}
+
+// setBLSEntryField replaces the value of the first line with the given key (e.g. "linux" or "initrd") in a BLS entry,
+// preserving every other byte. It returns an error if the key is absent unlike updateBLSEntryOptions above, which adds
+// an options line if none exists.
+func setBLSEntryField(content string, key string, newValue string) (string, error) {
+	for _, line := range bls.ParseLines(content) {
+		if line.Key != key {
+			continue
+		}
+		return content[:line.ContentStart] + key + " " + newValue + content[line.ContentEnd:], nil
+	}
+	return "", fmt.Errorf("failed to find the '%s' key in BLS entry", key)
+}
+
+// updateLiveOSBLSEntries applies the LiveOS-compatibility kernel-entry edits to the BLS entries under bootDir. It is
+// the BLS counterpart of the per-entry portion of updateGrubCfgForLiveOS.
+func updateLiveOSBLSEntries(bootDir string, initramfsImageType imagecustomizerapi.InitramfsImageType,
+	disableSELinux bool, savedConfigs *SavedConfigs,
+) error {
+	var argsToRemove []string
+	var argsToAppend []string
+
+	switch initramfsImageType {
+	case imagecustomizerapi.InitramfsImageTypeFullOS:
+		// Remove 'root' so that no pivoting takes place.
+		argsToRemove = append(argsToRemove, "root")
+	case imagecustomizerapi.InitramfsImageTypeBootstrap:
+		liveosKernelArgs := fmt.Sprintf(kernelArgsLiveOSTemplate, liveOSDir, liveOSImage)
+		argsToAppend = append(argsToAppend, strings.Fields(liveosKernelArgs)...)
+	default:
+		return fmt.Errorf("unsupported initramfs image type (%s)", initramfsImageType)
+	}
+
+	if disableSELinux {
+		argsToRemove = append(argsToRemove, selinuxArgNames...)
+		selinuxArgs, err := selinuxModeToArgs(imagecustomizerapi.SELinuxModeDisabled)
+		if err != nil {
+			return err
+		}
+		argsToAppend = append(argsToAppend, selinuxArgs...)
+	}
+
+	argsToAppend = append(argsToAppend, savedConfigs.LiveOS.KernelCommandLine.ExtraCommandLine...)
+
+	return forEachBLSEntry(bootDir, func(content string) (string, error) {
+		if initramfsImageType == imagecustomizerapi.InitramfsImageTypeFullOS {
+			var err error
+			content, err = setBLSEntryField(content, "initrd", isoInitrdPath)
+			if err != nil {
+				return "", fmt.Errorf("failed to update initrd path in BLS entry:\n%w", err)
+			}
+		}
+		return updateBLSEntryOptions(content, argsToRemove, argsToAppend), nil
+	})
+}
+
+// setLiveOSBLSEntriesRoot replaces the root= kernel arg in every BLS entry under bootDir and optionally appends
+// additional args.
+func setLiveOSBLSEntriesRoot(bootDir string, rootValue string, extraArgs []string) error {
+	argsToRemove := []string{"root"}
+	newArgs := append([]string{"root=" + rootValue}, extraArgs...)
+
+	return forEachBLSEntry(bootDir, func(content string) (string, error) {
+		return updateBLSEntryOptions(content, argsToRemove, newArgs), nil
+	})
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/blsutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/blsutils.go
@@ -365,7 +365,8 @@ func updateLiveOSBLSEntries(bootDir string, initramfsImageType imagecustomizerap
 				return "", fmt.Errorf("failed to update initrd path in BLS entry:\n%w", err)
 			}
 		}
-		return updateBLSEntryOptions(content, argsToRemove, argsToAppend), nil
+		content = updateBLSEntryOptions(content, argsToRemove, argsToAppend)
+		return content, nil
 	})
 }
 

--- a/toolkit/tools/pkg/imagecustomizerlib/blsutils_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/blsutils_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -569,4 +570,111 @@ func TestParseBLSOptionsValue(t *testing.T) {
 			assert.Equal(t, tc.wantArg, gotArgs)
 		})
 	}
+}
+
+// writeTestBLSEntry creates a single AZL4-style BLS entry under {bootDir}/loader/entries and returns the entry's
+// absolute path.
+func writeTestBLSEntry(t *testing.T, bootDir string) string {
+	entriesDir := filepath.Join(bootDir, "loader", "entries")
+	err := os.MkdirAll(entriesDir, 0o755)
+	assert.NoError(t, err)
+
+	content := "title Azure Linux (6.18.31-1.5.azl4.x86_64) 4.0\n" +
+		"version 6.18.31-1.5.azl4.x86_64\n" +
+		"linux /boot/vmlinuz-6.18.31-1.5.azl4.x86_64\n" +
+		"initrd /boot/initramfs-6.18.31-1.5.azl4.x86_64.img\n" +
+		"options console=ttyS0 root=UUID=1396c02f-6cf5-438c-9c9c-fb2001079bb9 rd.shell=0\n" +
+		"grub_users $grub_users\n" +
+		"grub_arg --unrestricted\n" +
+		"grub_class azurelinux\n"
+
+	entryPath := filepath.Join(entriesDir, "azl4.conf")
+	err = os.WriteFile(entryPath, []byte(content), 0o644)
+	assert.NoError(t, err)
+	return entryPath
+}
+
+func TestUpdateLiveOSBLSEntriesFullOS(t *testing.T) {
+	bootDir := t.TempDir()
+	entryPath := writeTestBLSEntry(t, bootDir)
+
+	savedConfigs := &SavedConfigs{}
+	savedConfigs.LiveOS.KernelCommandLine.ExtraCommandLine = []string{"rd.info"}
+
+	err := updateLiveOSBLSEntries(bootDir, imagecustomizerapi.InitramfsImageTypeFullOS, false /*disableSELinux*/, savedConfigs)
+	assert.NoError(t, err)
+
+	got, err := os.ReadFile(entryPath)
+	assert.NoError(t, err)
+	gotStr := string(got)
+
+	// Full-OS repoints initrd at the single regenerated /boot/initrd.img.
+	assert.Regexp(t, `(?m)^initrd /boot/initrd\.img$`, gotStr)
+	// root= is dropped so no pivot takes place, and the unrelated arg is preserved.
+	assert.NotContains(t, gotStr, "root=UUID=")
+	assert.Regexp(t, `(?m)^options .*console=ttyS0`, gotStr)
+	// The saved extra command line is appended.
+	assert.Regexp(t, `(?m)^options .* rd\.info$`, gotStr)
+	// blscfg-only keys are untouched.
+	assert.Contains(t, gotStr, "grub_class azurelinux")
+}
+
+func TestUpdateLiveOSBLSEntriesBootstrap(t *testing.T) {
+	bootDir := t.TempDir()
+	entryPath := writeTestBLSEntry(t, bootDir)
+
+	savedConfigs := &SavedConfigs{}
+	savedConfigs.LiveOS.KernelCommandLine.ExtraCommandLine = []string{"rd.shell"}
+
+	err := updateLiveOSBLSEntries(bootDir, imagecustomizerapi.InitramfsImageTypeBootstrap, true /*disableSELinux*/, savedConfigs)
+	assert.NoError(t, err)
+
+	got, err := os.ReadFile(entryPath)
+	assert.NoError(t, err)
+	gotStr := string(got)
+
+	// Bootstrap keeps the per-kernel initrd and the original root (the iso/pxe root is set later).
+	assert.Regexp(t, `(?m)^initrd /boot/initramfs-6\.18\.31-1\.5\.azl4\.x86_64\.img$`, gotStr)
+	assert.Contains(t, gotStr, "root=UUID=1396c02f-6cf5-438c-9c9c-fb2001079bb9")
+	// The dracut live-OS args are appended.
+	assert.Contains(t, gotStr, "rd.live.image")
+	assert.Contains(t, gotStr, "rd.live.dir="+liveOSDir)
+	assert.Contains(t, gotStr, "rd.live.squashimg="+liveOSImage)
+	// SELinux is disabled.
+	assert.Contains(t, gotStr, "selinux=0")
+	// The saved extra command line is appended.
+	assert.Regexp(t, `(?m)^options .* rd\.shell$`, gotStr)
+}
+
+func TestSetLiveOSBLSEntriesRootForIso(t *testing.T) {
+	bootDir := t.TempDir()
+	entryPath := writeTestBLSEntry(t, bootDir)
+
+	err := setLiveOSBLSEntriesRoot(bootDir, "live:LABEL=foo", nil)
+	assert.NoError(t, err)
+
+	got, err := os.ReadFile(entryPath)
+	assert.NoError(t, err)
+	gotStr := string(got)
+
+	assert.Contains(t, gotStr, "root=live:LABEL=foo")
+	assert.NotContains(t, gotStr, "root=UUID=")
+}
+
+func TestSetBLSEntryField(t *testing.T) {
+	content := "title Foo\n" +
+		"linux /boot/vmlinuz-6.6\n" +
+		"initrd /boot/initramfs-6.6.img\n" +
+		"options root=/dev/sda1\n"
+
+	got, err := setBLSEntryField(content, "initrd", "/boot/initrd.img")
+	assert.NoError(t, err)
+	assert.Regexp(t, `(?m)^initrd /boot/initrd\.img$`, got)
+	// Other lines are preserved verbatim.
+	assert.Contains(t, got, "linux /boot/vmlinuz-6.6\n")
+	assert.Contains(t, got, "options root=/dev/sda1\n")
+
+	// Absent key is an error rather than a silent no-op, mirroring the inline-grub path.
+	_, err = setBLSEntryField(content, "efi", "/x")
+	assert.Error(t, err)
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler.go
@@ -131,11 +131,32 @@ type DistroHandler interface {
 	UpdateBootConfigForVerity(verityMetadata []verityDeviceMetadata, bootPartitionTmpDir string,
 		bootRelativePath string, partitions []diskutils.PartitionInfo, buildDir string, bootUuid string) error
 
+	// UpdateLiveOSGrubCfgForLiveOS applies the common LiveOS-compatibility edits to the grub.cfg generation. It is the
+	// base that the iso and pxe steps build on.
+	UpdateLiveOSGrubCfgForLiveOS(grubCfgContent string, bootDir string,
+		initramfsType imagecustomizerapi.InitramfsImageType, disableSELinux bool, savedConfigs *SavedConfigs,
+		kernelVersions []string) (string, error)
+
+	// UpdateLiveOSGrubCfgForIso applies the iso-specific edits on top of the LiveOS edits.
+	UpdateLiveOSGrubCfgForIso(grubCfgContent string, bootDir string,
+		initramfsType imagecustomizerapi.InitramfsImageType) (string, error)
+
 	// ShimPackage returns the package that provides the shim EFI binary for this distro on the current architecture.
 	ShimPackage() string
 
 	// GrubEfiPackage returns the package that provides the grub EFI binary for this distro on the current architecture.
 	GrubEfiPackage() string
+
+	// LiveOSRequiredPackages returns the packages that must already be installed in the target image for Image
+	// Customizer to build a LiveOS bootstrap initrd (the squashfs and dracut live tooling).
+	LiveOSRequiredPackages() []string
+
+	// LiveOSGrubEfiPrefixDir returns the ISO-relative directory that this distro's grub EFI binary uses as its baked-in
+	// 'prefix', or "" if it doesn't use a baked-in prefix.
+	LiveOSGrubEfiPrefixDir() string
+
+	// LiveOSInitrdDracutModules returns the dracut modules to add when building the LiveOS bootstrap initrd.
+	LiveOSInitrdDracutModules() []string
 
 	// Distro has a root partition that is missing placeholder directories for special mounts like /dev.
 	RootMissingMountDirectories() bool

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
@@ -295,6 +295,19 @@ func (d *aclDistroHandler) UpdateBootConfigForVerity(verityMetadata []verityDevi
 	return fs.ErrNotExist
 }
 
+func (d *aclDistroHandler) UpdateLiveOSGrubCfgForLiveOS(grubCfgContent string, bootDir string,
+	initramfsType imagecustomizerapi.InitramfsImageType, disableSELinux bool, savedConfigs *SavedConfigs,
+	kernelVersions []string,
+) (string, error) {
+	return updateGrubCfgForLiveOS(grubCfgContent, initramfsType, disableSELinux, savedConfigs, kernelVersions)
+}
+
+func (d *aclDistroHandler) UpdateLiveOSGrubCfgForIso(grubCfgContent string, bootDir string,
+	initramfsType imagecustomizerapi.InitramfsImageType,
+) (string, error) {
+	return updateGrubCfgForIso(grubCfgContent, initramfsType)
+}
+
 func (d *aclDistroHandler) ShimPackage() string {
 	// ACL uses systemd-boot + UKI (no shim/grub from a package).
 	return ""
@@ -303,6 +316,18 @@ func (d *aclDistroHandler) ShimPackage() string {
 func (d *aclDistroHandler) GrubEfiPackage() string {
 	// ACL does not use grub.
 	return ""
+}
+
+func (d *aclDistroHandler) LiveOSRequiredPackages() []string {
+	return liveOSRequiredPackagesAzl3
+}
+
+func (d *aclDistroHandler) LiveOSGrubEfiPrefixDir() string {
+	return ""
+}
+
+func (d *aclDistroHandler) LiveOSInitrdDracutModules() []string {
+	return liveOSInitrdDracutModulesAzl3
 }
 
 func (d *aclDistroHandler) RootMissingMountDirectories() bool {

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux.go
@@ -36,8 +36,10 @@ const (
 )
 
 var (
-	grubEfiPackagesAzl3     = []string{grubEfiPackageAzl3, grubEfiNoPrefixPackageAzl3}
-	systemdBootPackagesAzl3 = []string{systemdBootPackage}
+	grubEfiPackagesAzl3           = []string{grubEfiPackageAzl3, grubEfiNoPrefixPackageAzl3}
+	systemdBootPackagesAzl3       = []string{systemdBootPackage}
+	liveOSRequiredPackagesAzl3    = []string{"squashfs-tools", "tar", "device-mapper", "curl"}
+	liveOSInitrdDracutModulesAzl3 = []string{"dmsquash-live", "livenet", "selinux"}
 )
 
 func newAzureLinuxDistroHandler(targetOs targetos.TargetOs) *azureLinuxDistroHandler {
@@ -219,12 +221,37 @@ func (d *azureLinuxDistroHandler) UpdateBootConfigForVerity(verityMetadata []ver
 	return updateGrubConfigForVerity(verityMetadata, grubCfgFullPath, partitions, buildDir, bootUuid)
 }
 
+func (d *azureLinuxDistroHandler) UpdateLiveOSGrubCfgForLiveOS(grubCfgContent string, bootDir string,
+	initramfsType imagecustomizerapi.InitramfsImageType, disableSELinux bool, savedConfigs *SavedConfigs,
+	kernelVersions []string,
+) (string, error) {
+	return updateGrubCfgForLiveOS(grubCfgContent, initramfsType, disableSELinux, savedConfigs, kernelVersions)
+}
+
+func (d *azureLinuxDistroHandler) UpdateLiveOSGrubCfgForIso(grubCfgContent string, bootDir string,
+	initramfsType imagecustomizerapi.InitramfsImageType,
+) (string, error) {
+	return updateGrubCfgForIso(grubCfgContent, initramfsType)
+}
+
 func (d *azureLinuxDistroHandler) ShimPackage() string {
 	return shimPackageAzl3
 }
 
 func (d *azureLinuxDistroHandler) GrubEfiPackage() string {
 	return grubEfiPackageAzl3
+}
+
+func (d *azureLinuxDistroHandler) LiveOSRequiredPackages() []string {
+	return liveOSRequiredPackagesAzl3
+}
+
+func (d *azureLinuxDistroHandler) LiveOSGrubEfiPrefixDir() string {
+	return ""
+}
+
+func (d *azureLinuxDistroHandler) LiveOSInitrdDracutModules() []string {
+	return liveOSInitrdDracutModulesAzl3
 }
 
 func (d *azureLinuxDistroHandler) RootMissingMountDirectories() bool {

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux4.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux4.go
@@ -32,9 +32,50 @@ type azureLinux4DistroHandler struct {
 
 const (
 	systemdBootUnsignedPackageAzl4 = "systemd-boot-unsigned"
+
+	osEspGrubDirAzl4 = osEspDir + "/EFI/azurelinux"
 )
 
 var systemdBootPackagesAzl4 = []string{systemdBootPackage, systemdBootUnsignedPackageAzl4}
+
+// bootloaderFilesConfigAzl4 is the boot-files map for Azure Linux 4.0.
+//
+// It matches the Fedora config (bootloaderFilesConfigFedora) except that osEspGrubBinaryPath is configured under
+// Azure Linux 4.0's grub EFI vendor directory instead.
+var bootloaderFilesConfigAzl4 = map[string]BootFilesArchConfig{
+	"amd64": {
+		bootBinary:                  bootx64BinaryFedora,
+		grubBinary:                  grubx64Binary,
+		grubNoPrefixBinary:          "",
+		espBootBinaryPath:           espBootloaderDir + "/" + bootx64BinaryFedora,
+		espGrubBinaryPath:           espBootloaderDir + "/" + grubx64Binary,
+		osEspBootBinaryPath:         osEspBootloaderDir + "/" + bootx64BinaryFedora,
+		osEspGrubBinaryPath:         osEspGrubDirAzl4 + "/" + grubx64Binary,
+		osEspGrubNoPrefixBinaryPath: "",
+		isoBootBinaryPath:           isoBootloaderDir + "/" + bootx64BinaryFedora,
+		isoGrubBinaryPath:           isoBootloaderDir + "/" + grubx64Binary,
+		ukiEfiStubBinary:            ukiEfiStubx64Binary,
+		ukiEfiStubBinaryPath:        ukiEfiStubDir + "/" + ukiEfiStubx64Binary,
+		ukiAddonStubBinary:          ukiAddonStubx64Binary,
+		ukiAddonStubBinaryPath:      ukiEfiStubDir + "/" + ukiAddonStubx64Binary,
+	},
+	"arm64": {
+		bootBinary:                  bootAA64BinaryFedora,
+		grubBinary:                  grubAA64Binary,
+		grubNoPrefixBinary:          "",
+		espBootBinaryPath:           espBootloaderDir + "/" + bootAA64BinaryFedora,
+		espGrubBinaryPath:           espBootloaderDir + "/" + grubAA64Binary,
+		osEspBootBinaryPath:         osEspBootloaderDir + "/" + bootAA64BinaryFedora,
+		osEspGrubBinaryPath:         osEspGrubDirAzl4 + "/" + grubAA64Binary,
+		osEspGrubNoPrefixBinaryPath: "",
+		isoBootBinaryPath:           isoBootloaderDir + "/" + bootAA64BinaryFedora,
+		isoGrubBinaryPath:           isoBootloaderDir + "/" + grubAA64Binary,
+		ukiEfiStubBinary:            ukiEfiStubAA64Binary,
+		ukiEfiStubBinaryPath:        ukiEfiStubDir + "/" + ukiEfiStubAA64Binary,
+		ukiAddonStubBinary:          ukiAddonStubAA64Binary,
+		ukiAddonStubBinaryPath:      ukiEfiStubDir + "/" + ukiAddonStubAA64Binary,
+	},
+}
 
 func newAzureLinux4DistroHandler(targetOs targetos.TargetOs) *azureLinux4DistroHandler {
 	logger.Log.Debugf("Distro handler: Azure Linux 4+ (distro='%s', versionid='%s')", targetOs.Distro, targetOs.VersionId)
@@ -312,5 +353,5 @@ func (d *azureLinux4DistroHandler) RootMissingMountDirectories() bool {
 }
 
 func (d *azureLinux4DistroHandler) GetBootArchConfig() (BootFilesArchConfig, error) {
-	return bootArchConfigFromMap(bootloaderFilesConfigFedora)
+	return bootArchConfigFromMap(bootloaderFilesConfigAzl4)
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux4.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux4.go
@@ -73,15 +73,16 @@ func (d *azureLinux4DistroHandler) ValidateConfig(rc *ResolvedConfig) error {
 	return nil
 }
 
+const azl4PxeUnsupportedError = "PXE output format is not supported yet for Azure Linux 4.0 images"
+
 func (d *azureLinux4DistroHandler) checkForUnsupportedApis(rc *ResolvedConfig) error {
 	if rc.HasPackageSnapshotTime() {
 		return ErrUnsupportedPackageSnapshotTime
 	}
 
 	switch rc.OutputImageFormat {
-	case imagecustomizerapi.ImageFormatTypeIso, imagecustomizerapi.ImageFormatTypePxeDir,
-		imagecustomizerapi.ImageFormatTypePxeTar:
-		return fmt.Errorf("ISO and PXE output formats are not supported yet for Azure Linux 4.0 images")
+	case imagecustomizerapi.ImageFormatTypePxeDir, imagecustomizerapi.ImageFormatTypePxeTar:
+		return errors.New(azl4PxeUnsupportedError)
 	}
 
 	return nil
@@ -256,6 +257,19 @@ func (d *azureLinux4DistroHandler) UpdateBootConfigForVerity(verityMetadata []ve
 	return updateBLSEntriesForVerity(verityMetadata, bootDir, partitions, buildDir, bootUuid)
 }
 
+func (d *azureLinux4DistroHandler) UpdateLiveOSGrubCfgForLiveOS(grubCfgContent string, bootDir string,
+	initramfsType imagecustomizerapi.InitramfsImageType, disableSELinux bool, savedConfigs *SavedConfigs,
+	kernelVersions []string,
+) (string, error) {
+	return updateLiveOSGrubCfgBLSForLiveOS(grubCfgContent, bootDir, initramfsType, disableSELinux, savedConfigs)
+}
+
+func (d *azureLinux4DistroHandler) UpdateLiveOSGrubCfgForIso(grubCfgContent string, bootDir string,
+	initramfsType imagecustomizerapi.InitramfsImageType,
+) (string, error) {
+	return updateLiveOSGrubCfgBLSForIso(grubCfgContent, bootDir, initramfsType)
+}
+
 func (d *azureLinux4DistroHandler) warnIfUnsignedSystemdBootPackage(detectedPackage string) {
 	if detectedPackage == systemdBootUnsignedPackageAzl4 {
 		logger.Log.Warnf("Detected package (%s): Customized image will fail Secure Boot verification", detectedPackage)
@@ -278,6 +292,18 @@ func (d *azureLinux4DistroHandler) GrubEfiPackage() string {
 	default:
 		return grubEfiPackageFedoraArm64
 	}
+}
+
+func (d *azureLinux4DistroHandler) LiveOSRequiredPackages() []string {
+	return liveOSRequiredPackagesFedora
+}
+
+func (d *azureLinux4DistroHandler) LiveOSGrubEfiPrefixDir() string {
+	return "EFI/azurelinux"
+}
+
+func (d *azureLinux4DistroHandler) LiveOSInitrdDracutModules() []string {
+	return liveOSInitrdDracutModulesFedora
 }
 
 func (d *azureLinux4DistroHandler) RootMissingMountDirectories() bool {

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux4.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux4.go
@@ -73,7 +73,8 @@ func (d *azureLinux4DistroHandler) ValidateConfig(rc *ResolvedConfig) error {
 	return nil
 }
 
-const azl4PxeUnsupportedError = "PXE output format is not supported yet for Azure Linux 4.0 images"
+var ErrAzureLinux4PxeUnsupported = NewImageCustomizerError("Validation:AzureLinux4PxeUnsupported",
+	"PXE output format is not supported yet for Azure Linux 4.0 images")
 
 func (d *azureLinux4DistroHandler) checkForUnsupportedApis(rc *ResolvedConfig) error {
 	if rc.HasPackageSnapshotTime() {
@@ -82,7 +83,7 @@ func (d *azureLinux4DistroHandler) checkForUnsupportedApis(rc *ResolvedConfig) e
 
 	switch rc.OutputImageFormat {
 	case imagecustomizerapi.ImageFormatTypePxeDir, imagecustomizerapi.ImageFormatTypePxeTar:
-		return errors.New(azl4PxeUnsupportedError)
+		return ErrAzureLinux4PxeUnsupported
 	}
 
 	return nil

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
@@ -45,40 +45,53 @@ const (
 //
 // Fedora-style distros do not ship a grub-noprefix binary, so grubNoPrefixBinary and
 // osEspGrubNoPrefixBinaryPath are left empty.
-var bootloaderFilesConfigFedora = map[string]BootFilesArchConfig{
-	"amd64": {
-		bootBinary:                  bootx64BinaryFedora,
-		grubBinary:                  grubx64Binary,
-		grubNoPrefixBinary:          "",
-		espBootBinaryPath:           espBootloaderDir + "/" + bootx64BinaryFedora,
-		espGrubBinaryPath:           espBootloaderDir + "/" + grubx64Binary,
-		osEspBootBinaryPath:         osEspBootloaderDir + "/" + bootx64BinaryFedora,
-		osEspGrubBinaryPath:         osEspBootloaderDir + "/" + grubx64Binary,
-		osEspGrubNoPrefixBinaryPath: "",
-		isoBootBinaryPath:           isoBootloaderDir + "/" + bootx64BinaryFedora,
-		isoGrubBinaryPath:           isoBootloaderDir + "/" + grubx64Binary,
-		ukiEfiStubBinary:            ukiEfiStubx64Binary,
-		ukiEfiStubBinaryPath:        ukiEfiStubDir + "/" + ukiEfiStubx64Binary,
-		ukiAddonStubBinary:          ukiAddonStubx64Binary,
-		ukiAddonStubBinaryPath:      ukiEfiStubDir + "/" + ukiAddonStubx64Binary,
-	},
-	"arm64": {
-		bootBinary:                  bootAA64BinaryFedora,
-		grubBinary:                  grubAA64Binary,
-		grubNoPrefixBinary:          "",
-		espBootBinaryPath:           espBootloaderDir + "/" + bootAA64BinaryFedora,
-		espGrubBinaryPath:           espBootloaderDir + "/" + grubAA64Binary,
-		osEspBootBinaryPath:         osEspBootloaderDir + "/" + bootAA64BinaryFedora,
-		osEspGrubBinaryPath:         osEspBootloaderDir + "/" + grubAA64Binary,
-		osEspGrubNoPrefixBinaryPath: "",
-		isoBootBinaryPath:           isoBootloaderDir + "/" + bootAA64BinaryFedora,
-		isoGrubBinaryPath:           isoBootloaderDir + "/" + grubAA64Binary,
-		ukiEfiStubBinary:            ukiEfiStubAA64Binary,
-		ukiEfiStubBinaryPath:        ukiEfiStubDir + "/" + ukiEfiStubAA64Binary,
-		ukiAddonStubBinary:          ukiAddonStubAA64Binary,
-		ukiAddonStubBinaryPath:      ukiEfiStubDir + "/" + ukiAddonStubAA64Binary,
-	},
-}
+var (
+	bootloaderFilesConfigFedora = map[string]BootFilesArchConfig{
+		"amd64": {
+			bootBinary:                  bootx64BinaryFedora,
+			grubBinary:                  grubx64Binary,
+			grubNoPrefixBinary:          "",
+			espBootBinaryPath:           espBootloaderDir + "/" + bootx64BinaryFedora,
+			espGrubBinaryPath:           espBootloaderDir + "/" + grubx64Binary,
+			osEspBootBinaryPath:         osEspBootloaderDir + "/" + bootx64BinaryFedora,
+			osEspGrubBinaryPath:         osEspBootloaderDir + "/" + grubx64Binary,
+			osEspGrubNoPrefixBinaryPath: "",
+			isoBootBinaryPath:           isoBootloaderDir + "/" + bootx64BinaryFedora,
+			isoGrubBinaryPath:           isoBootloaderDir + "/" + grubx64Binary,
+			ukiEfiStubBinary:            ukiEfiStubx64Binary,
+			ukiEfiStubBinaryPath:        ukiEfiStubDir + "/" + ukiEfiStubx64Binary,
+			ukiAddonStubBinary:          ukiAddonStubx64Binary,
+			ukiAddonStubBinaryPath:      ukiEfiStubDir + "/" + ukiAddonStubx64Binary,
+		},
+		"arm64": {
+			bootBinary:                  bootAA64BinaryFedora,
+			grubBinary:                  grubAA64Binary,
+			grubNoPrefixBinary:          "",
+			espBootBinaryPath:           espBootloaderDir + "/" + bootAA64BinaryFedora,
+			espGrubBinaryPath:           espBootloaderDir + "/" + grubAA64Binary,
+			osEspBootBinaryPath:         osEspBootloaderDir + "/" + bootAA64BinaryFedora,
+			osEspGrubBinaryPath:         osEspBootloaderDir + "/" + grubAA64Binary,
+			osEspGrubNoPrefixBinaryPath: "",
+			isoBootBinaryPath:           isoBootloaderDir + "/" + bootAA64BinaryFedora,
+			isoGrubBinaryPath:           isoBootloaderDir + "/" + grubAA64Binary,
+			ukiEfiStubBinary:            ukiEfiStubAA64Binary,
+			ukiEfiStubBinaryPath:        ukiEfiStubDir + "/" + ukiEfiStubAA64Binary,
+			ukiAddonStubBinary:          ukiAddonStubAA64Binary,
+			ukiAddonStubBinaryPath:      ukiEfiStubDir + "/" + ukiAddonStubAA64Binary,
+		},
+	}
+
+	// liveOSRequiredPackagesFedora lists the packages needed to build a LiveOS bootstrap initrd on Fedora-style distros
+	// Unlike Azure Linux 3.0, these ship the dmsquash-live/livenet dracut modules in a separate dracut-live package.
+	liveOSRequiredPackagesFedora = []string{"squashfs-tools", "tar", "device-mapper", "curl", "dracut-live"}
+
+	// liveOSInitrdDracutModulesFedora lists the dracut modules added to the LiveOS bootstrap initrd on Fedora-style
+	// distros. Unlike Azure Linux 3.0, the "selinux" module is omitted, since Fedora-style distros load SELinux policy
+	// after switch_root, as indicated by their base dracut's 98selinux check() returning 255, opting it out of normal
+	// initramfs builds. Loading it from the initramfs instead would deny execute on the initramfs binaries under
+	// enforcing policy.
+	liveOSInitrdDracutModulesFedora = []string{"dmsquash-live", "livenet"}
+)
 
 func newFedoraDistroHandler(targetOs targetos.TargetOs) *fedoraDistroHandler {
 	logger.Log.Debugf("Distro handler: Fedora (distro='%s', versionid='%s')", targetOs.Distro, targetOs.VersionId)
@@ -264,6 +277,19 @@ func (d *fedoraDistroHandler) UpdateBootConfigForVerity(verityMetadata []verityD
 	return updateBLSEntriesForVerity(verityMetadata, bootDir, partitions, buildDir, bootUuid)
 }
 
+func (d *fedoraDistroHandler) UpdateLiveOSGrubCfgForLiveOS(grubCfgContent string, bootDir string,
+	initramfsType imagecustomizerapi.InitramfsImageType, disableSELinux bool, savedConfigs *SavedConfigs,
+	kernelVersions []string,
+) (string, error) {
+	return updateLiveOSGrubCfgBLSForLiveOS(grubCfgContent, bootDir, initramfsType, disableSELinux, savedConfigs)
+}
+
+func (d *fedoraDistroHandler) UpdateLiveOSGrubCfgForIso(grubCfgContent string, bootDir string,
+	initramfsType imagecustomizerapi.InitramfsImageType,
+) (string, error) {
+	return updateLiveOSGrubCfgBLSForIso(grubCfgContent, bootDir, initramfsType)
+}
+
 func (d *fedoraDistroHandler) ShimPackage() string {
 	switch runtime.GOARCH {
 	case "amd64":
@@ -280,6 +306,18 @@ func (d *fedoraDistroHandler) GrubEfiPackage() string {
 	default:
 		return grubEfiPackageFedoraArm64
 	}
+}
+
+func (d *fedoraDistroHandler) LiveOSRequiredPackages() []string {
+	return liveOSRequiredPackagesFedora
+}
+
+func (d *fedoraDistroHandler) LiveOSGrubEfiPrefixDir() string {
+	return "EFI/fedora"
+}
+
+func (d *fedoraDistroHandler) LiveOSInitrdDracutModules() []string {
+	return liveOSInitrdDracutModulesFedora
 }
 
 func (d *fedoraDistroHandler) RootMissingMountDirectories() bool {

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
@@ -39,13 +39,22 @@ const (
 
 	grubToolsPackageFedora     = "grub2-tools"
 	grubPcModulesPackageFedora = "grub2-pc-modules"
+
+	osEspGrubDirFedora = osEspDir + "/EFI/fedora"
 )
 
-// bootloaderFilesConfigFedora is the boot-files map for Fedora-style ESPs (Azure Linux 4 and Fedora).
-//
-// Fedora-style distros do not ship a grub-noprefix binary, so grubNoPrefixBinary and
-// osEspGrubNoPrefixBinaryPath are left empty.
 var (
+	// bootloaderFilesConfigFedora is the boot-files map for Fedora.
+	//
+	// It matches the Azure Linux 3.0 config (bootloaderFilesConfigAzl3) except that
+	//
+	// 1. grubNoPrefixBinary and osEspGrubNoPrefixBinaryPath are left empty. This is because Fedora does not ship a
+	// grub-noprefix binary.
+	//
+	// 2. osEspGrubBinaryPath is configured under Fedora's grub EFI vendor directory. The grub package installs its
+	// (package-owned) grub EFI binary here, while the /EFI/BOOT copy is an unowned removable-media fallback duplicate.
+	// LiveOS grub detection keys off the vendor copy so that a removed grub package is correctly reported as a missing
+	// grub binary.
 	bootloaderFilesConfigFedora = map[string]BootFilesArchConfig{
 		"amd64": {
 			bootBinary:                  bootx64BinaryFedora,
@@ -54,7 +63,7 @@ var (
 			espBootBinaryPath:           espBootloaderDir + "/" + bootx64BinaryFedora,
 			espGrubBinaryPath:           espBootloaderDir + "/" + grubx64Binary,
 			osEspBootBinaryPath:         osEspBootloaderDir + "/" + bootx64BinaryFedora,
-			osEspGrubBinaryPath:         osEspBootloaderDir + "/" + grubx64Binary,
+			osEspGrubBinaryPath:         osEspGrubDirFedora + "/" + grubx64Binary,
 			osEspGrubNoPrefixBinaryPath: "",
 			isoBootBinaryPath:           isoBootloaderDir + "/" + bootx64BinaryFedora,
 			isoGrubBinaryPath:           isoBootloaderDir + "/" + grubx64Binary,
@@ -70,7 +79,7 @@ var (
 			espBootBinaryPath:           espBootloaderDir + "/" + bootAA64BinaryFedora,
 			espGrubBinaryPath:           espBootloaderDir + "/" + grubAA64Binary,
 			osEspBootBinaryPath:         osEspBootloaderDir + "/" + bootAA64BinaryFedora,
-			osEspGrubBinaryPath:         osEspBootloaderDir + "/" + grubAA64Binary,
+			osEspGrubBinaryPath:         osEspGrubDirFedora + "/" + grubAA64Binary,
 			osEspGrubNoPrefixBinaryPath: "",
 			isoBootBinaryPath:           isoBootloaderDir + "/" + bootAA64BinaryFedora,
 			isoGrubBinaryPath:           isoBootloaderDir + "/" + grubAA64Binary,

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_ubuntu.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_ubuntu.go
@@ -34,6 +34,8 @@ const (
 var (
 	ErrUbuntuUnsupportedBootloaderHardReset   = NewImageCustomizerError("Validation:UbuntuUnsupportedBootloaderHardReset", "bootloader hard-reset API is not supported yet for Ubuntu images")
 	ErrUbuntuUnsupportedDisableBaseImageRepos = NewImageCustomizerError("Validation:UbuntuUnsupportedDisableBaseImageRepos", "disabling base image package repositories is not supported yet for Ubuntu images")
+
+	liveOSRequiredPackagesUbuntu = []string{"squashfs-tools", "tar", "dmsetup", "curl"}
 )
 
 func newUbuntuDistroHandler(targetOs targetos.TargetOs) *ubuntuDistroHandler {
@@ -233,6 +235,19 @@ func (d *ubuntuDistroHandler) UpdateBootConfigForVerity(verityMetadata []verityD
 	return updateGrubConfigForVerity(verityMetadata, grubCfgFullPath, partitions, buildDir, bootUuid)
 }
 
+func (d *ubuntuDistroHandler) UpdateLiveOSGrubCfgForLiveOS(grubCfgContent string, bootDir string,
+	initramfsType imagecustomizerapi.InitramfsImageType, disableSELinux bool, savedConfigs *SavedConfigs,
+	kernelVersions []string,
+) (string, error) {
+	return updateGrubCfgForLiveOS(grubCfgContent, initramfsType, disableSELinux, savedConfigs, kernelVersions)
+}
+
+func (d *ubuntuDistroHandler) UpdateLiveOSGrubCfgForIso(grubCfgContent string, bootDir string,
+	initramfsType imagecustomizerapi.InitramfsImageType,
+) (string, error) {
+	return updateGrubCfgForIso(grubCfgContent, initramfsType)
+}
+
 func (d *ubuntuDistroHandler) ShimPackage() string {
 	return "shim"
 }
@@ -244,6 +259,19 @@ func (d *ubuntuDistroHandler) GrubEfiPackage() string {
 	default:
 		return grubEfiPackageDebianArm64
 	}
+}
+
+func (d *ubuntuDistroHandler) LiveOSRequiredPackages() []string {
+	return liveOSRequiredPackagesUbuntu
+}
+
+func (d *ubuntuDistroHandler) LiveOSGrubEfiPrefixDir() string {
+	return ""
+}
+
+func (d *ubuntuDistroHandler) LiveOSInitrdDracutModules() []string {
+	// Ubuntu LiveOS is not a validated path; default to the inline distros' module set.
+	return liveOSInitrdDracutModulesAzl3
 }
 
 func (d *ubuntuDistroHandler) RootMissingMountDirectories() bool {

--- a/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
@@ -26,6 +26,9 @@ var (
 
 	// Finds the SELinux mode line in the /etc/selinux/config file.
 	selinuxConfigModeRegex = regexp.MustCompile(`(?m)^SELINUX=(\w+)$`)
+
+	// Captures the variable a grub 'search' command assigns via '--set=<var>' (e.g. root or boot).
+	grubSearchSetTargetRegex = regexp.MustCompile(`\s+--set=(\w+)`)
 )
 
 const (
@@ -57,8 +60,9 @@ func findGrubCommandAll(inputGrubCfgContent string, commandName string, allowMul
 	return lines, nil
 }
 
-// Finds all search command occurrences and replaces them.
-func replaceSearchCommandAll(inputGrubCfgContent string, newSearchCommand string) (outputGrubCfgContent string, err error) {
+// Finds all search command occurrences and rewrites each to locate the LiveOS volume by label, preserving the
+// variable each original command assigned via '--set'.
+func replaceSearchCommandAll(inputGrubCfgContent string, volumeId string) (outputGrubCfgContent string, err error) {
 	lines, err := findGrubCommandAll(inputGrubCfgContent, "search", true /*allowMultiple*/)
 	if err != nil {
 		return "", err
@@ -71,6 +75,14 @@ func replaceSearchCommandAll(inputGrubCfgContent string, newSearchCommand string
 		line := lines[i]
 		start := line.Tokens[0].Loc.Start.Index
 		end := line.EndToken.Loc.Start.Index
+
+		// Commands without an explicit '--set=<var>' target default to 'root', matching grub's own default.
+		setTarget := "root"
+		if match := grubSearchSetTargetRegex.FindStringSubmatch(inputGrubCfgContent[start:end]); match != nil {
+			setTarget = match[1]
+		}
+		newSearchCommand := fmt.Sprintf("search --label %s --set %s", volumeId, setTarget)
+
 		outputGrubCfgContent = outputGrubCfgContent[:start] + newSearchCommand + outputGrubCfgContent[end:]
 	}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
@@ -27,8 +27,8 @@ var (
 	// Finds the SELinux mode line in the /etc/selinux/config file.
 	selinuxConfigModeRegex = regexp.MustCompile(`(?m)^SELINUX=(\w+)$`)
 
-	// Captures the variable a grub 'search' command assigns via '--set=<var>' (e.g. root or boot).
-	grubSearchSetTargetRegex = regexp.MustCompile(`\s+--set=(\w+)`)
+	// Captures the variable a grub 'search' command assigns via '--set=<var>' or '--set <var>' (e.g. root or boot).
+	grubSearchSetTargetRegex = regexp.MustCompile(`\s+--set(?:=|\s+)(\w+)`)
 )
 
 const (

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -325,7 +325,7 @@ func convertInputImageToWriteableFormat(ctx context.Context, rc *ResolvedConfig,
 	defer span.End()
 
 	if rc.InputIsIso() {
-		inputIsoArtifacts, inputIsoDistroHandler, err := createIsoArtifactStoreAndDistroHandlerFromIsoImage(
+		inputIsoArtifacts, inputIsoDistroHandler, err := createIsoArtifactStoreFromIsoImage(
 			rc.InputImage.Path, filepath.Join(rc.BuildDirAbs, "from-iso"))
 		if err != nil {
 			return inputIsoArtifacts, nil,

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -212,7 +212,7 @@ func customizeImageOptionsHelper(ctx context.Context, baseConfigPath string, con
 
 	LogVersionsOfToolDeps()
 
-	inputIsoArtifacts, err := convertInputImageToWriteableFormat(ctx, rc)
+	inputIsoArtifacts, inputIsoDistroHandler, err := convertInputImageToWriteableFormat(ctx, rc)
 	if err != nil {
 		return fmt.Errorf("%w:\n%w", ErrConvertInputImage, err)
 	}
@@ -250,6 +250,13 @@ func customizeImageOptionsHelper(ctx context.Context, baseConfigPath string, con
 	im, err := customizeOSContents(ctx, rc, toolsChrootInner)
 	if err != nil {
 		return err
+	}
+
+	// ISO input with no OS-partition customization has no mounted rootfs, so customizeOSContents will not detect the
+	// distro and will return im.distroHandler == nil. Fall back to the handler detected from the input ISO's initrd,
+	// which is guaranteed non-nil for ISO input.
+	if im.distroHandler == nil {
+		im.distroHandler = inputIsoDistroHandler
 	}
 
 	if rc.OutputArtifacts != nil {
@@ -307,7 +314,8 @@ func isKdumpBootFilesConfigChanging(requestedKdumpBootFiles *imagecustomizerapi.
 	return requestedKdumpBootFilesCfg != inputKdumpBootFilesCfg
 }
 
-func convertInputImageToWriteableFormat(ctx context.Context, rc *ResolvedConfig) (*IsoArtifactsStore, error) {
+func convertInputImageToWriteableFormat(ctx context.Context, rc *ResolvedConfig,
+) (*IsoArtifactsStore, DistroHandler, error) {
 	logger.Log.Infof("Converting input image to a writeable format")
 
 	_, span := otel.GetTracerProvider().Tracer(OtelTracerName).Start(ctx, "input_image_conversion")
@@ -317,17 +325,18 @@ func convertInputImageToWriteableFormat(ctx context.Context, rc *ResolvedConfig)
 	defer span.End()
 
 	if rc.InputIsIso() {
-		inputIsoArtifacts, err := createIsoArtifactStoreFromIsoImage(rc.InputImage.Path,
-			filepath.Join(rc.BuildDirAbs, "from-iso"))
+		inputIsoArtifacts, inputIsoDistroHandler, err := createIsoArtifactStoreAndDistroHandlerFromIsoImage(
+			rc.InputImage.Path, filepath.Join(rc.BuildDirAbs, "from-iso"))
 		if err != nil {
-			return inputIsoArtifacts, fmt.Errorf("%w (source='%s'):\n%w", ErrCreateArtifactsStore, rc.InputImage.Path, err)
+			return inputIsoArtifacts, nil,
+				fmt.Errorf("%w (source='%s'):\n%w", ErrCreateArtifactsStore, rc.InputImage.Path, err)
 		}
 
 		var liveosConfig LiveOSConfig
 		liveosConfig, convertInitramfsType, err := buildLiveOSConfig(inputIsoArtifacts, rc.Iso, rc.Pxe,
 			rc.OutputImageFormat)
 		if err != nil {
-			return nil, fmt.Errorf("%w:\n%w", ErrBuildLiveOSConfig, err)
+			return nil, nil, fmt.Errorf("%w:\n%w", ErrBuildLiveOSConfig, err)
 		}
 
 		// Check if the user is changing the kdump boot files configuration.
@@ -343,20 +352,20 @@ func convertInputImageToWriteableFormat(ctx context.Context, rc *ResolvedConfig)
 		if rebuildFullOsImage {
 			err = createWriteableImageFromArtifacts(rc.BuildDirAbs, inputIsoArtifacts, rc.RawImageFile)
 			if err != nil {
-				return nil, fmt.Errorf("%w:\n%w", ErrCreateWriteableImage, err)
+				return nil, nil, fmt.Errorf("%w:\n%w", ErrCreateWriteableImage, err)
 			}
 		}
 
-		return inputIsoArtifacts, nil
+		return inputIsoArtifacts, inputIsoDistroHandler, nil
 	} else {
 		logger.Log.Infof("Creating raw base image: %s", rc.RawImageFile)
 
 		_, err := convertImageToRaw(rc.InputImage.Path, rc.RawImageFile)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 
-		return nil, nil
+		return nil, nil, nil
 	}
 }
 

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoartifactstore.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoartifactstore.go
@@ -449,7 +449,8 @@ func createIsoInfoStoreFromMountedImage(buildDir string, imageRootDir string, di
 	return infoStore, nil
 }
 
-func createIsoFilesStoreFromIsoImage(isoImageFile, storeDir string) (filesStore *IsoFilesStore, err error) {
+func createIsoFilesStoreAndDistroHandlerFromIsoImage(isoImageFile, storeDir string,
+) (filesStore *IsoFilesStore, distroHandler DistroHandler, err error) {
 	artifactsDir := filepath.Join(storeDir, "artifacts")
 
 	filesStore = &IsoFilesStore{
@@ -459,12 +460,12 @@ func createIsoFilesStoreFromIsoImage(isoImageFile, storeDir string) (filesStore 
 
 	err = extractIsoImageContents(storeDir, isoImageFile, filesStore.artifactsDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to extract iso contents from input iso file (%s):\n%w", isoImageFile, err)
+		return nil, nil, fmt.Errorf("failed to extract iso contents from input iso file (%s):\n%w", isoImageFile, err)
 	}
 
 	isoFiles, err := file.EnumerateDirFiles(artifactsDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to enumerate expanded iso files under %s:\n%w", artifactsDir, err)
+		return nil, nil, fmt.Errorf("failed to enumerate expanded iso files under %s:\n%w", artifactsDir, err)
 	}
 
 	filesStore.additionalFiles = make(map[string]string)
@@ -475,7 +476,7 @@ func createIsoFilesStoreFromIsoImage(isoImageFile, storeDir string) (filesStore 
 	squashfsPath := filepath.Join(artifactsDir, liveOSImagePath)
 	squashfsExists, err := file.PathExists(squashfsPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check for squashfs at (%s):\n%w", squashfsPath, err)
+		return nil, nil, fmt.Errorf("failed to check for squashfs at (%s):\n%w", squashfsPath, err)
 	}
 
 	// A bootstrap ISO carries a squashfs root plus per-kernel dracut initrds, while a full-OS ISO has no squashfs and
@@ -495,27 +496,26 @@ func createIsoFilesStoreFromIsoImage(isoImageFile, storeDir string) (filesStore 
 			}
 		}
 		if initrdPath == "" {
-			return nil, fmt.Errorf("bootstrap ISO has no per-kernel initrd")
+			return nil, nil, fmt.Errorf("bootstrap ISO has no per-kernel initrd")
 		}
 	} else {
 		initrdPath = filepath.Join(artifactsDir, isoInitrdPath)
 		initrdExists, err := file.PathExists(initrdPath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to check for initrd at (%s):\n%w", initrdPath, err)
+			return nil, nil, fmt.Errorf("failed to check for initrd at (%s):\n%w", initrdPath, err)
 		}
 		if !initrdExists {
-			return nil, fmt.Errorf("full OS ISO has no initrd at expected path (%s)", initrdPath)
+			return nil, nil, fmt.Errorf("full OS ISO has no initrd at expected path (%s)", initrdPath)
 		}
 	}
 
-	distroHandler, err := NewDistroHandlerFromInitrd(initrdPath)
+	distroHandler, err = NewDistroHandlerFromInitrd(initrdPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to detect distro from initrd (%s):\n%w", initrdPath, err)
+		return nil, nil, fmt.Errorf("failed to detect distro from initrd (%s):\n%w", initrdPath, err)
 	}
-
 	bootFilesConfig, err := distroHandler.GetBootArchConfig()
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	isoBootBinaryPath := bootFilesConfig.isoBootBinaryPath
 	isoGrubBinaryPath := bootFilesConfig.isoGrubBinaryPath
@@ -568,7 +568,7 @@ func createIsoFilesStoreFromIsoImage(isoImageFile, storeDir string) (filesStore 
 		}
 	}
 
-	return filesStore, nil
+	return filesStore, distroHandler, nil
 }
 
 func createIsoInfoStoreFromIsoImage(savedConfigFile string) (infoStore *IsoInfoStore, err error) {
@@ -616,29 +616,30 @@ func createIsoArtifactStoreFromMountedImage(inputArtifactsStore *IsoArtifactsSto
 	return artifactStore, nil
 }
 
-func createIsoArtifactStoreFromIsoImage(isoImageFile, storeDir string) (artifactStore *IsoArtifactsStore, err error) {
+func createIsoArtifactStoreAndDistroHandlerFromIsoImage(isoImageFile, storeDir string,
+) (artifactStore *IsoArtifactsStore, distroHandler DistroHandler, err error) {
 	logger.Log.Debugf("Creating ISO store (%s) from (%s)", storeDir, isoImageFile)
 
 	err = os.MkdirAll(storeDir, os.ModePerm)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create folder %s:\n%w", storeDir, err)
+		return nil, nil, fmt.Errorf("failed to create folder %s:\n%w", storeDir, err)
 	}
 
 	artifactStore = &IsoArtifactsStore{}
 
-	filesStore, err := createIsoFilesStoreFromIsoImage(isoImageFile, storeDir)
+	filesStore, distroHandler, err := createIsoFilesStoreAndDistroHandlerFromIsoImage(isoImageFile, storeDir)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	artifactStore.files = filesStore
 
 	infoStore, err := createIsoInfoStoreFromIsoImage(filesStore.savedConfigsFilePath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	artifactStore.info = infoStore
 
-	return artifactStore, nil
+	return artifactStore, distroHandler, nil
 }
 
 func fileExistsToString(filePath string) string {

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoartifactstore.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoartifactstore.go
@@ -449,7 +449,7 @@ func createIsoInfoStoreFromMountedImage(buildDir string, imageRootDir string, di
 	return infoStore, nil
 }
 
-func createIsoFilesStoreAndDistroHandlerFromIsoImage(isoImageFile, storeDir string,
+func createIsoFilesStoreFromIsoImage(isoImageFile, storeDir string,
 ) (filesStore *IsoFilesStore, distroHandler DistroHandler, err error) {
 	artifactsDir := filepath.Join(storeDir, "artifacts")
 
@@ -616,7 +616,7 @@ func createIsoArtifactStoreFromMountedImage(inputArtifactsStore *IsoArtifactsSto
 	return artifactStore, nil
 }
 
-func createIsoArtifactStoreAndDistroHandlerFromIsoImage(isoImageFile, storeDir string,
+func createIsoArtifactStoreFromIsoImage(isoImageFile, storeDir string,
 ) (artifactStore *IsoArtifactsStore, distroHandler DistroHandler, err error) {
 	logger.Log.Debugf("Creating ISO store (%s) from (%s)", storeDir, isoImageFile)
 
@@ -627,7 +627,7 @@ func createIsoArtifactStoreAndDistroHandlerFromIsoImage(isoImageFile, storeDir s
 
 	artifactStore = &IsoArtifactsStore{}
 
-	filesStore, distroHandler, err := createIsoFilesStoreAndDistroHandlerFromIsoImage(isoImageFile, storeDir)
+	filesStore, distroHandler, err := createIsoFilesStoreFromIsoImage(isoImageFile, storeDir)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -285,7 +285,7 @@ func createLiveOSFromRawHelper(ctx context.Context, buildDir string, inputArtifa
 	// Update grub.cfg
 	err = updateGrubCfg(artifactsStore.files.isoGrubCfgPath, outputFormat, liveosConfig.initramfsType, disableSELinux,
 		updatedSavedConfigs, getKernelVersions(artifactsStore.files), artifactsStore.files.isoGrubCfgPath,
-		artifactsStore.files.pxeGrubCfgPath)
+		artifactsStore.files.pxeGrubCfgPath, distroHandler)
 	if err != nil {
 		return fmt.Errorf("failed to update grub.cfg:\n%w", err)
 	}
@@ -337,7 +337,7 @@ func createLiveOSFromRawHelper(ctx context.Context, buildDir string, inputArtifa
 	switch outputFormat {
 	case imagecustomizerapi.ImageFormatTypeIso:
 		err := createIsoImage(isoBuildDir, liveosConfig.initramfsType, artifactsStore.files,
-			liveosConfig.kdumpBootFiles, liveosConfig.additionalFiles, outputPath)
+			liveosConfig.kdumpBootFiles, liveosConfig.additionalFiles, outputPath, distroHandler)
 		if err != nil {
 			return fmt.Errorf("failed to create the Iso image\n%w", err)
 		}
@@ -379,7 +379,7 @@ func repackageLiveOSHelper(isoBuildDir string, liveosConfig LiveOSConfig, inputA
 	// Update grub.cfg
 	err = updateGrubCfg(inputArtifactsStore.files.isoGrubCfgPath, outputFormat, liveosConfig.initramfsType, disableSELinux,
 		updatedSavedConfigs, getKernelVersions(inputArtifactsStore.files), inputArtifactsStore.files.isoGrubCfgPath,
-		inputArtifactsStore.files.pxeGrubCfgPath)
+		inputArtifactsStore.files.pxeGrubCfgPath, distroHandler)
 	if err != nil {
 		return fmt.Errorf("failed to update grub.cfg:\n%w", err)
 	}
@@ -388,7 +388,7 @@ func repackageLiveOSHelper(isoBuildDir string, liveosConfig LiveOSConfig, inputA
 	switch outputFormat {
 	case imagecustomizerapi.ImageFormatTypeIso:
 		err := createIsoImage(isoBuildDir, liveosConfig.initramfsType, inputArtifactsStore.files,
-			liveosConfig.kdumpBootFiles, liveosConfig.additionalFiles, outputPath)
+			liveosConfig.kdumpBootFiles, liveosConfig.additionalFiles, outputPath, distroHandler)
 		if err != nil {
 			return fmt.Errorf("failed to create the Iso image\n%w", err)
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
@@ -25,12 +25,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// azl4IsoPxeUnsupportedError is the validation error returned by the
-// Azure Linux distro handler when ISO or PXE output is requested with
-// an Azure Linux 4.0 base image. ISO and PXE outputs are not supported
-// on Azure Linux 4.0; LiveOS tests expect this error in that case.
-const azl4IsoPxeUnsupportedError = "ISO and PXE output formats are not supported yet for Azure Linux 4.0 images"
-
 func createConfig(t *testing.T, baseImageVersion string, fileNames, kernelParameter string, initramfsType imagecustomizerapi.InitramfsImageType,
 	bootstrapFileUrl string, enlargeDisk, enableOsConfig, bootstrapPrereqs, twoKernels bool, kdumpBootFiles imagecustomizerapi.KdumpBootFilesType,
 	selinuxMode imagecustomizerapi.SELinuxMode,
@@ -39,7 +33,11 @@ func createConfig(t *testing.T, baseImageVersion string, fileNames, kernelParame
 
 	pkgsToInstall := []string{}
 	if bootstrapPrereqs {
-		pkgsToInstall = append(pkgsToInstall, "squashfs-tools", "tar", "device-mapper", "curl")
+		liveOSRequiredPackages := liveOSRequiredPackagesAzl3
+		if baseImageVersion == baseImageVersionAzl4 {
+			liveOSRequiredPackages = liveOSRequiredPackagesFedora
+		}
+		pkgsToInstall = append(pkgsToInstall, liveOSRequiredPackages...)
 	}
 	if selinuxMode != imagecustomizerapi.SELinuxModeDisabled {
 		pkgsToInstall = append(pkgsToInstall, "selinux-policy")
@@ -220,18 +218,17 @@ func ValidateLiveOSContent(t *testing.T, outputFormat imagecustomizerapi.ImageFo
 		verifyFilePermissions(t, os.FileMode(*additionalFile.Permissions), fullOSFilePath)
 	}
 
-	// Ensure grub.cfg file has the extra kernel command-line args.
-	grubCfgFilePath := filepath.Join(artifactsPath, grubCfgDir, isoGrubCfg)
-	grubCfgContents, err := file.Read(grubCfgFilePath)
-	assert.NoError(t, err, "read grub.cfg file")
+	// Ensure the kernel command line carries the extra kernel command-line args. Inline-grub distros keep these on
+	// the grub.cfg 'linux' lines; BLS distros (Azure Linux 4.0, Fedora) keep them on the BLS entry 'options' lines.
+	kernelEntryContent, kernelEntryKeyword := readLiveOSKernelEntryContent(t, artifactsPath)
 	for _, extraCommandLineParameter := range extraCommandLineParameters {
-		assert.Regexp(t, "linux.* "+extraCommandLineParameter+" ", grubCfgContents)
+		assert.Regexp(t, kernelEntryKeyword+".* "+extraCommandLineParameter+`\s`, kernelEntryContent)
 	}
 
 	// Check the saved-configs.yaml file.
 	savedConfigsFilePath := filepath.Join(artifactsPath, savedConfigsDir, savedConfigsFileName)
 	savedConfigs := &SavedConfigs{}
-	err = imagecustomizerapi.UnmarshalAndValidateYamlFile(savedConfigsFilePath, savedConfigs)
+	err := imagecustomizerapi.UnmarshalAndValidateYamlFile(savedConfigsFilePath, savedConfigs)
 	assert.NoErrorf(t, err, "read (%s) file", savedConfigsFilePath)
 	for _, extraCommandLineParameter := range extraCommandLineParameters {
 		assert.Contains(t, savedConfigs.LiveOS.KernelCommandLine.ExtraCommandLine, extraCommandLineParameter)
@@ -399,7 +396,6 @@ func ValidatePxeContent(t *testing.T, outputFormat imagecustomizerapi.ImageForma
 
 func VerifyBootstrapPXEArtifacts(t *testing.T, packageInfo *PackageVersionInformation, outImageFileName, isoMountDir, pxeBaseUrl string) {
 	var err error
-	pxeKernelIpArg := "linux.* ip=dhcp "
 
 	pxeImageFileUrl := ""
 	if strings.HasSuffix(pxeBaseUrl, ".iso") {
@@ -409,10 +405,6 @@ func VerifyBootstrapPXEArtifacts(t *testing.T, packageInfo *PackageVersionInform
 		assert.NoError(t, err)
 	}
 
-	pxeKernelRootArg := "linux.* root=live:" + pxeImageFileUrl
-	pxeKernelRootArg = strings.ReplaceAll(pxeKernelRootArg, "/", "\\/")
-	pxeKernelRootArg = strings.ReplaceAll(pxeKernelRootArg, ":", "\\:")
-
 	// Check if PXE support is present in the Dracut package version in use.
 	err = verifyDracutPXESupport(packageInfo)
 	if err != nil {
@@ -421,12 +413,42 @@ func VerifyBootstrapPXEArtifacts(t *testing.T, packageInfo *PackageVersionInform
 		return
 	}
 
-	// Ensure grub-pxe.cfg file exists and has the pxe-specific command-line args.
-	pxeGrubCfgFilePath := filepath.Join(isoMountDir, "/boot/grub2/grub.cfg")
-	pxeGrubCfgContents, err := file.Read(pxeGrubCfgFilePath)
+	pxeKernelEntryContent, pxeKernelEntryKeyword := readLiveOSKernelEntryContent(t, isoMountDir)
+
+	pxeKernelIpArg := pxeKernelEntryKeyword + ".* ip=dhcp "
+
+	pxeKernelRootArg := pxeKernelEntryKeyword + ".* root=live:" + pxeImageFileUrl
+	pxeKernelRootArg = strings.ReplaceAll(pxeKernelRootArg, "/", "\\/")
+	pxeKernelRootArg = strings.ReplaceAll(pxeKernelRootArg, ":", "\\:")
+
+	assert.Regexp(t, pxeKernelIpArg, pxeKernelEntryContent)
+	assert.Regexp(t, pxeKernelRootArg, pxeKernelEntryContent)
+}
+
+// readLiveOSKernelEntryContent returns the text that carries the LiveOS kernel command line under artifactsPath,
+// along with the grub keyword that introduces it. For BLS distros (Azure Linux 4.0, Fedora) this is the concatenation
+// of the /boot/loader/entries/*.conf files and the keyword is "options"; otherwise it is the grub.cfg content and the
+// keyword is "linux".
+func readLiveOSKernelEntryContent(t *testing.T, artifactsPath string) (string, string) {
+	blsEntriesDir := filepath.Join(artifactsPath, "boot/loader/entries")
+	blsEntries, err := os.ReadDir(blsEntriesDir)
+	if err == nil && len(blsEntries) > 0 {
+		var builder strings.Builder
+		for _, entry := range blsEntries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".conf") {
+				continue
+			}
+			entryContent, readErr := file.Read(filepath.Join(blsEntriesDir, entry.Name()))
+			assert.NoError(t, readErr, "read BLS entry %s", entry.Name())
+			builder.WriteString(entryContent)
+			builder.WriteString("\n")
+		}
+		return builder.String(), "options"
+	}
+
+	grubCfgContents, err := file.Read(filepath.Join(artifactsPath, grubCfgDir, isoGrubCfg))
 	assert.NoError(t, err, "read grub.cfg file")
-	assert.Regexp(t, pxeKernelIpArg, pxeGrubCfgContents)
-	assert.Regexp(t, pxeKernelRootArg, pxeGrubCfgContents)
+	return grubCfgContents, "linux"
 }
 
 func TestCustomizeImageLiveOSKeepKdumpFilesA(t *testing.T) {
@@ -468,10 +490,6 @@ func testCustomizeImageLiveOSKeepKdumpFilesA(t *testing.T, baseImageInfo testBas
 
 	err := basicCustomizeImage(t.Context(), buildDir, testDir, configA0, baseImage, outImageFilePath,
 		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
-	if baseImageInfo.Version == baseImageVersionAzl4 {
-		assert.ErrorContains(t, err, azl4IsoPxeUnsupportedError)
-		return
-	}
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -590,10 +608,6 @@ func testCustomizeImageLiveOSKeepKdumpFilesBC(t *testing.T, baseImageInfo testBa
 
 	err := basicCustomizeImage(t.Context(), buildDir, testDir, configB, baseImage, outImageFilePath,
 		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
-	if baseImageInfo.Version == baseImageVersionAzl4 {
-		assert.ErrorContains(t, err, azl4IsoPxeUnsupportedError)
-		return
-	}
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -664,10 +678,7 @@ func testCustomizeImageLiveOSMultiKernel(t *testing.T, baseImageInfo testBaseIma
 		if !assert.ErrorContains(t, err, "unsupported number of kernels") {
 			return
 		}
-	case baseImageVersionAzl4:
-		assert.ErrorContains(t, err, azl4IsoPxeUnsupportedError)
 	default:
-		// Azl3 should succeed.
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -710,10 +721,6 @@ func testCustomizeImageLiveOSInitramfs1Helper(t *testing.T, baseImageInfo testBa
 	// vhdx {raw} to ISO {bootstrap}, selinux enforcing + bootstrap prereqs
 	err := basicCustomizeImage(t.Context(), buildDir, testDir, configA, baseImage, outImageFilePath,
 		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
-	if baseImageInfo.Version == baseImageVersionAzl4 {
-		assert.ErrorContains(t, err, azl4IsoPxeUnsupportedError)
-		return
-	}
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -769,10 +776,6 @@ func TestCustomizeImageLiveOSInitramfs2(t *testing.T) {
 
 	err := basicCustomizeImage(t.Context(), buildDir, testDir, configA, baseImage, outImageFilePath,
 		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
-	if baseImageInfo.Version == baseImageVersionAzl4 {
-		assert.ErrorContains(t, err, azl4IsoPxeUnsupportedError)
-		return
-	}
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -831,10 +834,6 @@ func TestCustomizeImageLiveOSInitramfs3(t *testing.T) {
 
 	err := basicCustomizeImage(t.Context(), buildDir, testDir, configA, baseImage, outImageFilePath,
 		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
-	if baseImageInfo.Version == baseImageVersionAzl4 {
-		assert.ErrorContains(t, err, azl4IsoPxeUnsupportedError)
-		return
-	}
 	assert.ErrorContains(t, err, "selinux is not supported for full OS initramfs image")
 }
 
@@ -861,7 +860,7 @@ func TestCustomizeImageLiveOSPxe1(t *testing.T) {
 	err := basicCustomizeImage(t.Context(), buildDir, testDir, config, baseImage, outImageFilePath,
 		string(imagecustomizerapi.ImageFormatTypePxeTar), baseImageInfo.PreviewFeatures)
 	if baseImageInfo.Version == baseImageVersionAzl4 {
-		assert.ErrorContains(t, err, azl4IsoPxeUnsupportedError)
+		assert.ErrorContains(t, err, azl4PxeUnsupportedError)
 		return
 	}
 	if !assert.NoError(t, err) {
@@ -889,7 +888,7 @@ func TestCustomizeImageLiveOSPxe2(t *testing.T) {
 	err := basicCustomizeImage(t.Context(), buildDir, testDir, config, baseImage, outImageFilePath,
 		string(imagecustomizerapi.ImageFormatTypePxeTar), baseImageInfo.PreviewFeatures)
 	if baseImageInfo.Version == baseImageVersionAzl4 {
-		assert.ErrorContains(t, err, azl4IsoPxeUnsupportedError)
+		assert.ErrorContains(t, err, azl4PxeUnsupportedError)
 		return
 	}
 	if !assert.NoError(t, err) {
@@ -901,6 +900,10 @@ func TestCustomizeImageLiveOSPxe2(t *testing.T) {
 
 func TestCustomizeImageLiveOSIsoNoShimEfi(t *testing.T) {
 	for _, baseImageInfo := range baseImageAzureLinuxAll {
+		// Azure Linux 4.0's shim package cannot be removed (it's a protected package).
+		if baseImageInfo.Version == baseImageVersionAzl4 {
+			continue
+		}
 		t.Run(baseImageInfo.Name, func(t *testing.T) {
 			testCustomizeImageLiveOSIsoNoShimEfi(t, "TestCustomizeImageLiveCdIsoNoShimEfi"+baseImageInfo.Name, baseImageInfo)
 		})
@@ -936,10 +939,6 @@ func testCustomizeImageLiveOSIsoNoShimEfi(t *testing.T, testName string, baseIma
 	err := basicCustomizeImage(t.Context(), buildDir, testDir, config, baseImage, outImageFilePath,
 		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
 	assert.Error(t, err)
-	if baseImageInfo.Version == baseImageVersionAzl4 {
-		assert.ErrorContains(t, err, azl4IsoPxeUnsupportedError)
-		return
-	}
 	assert.ErrorContains(t, err, "failed to find the boot efi file")
 }
 
@@ -990,9 +989,5 @@ func TestCustomizeImageLiveOSIsoNoGrubEfi(t *testing.T) {
 	err := basicCustomizeImage(t.Context(), buildDir, testDir, config, baseImage, outImageFilePath,
 		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
 	assert.Error(t, err)
-	if baseImageInfo.Version == baseImageVersionAzl4 {
-		assert.ErrorContains(t, err, azl4IsoPxeUnsupportedError)
-		return
-	}
 	assert.ErrorContains(t, err, "failed to find the grub efi file")
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
@@ -190,7 +190,7 @@ func VerifyBootstrappedImageExists(t *testing.T, initramfsType imagecustomizerap
 }
 
 func ValidateLiveOSContent(t *testing.T, outputFormat imagecustomizerapi.ImageFormatType, config *imagecustomizerapi.Config,
-	testTempDir string, artifactsPath, bootstrappedImage string,
+	testTempDir string, artifactsPath, bootstrappedImage string, baseImageVersion string,
 ) {
 	var additionalFiles imagecustomizerapi.AdditionalFileList
 	var extraCommandLineParameters []string
@@ -220,7 +220,7 @@ func ValidateLiveOSContent(t *testing.T, outputFormat imagecustomizerapi.ImageFo
 
 	// Ensure the kernel command line carries the extra kernel command-line args. Inline-grub distros keep these on
 	// the grub.cfg 'linux' lines; BLS distros (Azure Linux 4.0, Fedora) keep them on the BLS entry 'options' lines.
-	kernelEntryContent, kernelEntryKeyword := readLiveOSKernelEntryContent(t, artifactsPath)
+	kernelEntryContent, kernelEntryKeyword := readLiveOSKernelEntryContent(t, artifactsPath, baseImageVersion)
 	for _, extraCommandLineParameter := range extraCommandLineParameters {
 		assert.Regexp(t, kernelEntryKeyword+".* "+extraCommandLineParameter+`\s`, kernelEntryContent)
 	}
@@ -248,7 +248,7 @@ func ValidateLiveOSContent(t *testing.T, outputFormat imagecustomizerapi.ImageFo
 
 	if outputFormat == "pxe" {
 		if initramfsType == imagecustomizerapi.InitramfsImageTypeBootstrap {
-			VerifyBootstrapPXEArtifacts(t, savedConfigs.OS.DracutPackageInfo, filepath.Base(bootstrappedImage), artifactsPath, pxeUrlBase)
+			VerifyBootstrapPXEArtifacts(t, savedConfigs.OS.DracutPackageInfo, filepath.Base(bootstrappedImage), artifactsPath, pxeUrlBase, baseImageVersion)
 		}
 	}
 }
@@ -356,7 +356,7 @@ func VerifyFullOSContents(t *testing.T, testTempDir, artifactsPath string, outpu
 	}
 }
 
-func ValidateIsoContent(t *testing.T, config *imagecustomizerapi.Config, testTempDir string, initramfsType imagecustomizerapi.InitramfsImageType, outImageFilePath string) {
+func ValidateIsoContent(t *testing.T, config *imagecustomizerapi.Config, testTempDir string, initramfsType imagecustomizerapi.InitramfsImageType, outImageFilePath string, baseImageVersion string) {
 	isoImageLoopDevice, err := safeloopback.NewLoopback(outImageFilePath)
 	if !assert.NoError(t, err) {
 		return
@@ -371,10 +371,10 @@ func ValidateIsoContent(t *testing.T, config *imagecustomizerapi.Config, testTem
 	}
 	defer isoImageMount.Close()
 
-	ValidateLiveOSContent(t, imagecustomizerapi.ImageFormatTypeIso, config, testTempDir, isoMountDir, "" /*bootstrappedImage*/)
+	ValidateLiveOSContent(t, imagecustomizerapi.ImageFormatTypeIso, config, testTempDir, isoMountDir, "" /*bootstrappedImage*/, baseImageVersion)
 }
 
-func ValidatePxeContent(t *testing.T, outputFormat imagecustomizerapi.ImageFormatType, config *imagecustomizerapi.Config, testTempDir, outImageFilePath string) {
+func ValidatePxeContent(t *testing.T, outputFormat imagecustomizerapi.ImageFormatType, config *imagecustomizerapi.Config, testTempDir, outImageFilePath string, baseImageVersion string) {
 	pxeArtifactsPath := ""
 	if strings.HasSuffix(outImageFilePath, ".tar.gz") {
 		pxeArtifactsPath = filepath.Join(testTempDir, "pxe-artifacts")
@@ -391,10 +391,10 @@ func ValidatePxeContent(t *testing.T, outputFormat imagecustomizerapi.ImageForma
 		bootstrappedImage = filepath.Join(pxeArtifactsPath, defaultIsoImageName)
 	}
 
-	ValidateLiveOSContent(t, outputFormat, config, testTempDir, pxeArtifactsPath, bootstrappedImage)
+	ValidateLiveOSContent(t, outputFormat, config, testTempDir, pxeArtifactsPath, bootstrappedImage, baseImageVersion)
 }
 
-func VerifyBootstrapPXEArtifacts(t *testing.T, packageInfo *PackageVersionInformation, outImageFileName, isoMountDir, pxeBaseUrl string) {
+func VerifyBootstrapPXEArtifacts(t *testing.T, packageInfo *PackageVersionInformation, outImageFileName, isoMountDir, pxeBaseUrl string, baseImageVersion string) {
 	var err error
 
 	pxeImageFileUrl := ""
@@ -413,7 +413,7 @@ func VerifyBootstrapPXEArtifacts(t *testing.T, packageInfo *PackageVersionInform
 		return
 	}
 
-	pxeKernelEntryContent, pxeKernelEntryKeyword := readLiveOSKernelEntryContent(t, isoMountDir)
+	pxeKernelEntryContent, pxeKernelEntryKeyword := readLiveOSKernelEntryContent(t, isoMountDir, baseImageVersion)
 
 	pxeKernelIpArg := pxeKernelEntryKeyword + ".* ip=dhcp "
 
@@ -425,15 +425,16 @@ func VerifyBootstrapPXEArtifacts(t *testing.T, packageInfo *PackageVersionInform
 	assert.Regexp(t, pxeKernelRootArg, pxeKernelEntryContent)
 }
 
-// readLiveOSKernelEntryContent returns the text that carries the LiveOS kernel command line under artifactsPath,
-// along with the grub keyword that introduces it. For BLS distros (Azure Linux 4.0, Fedora) this is the concatenation
-// of the /boot/loader/entries/*.conf files and the keyword is "options"; otherwise it is the grub.cfg content and the
-// keyword is "linux".
-func readLiveOSKernelEntryContent(t *testing.T, artifactsPath string) (string, string) {
-	blsEntriesDir := filepath.Join(artifactsPath, "boot/loader/entries")
-	blsEntries, err := os.ReadDir(blsEntriesDir)
-	if err == nil && len(blsEntries) > 0 {
+// readLiveOSKernelEntryContent returns the text that carries the LiveOS kernel command line under artifactsPath, along
+// with the grub keyword that introduces it.
+func readLiveOSKernelEntryContent(t *testing.T, artifactsPath string, baseImageVersion string) (string, string) {
+	if baseImageVersion == baseImageVersionAzl4 {
+		blsEntriesDir := filepath.Join(artifactsPath, "boot/loader/entries")
+		blsEntries, err := os.ReadDir(blsEntriesDir)
+		assert.NoError(t, err, "read BLS entries directory")
+
 		var builder strings.Builder
+		entryCount := 0
 		for _, entry := range blsEntries {
 			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".conf") {
 				continue
@@ -442,7 +443,9 @@ func readLiveOSKernelEntryContent(t *testing.T, artifactsPath string) (string, s
 			assert.NoError(t, readErr, "read BLS entry %s", entry.Name())
 			builder.WriteString(entryContent)
 			builder.WriteString("\n")
+			entryCount++
 		}
+		assert.Greater(t, entryCount, 0, "expected at least one BLS entry under %s", blsEntriesDir)
 		return builder.String(), "options"
 	}
 
@@ -494,7 +497,7 @@ func testCustomizeImageLiveOSKeepKdumpFilesA(t *testing.T, baseImageInfo testBas
 		return
 	}
 
-	ValidateIsoContent(t, configA0, testTempDir, imagecustomizerapi.InitramfsImageTypeFullOS, outImageFilePath)
+	ValidateIsoContent(t, configA0, testTempDir, imagecustomizerapi.InitramfsImageTypeFullOS, outImageFilePath, baseImageInfo.Version)
 
 	// Case A1:
 	//       Input: iso with kdumpBootFiles=keep
@@ -612,7 +615,7 @@ func testCustomizeImageLiveOSKeepKdumpFilesBC(t *testing.T, baseImageInfo testBa
 		return
 	}
 
-	ValidateIsoContent(t, configB, testTempDir, imagecustomizerapi.InitramfsImageTypeFullOS, outImageFilePath)
+	ValidateIsoContent(t, configB, testTempDir, imagecustomizerapi.InitramfsImageTypeFullOS, outImageFilePath, baseImageInfo.Version)
 
 	// Case C:
 	//       Input: base vhdx
@@ -634,7 +637,7 @@ func testCustomizeImageLiveOSKeepKdumpFilesBC(t *testing.T, baseImageInfo testBa
 		return
 	}
 
-	ValidateIsoContent(t, configC, testTempDir, imagecustomizerapi.InitramfsImageTypeFullOS, outImageFilePath)
+	ValidateIsoContent(t, configC, testTempDir, imagecustomizerapi.InitramfsImageTypeFullOS, outImageFilePath, baseImageInfo.Version)
 }
 
 func TestCustomizeImageLiveOSMultiKernel(t *testing.T) {
@@ -725,7 +728,7 @@ func testCustomizeImageLiveOSInitramfs1Helper(t *testing.T, baseImageInfo testBa
 		return
 	}
 
-	ValidateIsoContent(t, configA, testTempDir, imagecustomizerapi.InitramfsImageTypeBootstrap, outImageFilePath)
+	ValidateIsoContent(t, configA, testTempDir, imagecustomizerapi.InitramfsImageTypeBootstrap, outImageFilePath, baseImageInfo.Version)
 
 	// ISO  {bootstrap} to ISO {bootstrap}, with no OS changes
 	configB := createConfig(t, baseImageInfo.Version, "b.txt", "rd.debug", imagecustomizerapi.InitramfsImageTypeBootstrap,
@@ -738,7 +741,7 @@ func testCustomizeImageLiveOSInitramfs1Helper(t *testing.T, baseImageInfo testBa
 		return
 	}
 
-	ValidateIsoContent(t, configB, testTempDir, imagecustomizerapi.InitramfsImageTypeBootstrap, outImageFilePath)
+	ValidateIsoContent(t, configB, testTempDir, imagecustomizerapi.InitramfsImageTypeBootstrap, outImageFilePath, baseImageInfo.Version)
 
 	// - ISO {bootstrap} to ISO {full-os}, with selinux disabled
 	configC := createConfig(t, baseImageInfo.Version, "c.txt", "rd.shell", imagecustomizerapi.InitramfsImageTypeFullOS,
@@ -751,7 +754,7 @@ func testCustomizeImageLiveOSInitramfs1Helper(t *testing.T, baseImageInfo testBa
 		return
 	}
 
-	ValidateIsoContent(t, configC, testTempDir, imagecustomizerapi.InitramfsImageTypeFullOS, outImageFilePath)
+	ValidateIsoContent(t, configC, testTempDir, imagecustomizerapi.InitramfsImageTypeFullOS, outImageFilePath, baseImageInfo.Version)
 }
 
 // Tests:
@@ -780,7 +783,7 @@ func TestCustomizeImageLiveOSInitramfs2(t *testing.T) {
 		return
 	}
 
-	ValidateIsoContent(t, configA, testTempDir, imagecustomizerapi.InitramfsImageTypeFullOS, outImageFilePath)
+	ValidateIsoContent(t, configA, testTempDir, imagecustomizerapi.InitramfsImageTypeFullOS, outImageFilePath, baseImageInfo.Version)
 
 	// ISO  {full-os} to ISO {full-os}, with selinux disabled
 	configB := createConfig(t, baseImageInfo.Version, "b.txt", "rd.shell", imagecustomizerapi.InitramfsImageTypeFullOS,
@@ -793,7 +796,7 @@ func TestCustomizeImageLiveOSInitramfs2(t *testing.T) {
 		return
 	}
 
-	ValidateIsoContent(t, configB, testTempDir, imagecustomizerapi.InitramfsImageTypeFullOS, outImageFilePath)
+	ValidateIsoContent(t, configB, testTempDir, imagecustomizerapi.InitramfsImageTypeFullOS, outImageFilePath, baseImageInfo.Version)
 
 	// - ISO {full-os} to ISO {bootstrap}, with selinux enforcing
 
@@ -813,7 +816,7 @@ func TestCustomizeImageLiveOSInitramfs2(t *testing.T) {
 		return
 	}
 
-	ValidateIsoContent(t, configC, testTempDir, imagecustomizerapi.InitramfsImageTypeBootstrap, outImageFilePath)
+	ValidateIsoContent(t, configC, testTempDir, imagecustomizerapi.InitramfsImageTypeBootstrap, outImageFilePath, baseImageInfo.Version)
 }
 
 // Tests:
@@ -860,14 +863,14 @@ func TestCustomizeImageLiveOSPxe1(t *testing.T) {
 	err := basicCustomizeImage(t.Context(), buildDir, testDir, config, baseImage, outImageFilePath,
 		string(imagecustomizerapi.ImageFormatTypePxeTar), baseImageInfo.PreviewFeatures)
 	if baseImageInfo.Version == baseImageVersionAzl4 {
-		assert.ErrorContains(t, err, azl4PxeUnsupportedError)
+		assert.ErrorIs(t, err, ErrAzureLinux4PxeUnsupported)
 		return
 	}
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	ValidatePxeContent(t, imagecustomizerapi.ImageFormatTypePxeTar, config, testTempDir, outImageFilePath)
+	ValidatePxeContent(t, imagecustomizerapi.ImageFormatTypePxeTar, config, testTempDir, outImageFilePath, baseImageInfo.Version)
 }
 
 // Tests:
@@ -888,14 +891,14 @@ func TestCustomizeImageLiveOSPxe2(t *testing.T) {
 	err := basicCustomizeImage(t.Context(), buildDir, testDir, config, baseImage, outImageFilePath,
 		string(imagecustomizerapi.ImageFormatTypePxeTar), baseImageInfo.PreviewFeatures)
 	if baseImageInfo.Version == baseImageVersionAzl4 {
-		assert.ErrorContains(t, err, azl4PxeUnsupportedError)
+		assert.ErrorIs(t, err, ErrAzureLinux4PxeUnsupported)
 		return
 	}
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	ValidatePxeContent(t, imagecustomizerapi.ImageFormatTypePxeTar, config, testTempDir, outImageFilePath)
+	ValidatePxeContent(t, imagecustomizerapi.ImageFormatTypePxeTar, config, testTempDir, outImageFilePath, baseImageInfo.Version)
 }
 
 func TestCustomizeImageLiveOSIsoNoShimEfi(t *testing.T) {

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
@@ -190,7 +190,7 @@ func VerifyBootstrappedImageExists(t *testing.T, initramfsType imagecustomizerap
 }
 
 func ValidateLiveOSContent(t *testing.T, outputFormat imagecustomizerapi.ImageFormatType, config *imagecustomizerapi.Config,
-	testTempDir string, artifactsPath, bootstrappedImage string, baseImageVersion string,
+	testTempDir string, artifactsPath, bootstrappedImage string, baseImageInfo testBaseImageInfo,
 ) {
 	var additionalFiles imagecustomizerapi.AdditionalFileList
 	var extraCommandLineParameters []string
@@ -220,7 +220,7 @@ func ValidateLiveOSContent(t *testing.T, outputFormat imagecustomizerapi.ImageFo
 
 	// Ensure the kernel command line carries the extra kernel command-line args. Inline-grub distros keep these on
 	// the grub.cfg 'linux' lines; BLS distros (Azure Linux 4.0, Fedora) keep them on the BLS entry 'options' lines.
-	kernelEntryContent, kernelEntryKeyword := readLiveOSKernelEntryContent(t, artifactsPath, baseImageVersion)
+	kernelEntryContent, kernelEntryKeyword := readLiveOSKernelEntryContent(t, artifactsPath, baseImageInfo)
 	for _, extraCommandLineParameter := range extraCommandLineParameters {
 		assert.Regexp(t, kernelEntryKeyword+".* "+extraCommandLineParameter+`\s`, kernelEntryContent)
 	}
@@ -248,7 +248,7 @@ func ValidateLiveOSContent(t *testing.T, outputFormat imagecustomizerapi.ImageFo
 
 	if outputFormat == "pxe" {
 		if initramfsType == imagecustomizerapi.InitramfsImageTypeBootstrap {
-			VerifyBootstrapPXEArtifacts(t, savedConfigs.OS.DracutPackageInfo, filepath.Base(bootstrappedImage), artifactsPath, pxeUrlBase, baseImageVersion)
+			VerifyBootstrapPXEArtifacts(t, savedConfigs.OS.DracutPackageInfo, filepath.Base(bootstrappedImage), artifactsPath, pxeUrlBase, baseImageInfo)
 		}
 	}
 }
@@ -356,7 +356,7 @@ func VerifyFullOSContents(t *testing.T, testTempDir, artifactsPath string, outpu
 	}
 }
 
-func ValidateIsoContent(t *testing.T, config *imagecustomizerapi.Config, testTempDir string, initramfsType imagecustomizerapi.InitramfsImageType, outImageFilePath string, baseImageVersion string) {
+func ValidateIsoContent(t *testing.T, config *imagecustomizerapi.Config, testTempDir string, initramfsType imagecustomizerapi.InitramfsImageType, outImageFilePath string, baseImageInfo testBaseImageInfo) {
 	isoImageLoopDevice, err := safeloopback.NewLoopback(outImageFilePath)
 	if !assert.NoError(t, err) {
 		return
@@ -371,10 +371,10 @@ func ValidateIsoContent(t *testing.T, config *imagecustomizerapi.Config, testTem
 	}
 	defer isoImageMount.Close()
 
-	ValidateLiveOSContent(t, imagecustomizerapi.ImageFormatTypeIso, config, testTempDir, isoMountDir, "" /*bootstrappedImage*/, baseImageVersion)
+	ValidateLiveOSContent(t, imagecustomizerapi.ImageFormatTypeIso, config, testTempDir, isoMountDir, "" /*bootstrappedImage*/, baseImageInfo)
 }
 
-func ValidatePxeContent(t *testing.T, outputFormat imagecustomizerapi.ImageFormatType, config *imagecustomizerapi.Config, testTempDir, outImageFilePath string, baseImageVersion string) {
+func ValidatePxeContent(t *testing.T, outputFormat imagecustomizerapi.ImageFormatType, config *imagecustomizerapi.Config, testTempDir, outImageFilePath string, baseImageInfo testBaseImageInfo) {
 	pxeArtifactsPath := ""
 	if strings.HasSuffix(outImageFilePath, ".tar.gz") {
 		pxeArtifactsPath = filepath.Join(testTempDir, "pxe-artifacts")
@@ -391,10 +391,10 @@ func ValidatePxeContent(t *testing.T, outputFormat imagecustomizerapi.ImageForma
 		bootstrappedImage = filepath.Join(pxeArtifactsPath, defaultIsoImageName)
 	}
 
-	ValidateLiveOSContent(t, outputFormat, config, testTempDir, pxeArtifactsPath, bootstrappedImage, baseImageVersion)
+	ValidateLiveOSContent(t, outputFormat, config, testTempDir, pxeArtifactsPath, bootstrappedImage, baseImageInfo)
 }
 
-func VerifyBootstrapPXEArtifacts(t *testing.T, packageInfo *PackageVersionInformation, outImageFileName, isoMountDir, pxeBaseUrl string, baseImageVersion string) {
+func VerifyBootstrapPXEArtifacts(t *testing.T, packageInfo *PackageVersionInformation, outImageFileName, isoMountDir, pxeBaseUrl string, baseImageInfo testBaseImageInfo) {
 	var err error
 
 	pxeImageFileUrl := ""
@@ -413,7 +413,7 @@ func VerifyBootstrapPXEArtifacts(t *testing.T, packageInfo *PackageVersionInform
 		return
 	}
 
-	pxeKernelEntryContent, pxeKernelEntryKeyword := readLiveOSKernelEntryContent(t, isoMountDir, baseImageVersion)
+	pxeKernelEntryContent, pxeKernelEntryKeyword := readLiveOSKernelEntryContent(t, isoMountDir, baseImageInfo)
 
 	pxeKernelIpArg := pxeKernelEntryKeyword + ".* ip=dhcp "
 
@@ -427,8 +427,8 @@ func VerifyBootstrapPXEArtifacts(t *testing.T, packageInfo *PackageVersionInform
 
 // readLiveOSKernelEntryContent returns the text that carries the LiveOS kernel command line under artifactsPath, along
 // with the grub keyword that introduces it.
-func readLiveOSKernelEntryContent(t *testing.T, artifactsPath string, baseImageVersion string) (string, string) {
-	if baseImageVersion == baseImageVersionAzl4 {
+func readLiveOSKernelEntryContent(t *testing.T, artifactsPath string, baseImageInfo testBaseImageInfo) (string, string) {
+	if baseImageInfo.Version == baseImageVersionAzl4 {
 		blsEntriesDir := filepath.Join(artifactsPath, "boot/loader/entries")
 		blsEntries, err := os.ReadDir(blsEntriesDir)
 		assert.NoError(t, err, "read BLS entries directory")
@@ -497,7 +497,7 @@ func testCustomizeImageLiveOSKeepKdumpFilesA(t *testing.T, baseImageInfo testBas
 		return
 	}
 
-	ValidateIsoContent(t, configA0, testTempDir, imagecustomizerapi.InitramfsImageTypeFullOS, outImageFilePath, baseImageInfo.Version)
+	ValidateIsoContent(t, configA0, testTempDir, imagecustomizerapi.InitramfsImageTypeFullOS, outImageFilePath, baseImageInfo)
 
 	// Case A1:
 	//       Input: iso with kdumpBootFiles=keep
@@ -615,7 +615,7 @@ func testCustomizeImageLiveOSKeepKdumpFilesBC(t *testing.T, baseImageInfo testBa
 		return
 	}
 
-	ValidateIsoContent(t, configB, testTempDir, imagecustomizerapi.InitramfsImageTypeFullOS, outImageFilePath, baseImageInfo.Version)
+	ValidateIsoContent(t, configB, testTempDir, imagecustomizerapi.InitramfsImageTypeFullOS, outImageFilePath, baseImageInfo)
 
 	// Case C:
 	//       Input: base vhdx
@@ -637,7 +637,7 @@ func testCustomizeImageLiveOSKeepKdumpFilesBC(t *testing.T, baseImageInfo testBa
 		return
 	}
 
-	ValidateIsoContent(t, configC, testTempDir, imagecustomizerapi.InitramfsImageTypeFullOS, outImageFilePath, baseImageInfo.Version)
+	ValidateIsoContent(t, configC, testTempDir, imagecustomizerapi.InitramfsImageTypeFullOS, outImageFilePath, baseImageInfo)
 }
 
 func TestCustomizeImageLiveOSMultiKernel(t *testing.T) {
@@ -728,7 +728,7 @@ func testCustomizeImageLiveOSInitramfs1Helper(t *testing.T, baseImageInfo testBa
 		return
 	}
 
-	ValidateIsoContent(t, configA, testTempDir, imagecustomizerapi.InitramfsImageTypeBootstrap, outImageFilePath, baseImageInfo.Version)
+	ValidateIsoContent(t, configA, testTempDir, imagecustomizerapi.InitramfsImageTypeBootstrap, outImageFilePath, baseImageInfo)
 
 	// ISO  {bootstrap} to ISO {bootstrap}, with no OS changes
 	configB := createConfig(t, baseImageInfo.Version, "b.txt", "rd.debug", imagecustomizerapi.InitramfsImageTypeBootstrap,
@@ -741,7 +741,7 @@ func testCustomizeImageLiveOSInitramfs1Helper(t *testing.T, baseImageInfo testBa
 		return
 	}
 
-	ValidateIsoContent(t, configB, testTempDir, imagecustomizerapi.InitramfsImageTypeBootstrap, outImageFilePath, baseImageInfo.Version)
+	ValidateIsoContent(t, configB, testTempDir, imagecustomizerapi.InitramfsImageTypeBootstrap, outImageFilePath, baseImageInfo)
 
 	// - ISO {bootstrap} to ISO {full-os}, with selinux disabled
 	configC := createConfig(t, baseImageInfo.Version, "c.txt", "rd.shell", imagecustomizerapi.InitramfsImageTypeFullOS,
@@ -754,7 +754,7 @@ func testCustomizeImageLiveOSInitramfs1Helper(t *testing.T, baseImageInfo testBa
 		return
 	}
 
-	ValidateIsoContent(t, configC, testTempDir, imagecustomizerapi.InitramfsImageTypeFullOS, outImageFilePath, baseImageInfo.Version)
+	ValidateIsoContent(t, configC, testTempDir, imagecustomizerapi.InitramfsImageTypeFullOS, outImageFilePath, baseImageInfo)
 }
 
 // Tests:
@@ -783,7 +783,7 @@ func TestCustomizeImageLiveOSInitramfs2(t *testing.T) {
 		return
 	}
 
-	ValidateIsoContent(t, configA, testTempDir, imagecustomizerapi.InitramfsImageTypeFullOS, outImageFilePath, baseImageInfo.Version)
+	ValidateIsoContent(t, configA, testTempDir, imagecustomizerapi.InitramfsImageTypeFullOS, outImageFilePath, baseImageInfo)
 
 	// ISO  {full-os} to ISO {full-os}, with selinux disabled
 	configB := createConfig(t, baseImageInfo.Version, "b.txt", "rd.shell", imagecustomizerapi.InitramfsImageTypeFullOS,
@@ -796,7 +796,7 @@ func TestCustomizeImageLiveOSInitramfs2(t *testing.T) {
 		return
 	}
 
-	ValidateIsoContent(t, configB, testTempDir, imagecustomizerapi.InitramfsImageTypeFullOS, outImageFilePath, baseImageInfo.Version)
+	ValidateIsoContent(t, configB, testTempDir, imagecustomizerapi.InitramfsImageTypeFullOS, outImageFilePath, baseImageInfo)
 
 	// - ISO {full-os} to ISO {bootstrap}, with selinux enforcing
 
@@ -816,7 +816,7 @@ func TestCustomizeImageLiveOSInitramfs2(t *testing.T) {
 		return
 	}
 
-	ValidateIsoContent(t, configC, testTempDir, imagecustomizerapi.InitramfsImageTypeBootstrap, outImageFilePath, baseImageInfo.Version)
+	ValidateIsoContent(t, configC, testTempDir, imagecustomizerapi.InitramfsImageTypeBootstrap, outImageFilePath, baseImageInfo)
 }
 
 // Tests:
@@ -870,7 +870,7 @@ func TestCustomizeImageLiveOSPxe1(t *testing.T) {
 		return
 	}
 
-	ValidatePxeContent(t, imagecustomizerapi.ImageFormatTypePxeTar, config, testTempDir, outImageFilePath, baseImageInfo.Version)
+	ValidatePxeContent(t, imagecustomizerapi.ImageFormatTypePxeTar, config, testTempDir, outImageFilePath, baseImageInfo)
 }
 
 // Tests:
@@ -898,7 +898,7 @@ func TestCustomizeImageLiveOSPxe2(t *testing.T) {
 		return
 	}
 
-	ValidatePxeContent(t, imagecustomizerapi.ImageFormatTypePxeTar, config, testTempDir, outImageFilePath, baseImageInfo.Version)
+	ValidatePxeContent(t, imagecustomizerapi.ImageFormatTypePxeTar, config, testTempDir, outImageFilePath, baseImageInfo)
 }
 
 func TestCustomizeImageLiveOSIsoNoShimEfi(t *testing.T) {

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisogrub.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisogrub.go
@@ -5,6 +5,7 @@ package imagecustomizerlib
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/file"
@@ -13,7 +14,6 @@ import (
 )
 
 const (
-	searchCommandTemplate   = "search --label %s --set root"
 	rootValueLiveOSTemplate = "live:LABEL=%s"
 	rootValuePxeTemplate    = "live:%s"
 
@@ -31,10 +31,42 @@ const (
 	initrdPathAzl2Template  = "/boot/initrd.img-%s"
 )
 
+// updateLiveOSGrubCfgBLSForLiveOS applies the common LiveOS-compatibility edits for distros that use Boot Loader
+// Specification entries.
+func updateLiveOSGrubCfgBLSForLiveOS(grubCfgContent string, bootDir string,
+	initramfsType imagecustomizerapi.InitramfsImageType, disableSELinux bool, savedConfigs *SavedConfigs,
+) (string, error) {
+	grubCfgContent, err := replaceSearchCommandAll(grubCfgContent, isogenerator.DefaultVolumeId)
+	if err != nil {
+		return "", fmt.Errorf("failed to update the search command in the live OS grub.cfg:\n%w", err)
+	}
+
+	err = updateLiveOSBLSEntries(bootDir, initramfsType, disableSELinux, savedConfigs)
+	if err != nil {
+		return "", fmt.Errorf("failed to update the live OS BLS entries:\n%w", err)
+	}
+	return grubCfgContent, nil
+}
+
+// updateLiveOSGrubCfgBLSForIso applies the iso-specific root rewrite (root=live:LABEL for a bootstrap initramfs) to
+// the BLS .conf files under bootDir for BLS distros.
+func updateLiveOSGrubCfgBLSForIso(grubCfgContent string, bootDir string,
+	initramfsType imagecustomizerapi.InitramfsImageType,
+) (string, error) {
+	if initramfsType == imagecustomizerapi.InitramfsImageTypeBootstrap {
+		rootValue := fmt.Sprintf(rootValueLiveOSTemplate, isogenerator.DefaultVolumeId)
+		err := setLiveOSBLSEntriesRoot(bootDir, rootValue, nil)
+		if err != nil {
+			return "", fmt.Errorf("failed to update the root kernel argument in the iso BLS entries:\n%w", err)
+		}
+	}
+	return grubCfgContent, nil
+}
+
 func updateGrubCfgForLiveOS(inputContentString string, initramfsImageType imagecustomizerapi.InitramfsImageType,
-	disableSELinux bool, savedConfigs *SavedConfigs, kernelVersions []string) (string, error) {
-	searchCommand := fmt.Sprintf(searchCommandTemplate, isogenerator.DefaultVolumeId)
-	inputContentString, err := replaceSearchCommandAll(inputContentString, searchCommand)
+	disableSELinux bool, savedConfigs *SavedConfigs, kernelVersions []string,
+) (string, error) {
+	inputContentString, err := replaceSearchCommandAll(inputContentString, isogenerator.DefaultVolumeId)
 	if err != nil {
 		return "", fmt.Errorf("failed to update the search command in the live OS grub.cfg:\n%w", err)
 	}
@@ -151,7 +183,8 @@ func updateGrubCfgForIso(inputContentString string, initramfsImageType imagecust
 }
 
 func updateGrubCfgForPxe(inputContentString string, initramfsImageType imagecustomizerapi.InitramfsImageType, bootstrapBaseUrl string,
-	bootstrapFileUrl string) (string, error) {
+	bootstrapFileUrl string,
+) (string, error) {
 	// remove 'search' commands from PXE grub.cfg because it is not needed.
 	inputContentString, err := removeCommandAll(inputContentString, "search")
 	if err != nil {
@@ -184,7 +217,9 @@ func updateGrubCfgForPxe(inputContentString string, initramfsImageType imagecust
 // This function generates both the iso and the pxe versions of the grub so
 // that the call does not need to call it multiple times.
 func updateGrubCfg(inputGrubCfgPath string, outputFormat imagecustomizerapi.ImageFormatType, initramfsImageType imagecustomizerapi.InitramfsImageType,
-	disableSELinux bool, savedConfigs *SavedConfigs, kernelVersions []string, outputIsoGrubCfgPath, outputPxeGrubCfgPath string) error {
+	disableSELinux bool, savedConfigs *SavedConfigs, kernelVersions []string, outputIsoGrubCfgPath, outputPxeGrubCfgPath string,
+	distroHandler DistroHandler,
+) error {
 	logger.Log.Infof("Updating grub.cfg")
 
 	inputContentString, err := file.Read(inputGrubCfgPath)
@@ -192,8 +227,11 @@ func updateGrubCfg(inputGrubCfgPath string, outputFormat imagecustomizerapi.Imag
 		return err
 	}
 
+	bootDir := filepath.Dir(filepath.Dir(inputGrubCfgPath))
+
 	// Update grub.cfg content to be 'live-os compatible'.
-	liveosContentString, err := updateGrubCfgForLiveOS(inputContentString, initramfsImageType, disableSELinux, savedConfigs, kernelVersions)
+	liveosContentString, err := distroHandler.UpdateLiveOSGrubCfgForLiveOS(inputContentString, bootDir,
+		initramfsImageType, disableSELinux, savedConfigs, kernelVersions)
 	if err != nil {
 		return err
 	}
@@ -202,7 +240,8 @@ func updateGrubCfg(inputGrubCfgPath string, outputFormat imagecustomizerapi.Imag
 	if (outputFormat == imagecustomizerapi.ImageFormatTypeIso) ||
 		((outputFormat == imagecustomizerapi.ImageFormatTypePxeDir || outputFormat == imagecustomizerapi.ImageFormatTypePxeTar) &&
 			initramfsImageType == imagecustomizerapi.InitramfsImageTypeBootstrap) {
-		isoContentString, err := updateGrubCfgForIso(liveosContentString, initramfsImageType)
+		isoContentString, err := distroHandler.UpdateLiveOSGrubCfgForIso(liveosContentString, bootDir,
+			initramfsImageType)
 		if err != nil {
 			return fmt.Errorf("failed to update %s:\n%w", inputGrubCfgPath, err)
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoimages.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoimages.go
@@ -47,8 +47,6 @@ hostonly="no"
 	usrLibLocaleDir = "/usr/lib/locale"
 )
 
-var kdumpInitramfsRegEx = regexp.MustCompile(`/initramfs-(.*)kdump\.img$`)
-
 type StageFile struct {
 	sourcePath    string
 	targetRelPath string

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoimages.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoimages.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/diskutils"
@@ -31,7 +32,7 @@ const (
 	initKernelInitrdPath = "/init"
 	initBinaryInitrdPath = "/lib/systemd/systemd"
 
-	dracutConfig = `add_dracutmodules+=" dmsquash-live livenet selinux "
+	dracutConfigTemplate = `add_dracutmodules+=" %s "
 add_drivers+=" overlay "
 hostonly="no"
 `
@@ -46,9 +47,7 @@ hostonly="no"
 	usrLibLocaleDir = "/usr/lib/locale"
 )
 
-var (
-	kdumpInitramfsRegEx = regexp.MustCompile(`/initramfs-(.*)kdump\.img$`)
-)
+var kdumpInitramfsRegEx = regexp.MustCompile(`/initramfs-(.*)kdump\.img$`)
 
 type StageFile struct {
 	sourcePath    string
@@ -112,7 +111,8 @@ func cleanFullOSFolderForLiveOS(fullOSDir string, kdumpBootFiles *imagecustomize
 }
 
 func createFullOSInitrdImage(writeableRootfsDir string, kernelKdumpFiles *imagecustomizerapi.KdumpBootFilesType,
-	kdumpBootFilesMap map[string]*KdumpBootFiles, outputInitrdPath string) error {
+	kdumpBootFilesMap map[string]*KdumpBootFiles, outputInitrdPath string,
+) error {
 	logger.Log.Infof("Creating full OS initrd")
 
 	err := cleanFullOSFolderForLiveOS(writeableRootfsDir, kernelKdumpFiles, kdumpBootFilesMap)
@@ -146,6 +146,8 @@ func createBootstrapInitrdImage(writeableRootfsDir, kernelVersion, outputInitrdP
 ) error {
 	logger.Log.Infof("Creating bootstrap initrd for %s", kernelVersion)
 
+	dracutModules := distroHandler.LiveOSInitrdDracutModules()
+	dracutConfig := fmt.Sprintf(dracutConfigTemplate, strings.Join(dracutModules, " "))
 	dracutConfigFile := filepath.Join(writeableRootfsDir, "/etc/dracut.conf.d/20-live-cd.conf")
 	err := file.Write(dracutConfig, dracutConfigFile)
 	if err != nil {
@@ -164,15 +166,15 @@ func createBootstrapInitrdImage(writeableRootfsDir, kernelVersion, outputInitrdP
 		return fmt.Errorf("failed to initialize chroot object for %s:\n%w", writeableRootfsDir, err)
 	}
 
-	requiredRpms := []string{"squashfs-tools", "tar", "device-mapper", "curl"}
-	for _, requiredRpm := range requiredRpms {
-		logger.Log.Debugf("Checking if (%s) is installed", requiredRpm)
-		installed, err := distroHandler.IsPackageInstalled(chroot, nil, requiredRpm)
+	requiredPackages := distroHandler.LiveOSRequiredPackages()
+	for _, requiredPackage := range requiredPackages {
+		logger.Log.Debugf("Checking if (%s) is installed", requiredPackage)
+		installed, err := distroHandler.IsPackageInstalled(chroot, nil, requiredPackage)
 		if err != nil {
-			return fmt.Errorf("failed to check if package (%s) is installed:\n%w", requiredRpm, err)
+			return fmt.Errorf("failed to check if package (%s) is installed:\n%w", requiredPackage, err)
 		}
 		if !installed {
-			return fmt.Errorf("package (%s) is not installed:\nthe following packages must be installed to generate an iso: %v", requiredRpm, requiredRpms)
+			return fmt.Errorf("package (%s) is not installed:\nthe following packages must be installed to generate an iso: %v", requiredPackage, requiredPackages)
 		}
 	}
 
@@ -181,7 +183,8 @@ func createBootstrapInitrdImage(writeableRootfsDir, kernelVersion, outputInitrdP
 		initrdPathInChroot,
 		"--kver", kernelVersion,
 		"--filesystems", "squashfs",
-		"--include", usrLibLocaleDir, usrLibLocaleDir}
+		"--include", usrLibLocaleDir, usrLibLocaleDir,
+	}
 
 	err = shell.NewExecBuilder("dracut", dracutParams...).
 		LogLevel(logrus.DebugLevel, logrus.DebugLevel).
@@ -201,7 +204,8 @@ func createBootstrapInitrdImage(writeableRootfsDir, kernelVersion, outputInitrdP
 }
 
 func createSquashfsImage(writeableRootfsDir string, kdumpBootFiles *imagecustomizerapi.KdumpBootFilesType,
-	kdumpBootFilesMap map[string]*KdumpBootFiles, outputSquashfsPath string) error {
+	kdumpBootFilesMap map[string]*KdumpBootFiles, outputSquashfsPath string,
+) error {
 	logger.Log.Infof("Creating squashfs")
 
 	err := cleanFullOSFolderForLiveOS(writeableRootfsDir, kdumpBootFiles, kdumpBootFilesMap)
@@ -424,7 +428,8 @@ func stageLiveOSFiles(initramfsType imagecustomizerapi.InitramfsImageType, outpu
 
 func createIsoImage(buildDir string, initramfsType imagecustomizerapi.InitramfsImageType, filesStore *IsoFilesStore,
 	kdumpBootFiles *imagecustomizerapi.KdumpBootFilesType, additionalIsoFiles imagecustomizerapi.AdditionalFileList,
-	outputImagePath string) error {
+	outputImagePath string, distroHandler DistroHandler,
+) error {
 	stagingDir := filepath.Join(buildDir, "iso-staging")
 
 	err := stageLiveOSFiles(initramfsType, imagecustomizerapi.ImageFormatTypeIso, filesStore,
@@ -433,11 +438,42 @@ func createIsoImage(buildDir string, initramfsType imagecustomizerapi.InitramfsI
 		return fmt.Errorf("failed to stage one or more iso files:\n%w", err)
 	}
 
+	if grubPrefixDir := distroHandler.LiveOSGrubEfiPrefixDir(); grubPrefixDir != "" {
+		err = writeIsoGrubPrefixRedirector(stagingDir, grubPrefixDir)
+		if err != nil {
+			return fmt.Errorf("failed to stage grub prefix redirector:\n%w", err)
+		}
+	}
+
 	biosBootEnabled := false
 	biosFilesDirPath := ""
 	err = isogenerator.BuildIsoImage(stagingDir, biosBootEnabled, biosFilesDirPath, outputImagePath)
 	if err != nil {
 		return fmt.Errorf("failed to create (%s) using the (%s) folder:\n%w", outputImagePath, stagingDir, err)
+	}
+
+	return nil
+}
+
+// writeIsoGrubPrefixRedirector writes a minimal grub.cfg into grubPrefixDir (the directory the ISO's grub EFI binary
+// uses as its baked-in 'prefix', e.g. EFI/azurelinux) within stagingPath. BLS-style distros (Azure Linux 4.0, Fedora)
+// ship a grub binary whose prefix points at EFI/<distro> rather than the boot media root, so without this file grub
+// would look for <prefix>/grub.cfg, find nothing, and drop to the 'grub>' rescue prompt. The redirector locates the
+// LiveOS volume by label and chains to the real configuration at isoGrubCfgPath.
+func writeIsoGrubPrefixRedirector(stagingPath string, grubPrefixDir string) error {
+	redirector := fmt.Sprintf("search --label %s --set root\n"+
+		"set prefix=($root)%s\n"+
+		"configfile ($root)%s\n", isogenerator.DefaultVolumeId, grubCfgDir, isoGrubCfgPath)
+
+	targetPath := filepath.Join(stagingPath, grubPrefixDir, isoGrubCfg)
+	err := os.MkdirAll(filepath.Dir(targetPath), os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("failed to create grub prefix directory (%s):\n%w", filepath.Dir(targetPath), err)
+	}
+
+	err = file.Write(redirector, targetPath)
+	if err != nil {
+		return fmt.Errorf("failed to write grub prefix redirector (%s):\n%w", targetPath, err)
 	}
 
 	return nil
@@ -468,7 +504,6 @@ func getSizeOnDiskInBytes(fileOrDir string) (size uint64, err error) {
 }
 
 func getDiskSizeEstimateInMBs(filesOrDirs []string, safetyFactor float64) (size uint64, err error) {
-
 	totalSizeInBytes := uint64(0)
 	for _, fileOrDir := range filesOrDirs {
 		sizeInBytes, err := getSizeOnDiskInBytes(fileOrDir)
@@ -531,7 +566,8 @@ func createWriteableImageFromArtifacts(buildDir string, inputArtifactsStore *Iso
 		rootfsDir,
 		inputArtifactsStore.files.bootEfiPath,
 		inputArtifactsStore.files.grubEfiPath,
-		artifactsBootDir}
+		artifactsBootDir,
+	}
 
 	// estimate the new disk size
 	safeDiskSizeMB, err := getDiskSizeEstimateInMBs(imageContentList, expansionSafetyFactor)

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoimages.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoimages.go
@@ -707,6 +707,28 @@ func createWriteableImageFromArtifacts(buildDir string, inputArtifactsStore *Iso
 			return fmt.Errorf("failed to copy (%s) to (%s):\n%w", inputArtifactsStore.files.grubEfiPath, targetGrubPath, err)
 		}
 
+		// The EFI/BOOT copy above keeps the reconstructed image bootable via the removable-media path. Some distros
+		// place the package-owned grub EFI binary under a vendor directory instead
+		// (e.g. EFI/azurelinux on Azure Linux 4.0), and that vendor location is where this distro's LiveOS grub
+		// detection looks. Restore a copy there too so a subsequent LiveOS extraction from this reconstructed image
+		// finds grub where it expects it. On distros that keep grub under EFI/BOOT this resolves to the same file and
+		// is skipped.
+		bootFilesConfig, err := distroHandler.GetBootArchConfig()
+		if err != nil {
+			return err
+		}
+		vendorGrubPath := filepath.Join(imageChroot.RootDir(), bootFilesConfig.osEspGrubBinaryPath)
+		if vendorGrubPath != targetGrubPath {
+			err = os.MkdirAll(filepath.Dir(vendorGrubPath), os.ModePerm)
+			if err != nil {
+				return fmt.Errorf("failed to create destination efi directory (%s):\n%w", filepath.Dir(vendorGrubPath), err)
+			}
+			err = file.Copy(inputArtifactsStore.files.grubEfiPath, vendorGrubPath)
+			if err != nil {
+				return fmt.Errorf("failed to copy (%s) to (%s):\n%w", inputArtifactsStore.files.grubEfiPath, vendorGrubPath, err)
+			}
+		}
+
 		return err
 	}
 

--- a/toolkit/tools/pkg/imagecustomizerlib/liveospxe.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveospxe.go
@@ -92,7 +92,7 @@ func createPXEArtifacts(buildDir string, outputFormat imagecustomizerapi.ImageFo
 		// dracut livenet module will download it.
 		artifactsIsoImagePath := filepath.Join(outputPXEArtifactsDir, isoImageName)
 		err = createIsoImage(buildDir, imagecustomizerapi.InitramfsImageTypeBootstrap,
-			artifactsStore.files, kdumpBootFiles, additionalIsoFiles, artifactsIsoImagePath)
+			artifactsStore.files, kdumpBootFiles, additionalIsoFiles, artifactsIsoImagePath, distroHandler)
 		if err != nil {
 			return fmt.Errorf("failed to create the Iso image.\n%w", err)
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/iso-bootstrap-vm-azl4.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/iso-bootstrap-vm-azl4.yaml
@@ -15,6 +15,8 @@ os:
     - tar
     - device-mapper
     - curl
+    # Azure Linux 4.0 ships the dmsquash-live dracut module in a separate dracut-live package.
+    - dracut-live
     # Required package for SELinux.
     - selinux-policy
 


### PR DESCRIPTION
This enables Azure Linux 4.0 ISO (LiveOS) bootstrap and full-OS output. It was previously gated off because Azure Linux 4.0 uses Fedora-style BLS bootloader packaging that the LiveOS ISO builder did not handle, and this change adds distro-aware LiveOS hooks on `DistroHandler` to support it.

**What changed**
- Distro-aware LiveOS hooks on `DistroHandler` (required packages, grub EFI prefix directory, initrd dracut modules) for acl, azurelinux, azurelinux4, fedora, and ubuntu, plus the BLS grub.cfg and PXE boot-config helpers.
- BLS-layout builder fixes: preserve each loader entry's `boot/loader/entries` subpath when staging, skip dangling module symlinks such as `symvers` when building the bootstrap initrd, write a grub prefix redirector so Azure Linux 4.0's `EFI/azurelinux`-prefixed grub finds its config, preserve each grub `search --set=<target>` when relabeling for the ISO volume id, and fall back to the input ISO's distro handler when repackaging an ISO without OS customization.
- Omit the `selinux` dracut module for Fedora and Azure Linux 4.0, whose policy loads after `switch_root`.
- Add the `dracut-live` package to the Azure Linux 4.0 bootstrap config and unskip the Azure Linux 4.0 ISO vmtests.

PXE output stays explicitly unsupported for Azure Linux 4.0. That follows in a separate change.

---

### **Checklist**
- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines