### PR TITLE
Allow creation of tools directory for all distros.

### DIFF
--- a/.github/workflows/tests-functional.yml
+++ b/.github/workflows/tests-functional.yml
@@ -135,9 +135,9 @@ jobs:
         set -eux
         pushd repo/toolkit/tools
         if [[ "$TEST_DISTRO" == "azl3" ]]; then
-          ./internal/testutils/testrpms/download-test-utils.sh -d azurelinux -t 3.0 -s true
+          ./internal/testutils/testrpms/download-test-utils.sh -d azurelinux -t 3.0
         elif [[ "$TEST_DISTRO" == "azl4" ]]; then
-          ./internal/testutils/testrpms/download-test-utils.sh -d azurelinux -t 4.0 -s true
+          ./internal/testutils/testrpms/download-test-utils.sh -d azurelinux -t 4.0
         elif [[ "$TEST_DISTRO" == "ubuntu" ]]; then
           echo "No test utils needed for Ubuntu tests"
         else

--- a/.github/workflows/tests-vmtests.yml
+++ b/.github/workflows/tests-vmtests.yml
@@ -154,9 +154,9 @@ jobs:
 
         pushd ./repo/toolkit/tools/internal/testutils/testrpms
 
-        ./download-test-utils.sh -d azurelinux -t 3.0 -s true
-        ./download-test-utils.sh -d azurelinux -t 4.0 -s true
-        ./download-test-utils.sh -d fedora -t 42 -s true -r "$AZURE_CR_CACHE"
+        ./download-test-utils.sh -d azurelinux -t 3.0
+        ./download-test-utils.sh -d azurelinux -t 4.0
+        ./download-test-utils.sh -d fedora -t 42 -r "$AZURE_CR_CACHE"
       env:
         AZURE_CR_CACHE: ${{ vars.AZURE_CR_CACHE }}
 

--- a/docs/imagecustomizer/developer-guide.md
+++ b/docs/imagecustomizer/developer-guide.md
@@ -48,7 +48,7 @@ sudo go test -C ./toolkit/tools ./...
 2. Download the test RPM files:
 
    ```bash
-   ./toolkit/tools/internal/testutils/testrpms/download-test-utils.sh -d azurelinux -t 3.0 -s true
+   ./toolkit/tools/internal/testutils/testrpms/download-test-utils.sh -d azurelinux -t 3.0
    ```
 
 3. Run the tests:

--- a/toolkit/tools/internal/testutils/testrpms/download-test-utils.sh
+++ b/toolkit/tools/internal/testutils/testrpms/download-test-utils.sh
@@ -14,12 +14,11 @@ DISTRO_VERSION="3.0"
 CREATE_IMAGE="false"
 CONTAINER_REGISTRY=""
 
-while getopts "d:t:s:r:" flag
+while getopts "d:t:r:" flag
 do
     case "${flag}" in
         d) DISTRO="$OPTARG";;
         t) DISTRO_VERSION="$OPTARG";;
-        s) CREATE_IMAGE="$OPTARG";;
         r) CONTAINER_REGISTRY="$OPTARG";;
         h) ;;&
         ?) echo "Usage: download-test-utils.sh [-d DISTRO] [-t DISTRO_VERSION] [-s CREATE_IMAGE] [-r CONTAINER_REGISTRY]"
@@ -85,35 +84,34 @@ else
   DISTRO_CONFIG_MAP["azurelinux-4.0"]="create-azl4-arm64.yaml create-azl4-btrfs-arm64.yaml"
 fi
 
-# Get configuration files for the distro-version
-CONFIG_FILES="${DISTRO_CONFIG_MAP[${DISTRO}-${DISTRO_VERSION}]:-}"
-# Validate that we have configuration for this distro
-if [[ -z "$CONFIG_FILES" ]]; then
-  echo "Error: Unsupported distro '$DISTRO'"
-  echo "Supported distros: ${!DISTRO_CONFIG_MAP[@]}"
+# Handle tools file creation
+echo "Creating tools file: $TOOLS_FILE"
+$SCRIPT_DIR/create-tools-file.sh "$CONTAINER_IMAGE" "$TOOLS_FILE"
+echo "Tools file created successfully."
+
+TOOLS_DIR="${TOOLS_FILE%.tar.gz}-dir"
+echo "Extracting tools dir: $TOOLS_DIR"
+mkdir -p "$TOOLS_DIR"
+tar -x -z -f "$TOOLS_FILE" -C "$TOOLS_DIR"
+echo "Tools dir extracted successfully."
+
+# Check for python3 availability
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "Error: python3 is required but not found in PATH"
+  echo "Please install python3 to extract package lists from config files"
   exit 1
