### PR TITLE
Fix ISO->ISO customization with initrd.img distros.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoartifactstore.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoartifactstore.go
@@ -480,8 +480,7 @@ func createIsoFilesStoreFromIsoImage(isoImageFile, storeDir string) (filesStore 
 		// Any of the per-kernel dracut initrds is fine for distro detection since they're all from the same OS.
 		for _, f := range isoFiles {
 			base := filepath.Base(f)
-			isInitrd := ((strings.HasPrefix(base, initramfsPrefix) && strings.HasSuffix(base, ".img")) ||
-				strings.HasPrefix(base, initrdPrefix))
+			isInitrd := strings.HasPrefix(base, initramfsPrefix) || strings.HasPrefix(base, initrdPrefix)
 			if isInitrd {
 				initrdPath = f
 				break

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoartifactstore.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoartifactstore.go
@@ -480,8 +480,9 @@ func createIsoFilesStoreFromIsoImage(isoImageFile, storeDir string) (filesStore 
 		// Any of the per-kernel dracut initrds is fine for distro detection since they're all from the same OS.
 		for _, f := range isoFiles {
 			base := filepath.Base(f)
-			isInitrd := strings.HasPrefix(base, initramfsPrefix) || strings.HasPrefix(base, initrdPrefix)
-			if isInitrd && strings.HasSuffix(base, ".img") {
+			isInitrd := ((strings.HasPrefix(base, initramfsPrefix) && strings.HasSuffix(base, ".img")) ||
+				strings.HasPrefix(base, initrdPrefix))
+			if isInitrd {
 				initrdPath = f
 				break
 			}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
@@ -681,9 +681,17 @@ func testCustomizeImageLiveOSMultiKernel(t *testing.T, baseImageInfo testBaseIma
 // - ISO  {bootstrap}  to ISO {bootstrap}    , with no OS changes
 // - ISO  {bootstrap}  to ISO {full-os}      , with selinux disabled
 func TestCustomizeImageLiveOSInitramfs1(t *testing.T) {
-	baseImage, baseImageInfo := checkSkipForCustomizeDefaultAzureLinuxImage(t)
+	for _, baseImageInfo := range baseImageAzureLinuxAll {
+		t.Run(baseImageInfo.Name, func(t *testing.T) {
+			testCustomizeImageLiveOSInitramfs1Helper(t, baseImageInfo)
+		})
+	}
+}
 
-	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageLiveOSInitramfs1")
+func testCustomizeImageLiveOSInitramfs1Helper(t *testing.T, baseImageInfo testBaseImageInfo) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
+
+	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageLiveOSInitramfs1"+baseImageInfo.Name)
 	defer os.RemoveAll(testTempDir)
 
 	buildDir := filepath.Join(testTempDir, "build")


### PR DESCRIPTION
The logic for finding initramfs files for ISO distro detection when `initrd.img-*` names are used is wrong.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