-fi
-
-
-# Handle tools file creation and package extraction for create subcommand testing
-if [ "$CREATE_IMAGE" = "true" ]; then
-  echo "Creating tools file: $TOOLS_FILE"
-  $SCRIPT_DIR/create-tools-file.sh "$CONTAINER_IMAGE" "$TOOLS_FILE"
-  echo "Tools file created successfully."
-
-  TOOLS_DIR="${TOOLS_FILE%.tar.gz}-dir"
-  echo "Extracting tools dir: $TOOLS_DIR"
-  mkdir -p "$TOOLS_DIR"
-  tar -x -z -f "$TOOLS_FILE" -C "$TOOLS_DIR"
-  echo "Tools dir extracted successfully."
-
-  # Check for python3 availability
-  if ! command -v python3 >/dev/null 2>&1; then
-    echo "Error: python3 is required but not found in PATH"
-    echo "Please install python3 to extract package lists from config files"
-    exit 1
   fi
 
+# Handle package extraction for create subcommand testing.
+# Get configuration files for the distro-version.
+CONFIG_FILES="${DISTRO_CONFIG_MAP[${DISTRO}-${DISTRO_VERSION}]:-}"
+
+# Check if we have configuration for this distro.
+if [[ -z "$CONFIG_FILES" ]]; then
+  echo "Skipping package extraction."
+  echo "Unsupported distro '$DISTRO'"
+  echo "Supported distros: ${!DISTRO_CONFIG_MAP[@]}"
+else
   # Extract package list from all config files for this distro
   for CONFIG_FILE in $CONFIG_FILES; do
     CONFIG_PATH="$TESTDATA_DIR/$CONFIG_FILE"
@@ -127,8 +125,6 @@ if [ "$CREATE_IMAGE" = "true" ]; then
     echo "Package list from $CONFIG_FILE: $FILE_PACKAGES"
     PACKAGE_LIST="$PACKAGE_LIST $FILE_PACKAGES"
   done
-else
-  echo "Skipping tools file creation and package extraction."
 fi
 
 # Combine with common testing packages

--- a/toolkit/tools/internal/testutils/testrpms/download-test-utils.sh
+++ b/toolkit/tools/internal/testutils/testrpms/download-test-utils.sh
@@ -11,7 +11,6 @@ FEDORA_42_CONTAINER_IMAGE="quay.io/fedora/fedora:42"
 DISTRO="azurelinux"
 DISTRO_VERSION="3.0"
 
-CREATE_IMAGE="false"
 CONTAINER_REGISTRY=""
 
 while getopts "d:t:r:" flag
@@ -21,12 +20,11 @@ do
         t) DISTRO_VERSION="$OPTARG";;
         r) CONTAINER_REGISTRY="$OPTARG";;
         h) ;;&
-        ?) echo "Usage: download-test-utils.sh [-d DISTRO] [-t DISTRO_VERSION] [-s CREATE_IMAGE] [-r CONTAINER_REGISTRY]"
+        ?) echo "Usage: download-test-utils.sh [-d DISTRO] [-t DISTRO_VERSION] [-r CONTAINER_REGISTRY]"
             echo ""
             echo "Args:"
             echo "  -d DISTRO              The distribution to use (azurelinux or fedora). Default: azurelinux"
             echo "  -t DISTRO_VERSION      The image version to download the RPMs for (2.0, 3.0 for Azure Linux or 42 for Fedora)."
-            echo "  -s CREATE_IMAGE        If set to true, the script will create a tools tar.gz and download the rpms needed for the create subcommand."
             echo "  -r CONTAINER_REGISTRY  Container registry URL to use for Fedora images (e.g., myacr.azurecr.io)."
             echo "  -h Show help"
             exit 1;;
@@ -95,22 +93,13 @@ mkdir -p "$TOOLS_DIR"
 tar -x -z -f "$TOOLS_FILE" -C "$TOOLS_DIR"
 echo "Tools dir extracted successfully."
 
-# Check for python3 availability
-if ! command -v python3 >/dev/null 2>&1; then
-  echo "Error: python3 is required but not found in PATH"
-  echo "Please install python3 to extract package lists from config files"
-  exit 1
-  fi
-
 # Handle package extraction for create subcommand testing.
 # Get configuration files for the distro-version.
 CONFIG_FILES="${DISTRO_CONFIG_MAP[${DISTRO}-${DISTRO_VERSION}]:-}"
 
 # Check if we have configuration for this distro.
 if [[ -z "$CONFIG_FILES" ]]; then
-  echo "Skipping package extraction."
-  echo "Unsupported distro '$DISTRO'"
-  echo "Supported distros: ${!DISTRO_CONFIG_MAP[@]}"
+  echo "Skipping create-image package extraction for distro '$DISTRO'"
 else
   # Extract package list from all config files for this distro
   for CONFIG_FILE in $CONFIG_FILES; do

--- a/toolkit/tools/internal/testutils/testutils.go
+++ b/toolkit/tools/internal/testutils/testutils.go
@@ -90,36 +90,43 @@ func isZstFile(firstBytes []byte) bool {
 	return magicNumber == 0xFD2FB528 || (magicNumber >= 0x184D2A50 && magicNumber <= 0x184D2A5F)
 }
 
-func GetDownloadedRpmsDir(t *testing.T, testutilsDir string, distro string, distroVersion string, createImage bool,
+func GetDownloadedRpmsDir(t *testing.T, testutilsDir string, distro string, distroVersion string,
 ) string {
+	if distro == "ubuntu" {
+		t.Skip("test requires downloaded RPMs dir:\nRPMs dir not supported for Ubuntu yet")
+	}
+
 	downloadedRpmsDir := filepath.Join(testutilsDir, "testrpms/downloadedrpms", distro, distroVersion)
 	if _, err := os.Stat(downloadedRpmsDir); os.IsNotExist(err) {
 		t.Skipf("test requires downloaded RPMs dir: %s;\n"+
-			"please run toolkit/tools/internal/testutils/testrpms/download-test-utils.sh -d %s -t %s -s %t",
-			downloadedRpmsDir, distro, distroVersion, createImage)
+			"please run toolkit/tools/internal/testutils/testrpms/download-test-utils.sh -d %s -t %s",
+			downloadedRpmsDir, distro, distroVersion)
 	}
 
 	return downloadedRpmsDir
 }
 
-func GetDownloadedToolsDir(t *testing.T, testutilsDir string, distro string, distroVersion string, createImage bool,
+func GetDownloadedToolsDir(t *testing.T, testutilsDir string, distro string, distroVersion string,
 ) string {
+	if distro == "ubuntu" {
+		t.Skip("test requires downloaded tools dir:\ntools dir not supported for Ubuntu yet")
+	}
+
 	toolsDirName := fmt.Sprintf("tools-%s-%s-dir", distro, distroVersion)
 	toolsDirPath := filepath.Join(testutilsDir, "testrpms/build", toolsDirName)
 
 	if _, err := os.Stat(toolsDirPath); os.IsNotExist(err) {
 		t.Skipf("test requires downloaded tools dir: %s;\n"+
-			"please run toolkit/tools/internal/testutils/testrpms/download-test-utils.sh -d %s -t %s -s %t",
-			toolsDirPath, distro, distroVersion, createImage)
+			"please run toolkit/tools/internal/testutils/testrpms/download-test-utils.sh -d %s -t %s",
+			toolsDirPath, distro, distroVersion)
 	}
 
 	return toolsDirPath
 }
 
 func GetDownloadedRpmsRepoFile(t *testing.T, testutilsDir string, distro string, distroVersion string, withGpgKey bool,
-	createImage bool,
 ) string {
-	dir := GetDownloadedRpmsDir(t, testutilsDir, distro, distroVersion, createImage)
+	dir := GetDownloadedRpmsDir(t, testutilsDir, distro, distroVersion)
 
 	suffix := "nokey"
 	if withGpgKey {

--- a/toolkit/tools/pkg/imagecustomizerlib/createimage_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/createimage_test.go
@@ -49,9 +49,9 @@ func testCreateImageRaw(t *testing.T, imageInfo testImageInfo) {
 
 	// get RPM sources
 	downloadedRpmsRepoFile := testutils.GetDownloadedRpmsRepoFile(t, testutilsDir, imageInfo.Distro, imageInfo.Version,
-		false, true)
+		false)
 	rpmSources := []string{downloadedRpmsRepoFile}
-	toolsDir := testutils.GetDownloadedToolsDir(t, testutilsDir, imageInfo.Distro, imageInfo.Version, true)
+	toolsDir := testutils.GetDownloadedToolsDir(t, testutilsDir, imageInfo.Distro, imageInfo.Version)
 
 	err := basicCreateImageWithConfigFile(
 		t.Context(), buildDir, configFile, rpmSources, toolsDir,
@@ -106,9 +106,9 @@ func testCreateImageBtrfs(t *testing.T, imageInfo testImageInfo) {
 	outputImageFormat := "raw"
 
 	downloadedRpmsRepoFile := testutils.GetDownloadedRpmsRepoFile(t, testutilsDir, imageInfo.Distro, imageInfo.Version,
-		false, true)
+		false)
 	rpmSources := []string{downloadedRpmsRepoFile}
-	toolsDir := testutils.GetDownloadedToolsDir(t, testutilsDir, imageInfo.Distro, imageInfo.Version, true)
+	toolsDir := testutils.GetDownloadedToolsDir(t, testutilsDir, imageInfo.Distro, imageInfo.Version)
 
 	err := basicCreateImageWithConfigFile(
 		t.Context(), buildDir, partitionsConfigFile, rpmSources, toolsDir,
@@ -208,8 +208,8 @@ func testCreateImage_OutputImageFileAsRelativePath(t *testing.T, imageInfo testI
 	assert.NoError(t, err)
 
 	rpmSources := []string{testutils.GetDownloadedRpmsRepoFile(t, testutilsDir, imageInfo.Distro, imageInfo.Version,
-		false, true)}
-	toolsDir := testutils.GetDownloadedToolsDir(t, testutilsDir, imageInfo.Distro, imageInfo.Version, true)
+		false)}
+	toolsDir := testutils.GetDownloadedToolsDir(t, testutilsDir, imageInfo.Distro, imageInfo.Version)
 	outputImageFileAbsolute := filepath.Join(buildDir, "image1.raw")
 
 	cwd, err := os.Getwd()

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
@@ -29,8 +29,7 @@ func TestCustomizeImagePackagesAddOfflineDir(t *testing.T) {
 	defer os.RemoveAll(testTmpDir)
 
 	baseImage, baseImageInfo := checkSkipForCustomizeDefaultAzureLinuxImage(t)
-	downloadedRpmsDir := testutils.GetDownloadedRpmsDir(t, testutilsDir, baseImageInfo.Distro, baseImageInfo.Version,
-		false)
+	downloadedRpmsDir := testutils.GetDownloadedRpmsDir(t, testutilsDir, baseImageInfo.Distro, baseImageInfo.Version)
 	buildDir := filepath.Join(testTmpDir, "build")
 	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
 
@@ -194,7 +193,7 @@ func testCustomizeImagePackagesAddOfflineLocalRepoHelper(t *testing.T, testName 
 	}
 
 	downloadedRpmsRepoFile := testutils.GetDownloadedRpmsRepoFile(t, testutilsDir, baseImageInfo.Distro,
-		baseImageInfo.Version, withGpgKey, false)
+		baseImageInfo.Version, withGpgKey)
 	rpmSources := []string{downloadedRpmsRepoFile}
 
 	buildDir := filepath.Join(testTmpDir, "build")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
@@ -35,7 +35,7 @@ func testCustomizeImageVerityUsrUkiHelper(t *testing.T, baseImageInfo testBaseIm
 		t.Skip("The 'ukify' command is not available")
 	}
 
-	toolsDir := testutils.GetDownloadedToolsDir(t, testutilsDir, baseImageInfo.Distro, baseImageInfo.Version, true)
+	toolsDir := testutils.GetDownloadedToolsDir(t, testutilsDir, baseImageInfo.Distro, baseImageInfo.Version)
 
 	testTempDir := filepath.Join(tmpDir, fmt.Sprintf("TestCustomizeImageUsrVerityUki_%s", baseImageInfo.Name))
 	defer os.RemoveAll(testTempDir)


### PR DESCRIPTION
Refactor the `download-test-utils.sh` script to allow for creation of the tools-directory for all distros, not just distros that have create support.

Also, remove the `-s` parameter from `download-test-utils.sh` and instead just always download the full set of RPMs for both create and customzie testing. If a distro doesn't have package lists for create testing, then skip that part and only download RPMs for customize testing.

Also, automatically skip tests that request offline RPMs or the tools directory for Ubuntu, since it isn't supported yet.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
