### PR TITLE
Move COSI types into separate package.

### DIFF
--- a/toolkit/tools/cosiapi/cosimetadata.go
+++ b/toolkit/tools/cosiapi/cosimetadata.go
@@ -1,4 +1,4 @@
-package imagecustomizerlib
+package cosiapi
 
 type BootloaderType string
 
@@ -26,21 +26,21 @@ type SystemDBoot struct {
 	Entries []SystemDBootEntry `json:"entries"`
 }
 
-type CosiBootloader struct {
+type Bootloader struct {
 	Type        BootloaderType `json:"type"`
 	SystemdBoot *SystemDBoot   `json:"systemdBoot,omitempty"`
 }
 
 type MetadataJson struct {
-	Version     string         `json:"version"`
-	OsArch      string         `json:"osArch"`
-	Disk        Disk           `json:"disk"`
-	Images      []FileSystem   `json:"images"`
-	OsRelease   string         `json:"osRelease"`
-	Id          string         `json:"id"`
-	Bootloader  CosiBootloader `json:"bootloader"`
-	OsPackages  []OsPackage    `json:"osPackages"`
-	Compression Compression    `json:"compression"`
+	Version     string       `json:"version"`
+	OsArch      string       `json:"osArch"`
+	Disk        Disk         `json:"disk"`
+	Images      []FileSystem `json:"images"`
+	OsRelease   string       `json:"osRelease"`
+	Id          string       `json:"id"`
+	Bootloader  Bootloader   `json:"bootloader"`
+	OsPackages  []OsPackage  `json:"osPackages"`
+	Compression Compression  `json:"compression"`
 }
 
 type Compression struct {

--- a/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput.go
@@ -17,6 +17,7 @@ import (
 	"go.opentelemetry.io/otel"
 	"gopkg.in/yaml.v3"
 
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/cosiapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/file"
@@ -462,7 +463,7 @@ func injectFilesIntoImage(buildDir string, baseConfigPath string, rawImageFile s
 
 func prepareImageConversionData(ctx context.Context, rawImageFile string, buildDir string,
 ) ([]fstabEntryPartNum, []verityDeviceMetadata, string,
-	[]OsPackage, [randomization.UuidSize]byte, string, *CosiBootloader, []string, error,
+	[]cosiapi.OsPackage, [randomization.UuidSize]byte, string, *cosiapi.Bootloader, []string, error,
 ) {
 	imageMountPoint := filepath.Join(buildDir, "imageroot")
 

--- a/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/cosiapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/file"
@@ -177,14 +178,14 @@ func TestOutputAndInjectArtifactsCosi(t *testing.T) {
 		return
 	}
 
-	expectedCosiMetadata := MetadataJson{
-		Disk: Disk{
+	expectedCosiMetadata := cosiapi.MetadataJson{
+		Disk: cosiapi.Disk{
 			Size:       5639 * diskutils.MiB,
 			GptRegions: newTestCosiGptSections([]int{1, 2, 3, 4, 5}),
 		},
-		Images: []FileSystem{
+		Images: []cosiapi.FileSystem{
 			{
-				Image: ImageFile{
+				Image: cosiapi.ImageFile{
 					Path: "images/image_1.raw.zst",
 				},
 				MountPoint: "/boot/efi",
@@ -192,7 +193,7 @@ func TestOutputAndInjectArtifactsCosi(t *testing.T) {
 				PartType:   imagecustomizerapi.PartitionTypeToUuid[imagecustomizerapi.PartitionTypeESP],
 			},
 			{
-				Image: ImageFile{
+				Image: cosiapi.ImageFile{
 					Path: "images/image_2.raw.zst",
 				},
 				MountPoint: "/boot",
@@ -200,20 +201,20 @@ func TestOutputAndInjectArtifactsCosi(t *testing.T) {
 				PartType:   imagecustomizerapi.PartitionTypeToUuid[imagecustomizerapi.PartitionTypeLinuxGeneric],
 			},
 			{
-				Image: ImageFile{
+				Image: cosiapi.ImageFile{
 					Path: "images/image_3.raw.zst",
 				},
 				MountPoint: "/",
 				FsType:     "ext4",
 				PartType:   imagecustomizerapi.PartitionTypeToUuid[imagecustomizerapi.PartitionTypeLinuxGeneric],
-				Verity: &VerityConfig{
-					Image: ImageFile{
+				Verity: &cosiapi.VerityConfig{
+					Image: cosiapi.ImageFile{
 						Path: "images/image_4.raw.zst",
 					},
 				},
 			},
 			{
-				Image: ImageFile{
+				Image: cosiapi.ImageFile{
 					Path: "images/image_5.raw.zst",
 				},
 				MountPoint: "/var",
@@ -221,17 +222,17 @@ func TestOutputAndInjectArtifactsCosi(t *testing.T) {
 				PartType:   imagecustomizerapi.PartitionTypeToUuid[imagecustomizerapi.PartitionTypeLinuxGeneric],
 			},
 		},
-		Bootloader: CosiBootloader{
+		Bootloader: cosiapi.Bootloader{
 			Type: "systemd-boot",
-			SystemdBoot: &SystemDBoot{
-				Entries: []SystemDBootEntry{
+			SystemdBoot: &cosiapi.SystemDBoot{
+				Entries: []cosiapi.SystemDBootEntry{
 					{
 						Type: "uki-standalone",
 					},
 				},
 			},
 		},
-		Compression: Compression{
+		Compression: cosiapi.Compression{
 			MaxWindowLog: imagecustomizerapi.DefaultCosiCompressionLong,
 		},
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/cosicommon.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/cosicommon.go
@@ -14,6 +14,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/cosiapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/file"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/imageconnection"
@@ -40,14 +41,14 @@ var (
 type ImageBuildData struct {
 	Source       string
 	KnownInfo    outputPartitionMetadata
-	Metadata     *FileSystem
+	Metadata     *cosiapi.FileSystem
 	VeritySource string
 }
 
 func convertToCosi(buildDirAbs string, rawImageFile string, outputImageFile string,
 	partitionsLayout []fstabEntryPartNum, verityMetadata []verityDeviceMetadata,
-	osRelease string, osPackages []OsPackage, imageUuid [randomization.UuidSize]byte, imageUuidStr string,
-	cosiBootMetadata *CosiBootloader, compressionLevel int, compressionLong int, includeVhdFooter bool,
+	osRelease string, osPackages []cosiapi.OsPackage, imageUuid [randomization.UuidSize]byte, imageUuidStr string,
+	cosiBootMetadata *cosiapi.Bootloader, compressionLevel int, compressionLong int, includeVhdFooter bool,
 	partitionOriginalSizes map[string]uint64,
 ) error {
 	outputImageBase := strings.TrimSuffix(filepath.Base(outputImageFile), filepath.Ext(outputImageFile))
@@ -118,7 +119,7 @@ func convertToCosi(buildDirAbs string, rawImageFile string, outputImageFile stri
 
 func buildCosiFile(sourceDir string, outputFile string, partitions []outputPartitionMetadata,
 	verityMetadata []verityDeviceMetadata, partitionsLayout []fstabEntryPartNum,
-	imageUuidStr string, osRelease string, osPackages []OsPackage, cosiBootMetadata *CosiBootloader,
+	imageUuidStr string, osRelease string, osPackages []cosiapi.OsPackage, cosiBootMetadata *cosiapi.Bootloader,
 	gptData *GptExtractedData, compressionLong int,
 ) error {
 	// Pre-compute a map from partition UUID to index for quick lookup
@@ -139,13 +140,13 @@ func buildCosiFile(sourceDir string, outputFile string, partitions []outputParti
 	}
 
 	imageData := []ImageBuildData{}
-	partitionImageFiles := make(map[int]ImageFile)
+	partitionImageFiles := make(map[int]cosiapi.ImageFile)
 	for _, partition := range partitions {
 		partitionPath := path.Join("images", partition.PartitionFilename)
 		partitionSource := path.Join(sourceDir, partition.PartitionFilename)
 
-		// Create and populate ImageFile for partition
-		partitionImageFile := ImageFile{
+		// Create and populate cosiapi.ImageFile for partition
+		partitionImageFile := cosiapi.ImageFile{
 			Path:             partitionPath,
 			UncompressedSize: partition.UncompressedSize,
 		}
@@ -174,7 +175,7 @@ func buildCosiFile(sourceDir string, outputFile string, partitions []outputParti
 			continue
 		}
 
-		metadataImage := FileSystem{
+		metadataImage := cosiapi.FileSystem{
 			Image:      partitionImageFiles[partition.PartitionNum],
 			PartType:   partition.PartitionTypeUuid,
 			MountPoint: entry.FstabEntry.Target,
@@ -202,7 +203,7 @@ func buildCosiFile(sourceDir string, outputFile string, partitions []outputParti
 				}
 
 				hashPartition := partitions[hashPartitionIndex]
-				metadataImage.Verity = &VerityConfig{
+				metadataImage.Verity = &cosiapi.VerityConfig{
 					Roothash:   verity.rootHash,
 					Image:      partitionImageFiles[hashPartition.PartitionNum],
 					HashOffset: hashOffset,
@@ -218,7 +219,7 @@ func buildCosiFile(sourceDir string, outputFile string, partitions []outputParti
 	}
 
 	// Build GPT image file metadata
-	gptImageFile := ImageFile{
+	gptImageFile := cosiapi.ImageFile{
 		Path:             path.Join("images", filepath.Base(gptData.CompressedFilePath)),
 		UncompressedSize: gptData.UncompressedSize,
 	}
@@ -232,16 +233,16 @@ func buildCosiFile(sourceDir string, outputFile string, partitions []outputParti
 		return fmt.Errorf("failed to build disk metadata:\n%w", err)
 	}
 
-	metadata := MetadataJson{
+	metadata := cosiapi.MetadataJson{
 		Version:    "1.2",
 		OsArch:     getArchitectureForCosi(),
 		Id:         imageUuidStr,
 		Disk:       diskInfo,
-		Images:     make([]FileSystem, len(imageData)),
+		Images:     make([]cosiapi.FileSystem, len(imageData)),
 		OsRelease:  osRelease,
 		OsPackages: osPackages,
 		Bootloader: handleBootloaderMetadata(cosiBootMetadata),
-		Compression: Compression{
+		Compression: cosiapi.Compression{
 			MaxWindowLog: compressionLong,
 		},
 	}
@@ -316,7 +317,7 @@ func buildCosiFile(sourceDir string, outputFile string, partitions []outputParti
 	return nil
 }
 
-func addFileToCosi(tw *tar.Writer, source string, image ImageFile) error {
+func addFileToCosi(tw *tar.Writer, source string, image cosiapi.ImageFile) error {
 	file, err := os.Open(source)
 	if err != nil {
 		return fmt.Errorf("failed to open file :\n%w", err)
@@ -356,7 +357,7 @@ func sha384sum(path string) (string, error) {
 	return fmt.Sprintf("%x", sha384.Sum(nil)), nil
 }
 
-func populateImageFile(source string, imageFile *ImageFile) error {
+func populateImageFile(source string, imageFile *cosiapi.ImageFile) error {
 	stat, err := os.Stat(source)
 	if err != nil {
 		return fmt.Errorf("failed to stat %s:\n%w", source, err)
@@ -382,13 +383,13 @@ func getArchitectureForCosi() string {
 	return runtime.GOARCH
 }
 
-func getAllPackagesFromChroot(imageConnection *imageconnection.ImageConnection, distroHandler DistroHandler) ([]OsPackage, error) {
+func getAllPackagesFromChroot(imageConnection *imageconnection.ImageConnection, distroHandler DistroHandler) ([]cosiapi.OsPackage, error) {
 	return distroHandler.GetAllPackagesFromChroot(imageConnection.Chroot())
 }
 
 func extractCosiBootMetadata(buildDirAbs string, imageConnection *imageconnection.ImageConnection,
 	distroHandler DistroHandler, toolsChroot *safechroot.Chroot,
-) (*CosiBootloader, error) {
+) (*cosiapi.Bootloader, error) {
 	bootloaderType, err := distroHandler.DetectBootloaderType(imageConnection.Chroot(), toolsChroot)
 	if err != nil {
 		return nil, fmt.Errorf("failed to detect bootloader type:\n%w", err)
@@ -397,16 +398,16 @@ func extractCosiBootMetadata(buildDirAbs string, imageConnection *imageconnectio
 	chrootDir := imageConnection.Chroot().RootDir()
 
 	switch bootloaderType {
-	case BootloaderTypeSystemdBoot:
+	case cosiapi.BootloaderTypeSystemdBoot:
 		// Try extracting systemd-boot entries (UKI + config or config-only)
 		configEntries, err := extractSystemdBootEntriesIfPresent(chrootDir)
 		if err != nil {
 			return nil, fmt.Errorf("error extracting systemd-boot config entries:\n%w", err)
 		}
 		if len(configEntries) > 0 {
-			return &CosiBootloader{
-				Type:        BootloaderTypeSystemdBoot,
-				SystemdBoot: &SystemDBoot{Entries: configEntries},
+			return &cosiapi.Bootloader{
+				Type:        cosiapi.BootloaderTypeSystemdBoot,
+				SystemdBoot: &cosiapi.SystemDBoot{Entries: configEntries},
 			}, nil
 		}
 
@@ -416,17 +417,17 @@ func extractCosiBootMetadata(buildDirAbs string, imageConnection *imageconnectio
 			return nil, fmt.Errorf("error extracting UKI standalone entries:\n%w", err)
 		}
 		if len(ukiEntries) > 0 {
-			return &CosiBootloader{
-				Type:        BootloaderTypeSystemdBoot,
-				SystemdBoot: &SystemDBoot{Entries: ukiEntries},
+			return &cosiapi.Bootloader{
+				Type:        cosiapi.BootloaderTypeSystemdBoot,
+				SystemdBoot: &cosiapi.SystemDBoot{Entries: ukiEntries},
 			}, nil
 		}
 
 		return nil, fmt.Errorf("systemd-boot detected, but no supported boot entries found")
 
-	case BootloaderTypeGrub:
-		return &CosiBootloader{
-			Type:        BootloaderTypeGrub,
+	case cosiapi.BootloaderTypeGrub:
+		return &cosiapi.Bootloader{
+			Type:        cosiapi.BootloaderTypeGrub,
 			SystemdBoot: nil,
 		}, nil
 
@@ -435,7 +436,7 @@ func extractCosiBootMetadata(buildDirAbs string, imageConnection *imageconnectio
 	}
 }
 
-func extractUkiEntriesIfPresent(chrootDir, buildDir string, distroHandler DistroHandler) ([]SystemDBootEntry, error) {
+func extractUkiEntriesIfPresent(chrootDir, buildDir string, distroHandler DistroHandler) ([]cosiapi.SystemDBootEntry, error) {
 	espDir := filepath.Join(chrootDir, distroHandler.GetEspDir())
 
 	cmdlines, err := extractKernelCmdlineFromUkiEfis(espDir, buildDir)
@@ -443,15 +444,15 @@ func extractUkiEntriesIfPresent(chrootDir, buildDir string, distroHandler Distro
 		return nil, fmt.Errorf("failed to extract kernel cmdline from UKI .efi files:\n%w", err)
 	}
 
-	var entries []SystemDBootEntry
+	var entries []cosiapi.SystemDBootEntry
 	for kernelName, cmdline := range cmdlines {
 		efiPath := filepath.Join("/", distroHandler.GetEspDir(), "EFI/Linux", fmt.Sprintf("%s.efi", kernelName))
 		kernelVersion, err := getKernelVersion(kernelName)
 		if err != nil {
 			return nil, fmt.Errorf("invalid kernel name in UKI file (%s):\n%w", kernelName, err)
 		}
-		entries = append(entries, SystemDBootEntry{
-			Type:    SystemDBootEntryTypeUKIStandalone,
+		entries = append(entries, cosiapi.SystemDBootEntry{
+			Type:    cosiapi.SystemDBootEntryTypeUKIStandalone,
 			Path:    efiPath,
 			Kernel:  kernelVersion,
 			Cmdline: strings.TrimRight(cmdline, "\n"),
@@ -460,7 +461,7 @@ func extractUkiEntriesIfPresent(chrootDir, buildDir string, distroHandler Distro
 	return entries, nil
 }
 
-func extractSystemdBootEntriesIfPresent(chrootDir string) ([]SystemDBootEntry, error) {
+func extractSystemdBootEntriesIfPresent(chrootDir string) ([]cosiapi.SystemDBootEntry, error) {
 	loaderEntryDir := filepath.Join(chrootDir, "boot", "loader", "entries")
 	exists, err := file.DirExists(loaderEntryDir)
 	if err != nil {
@@ -478,13 +479,13 @@ func extractSystemdBootEntriesIfPresent(chrootDir string) ([]SystemDBootEntry, e
 	return entries, nil
 }
 
-func extractSystemdBootEntries(entryDir string) ([]SystemDBootEntry, error) {
+func extractSystemdBootEntries(entryDir string) ([]cosiapi.SystemDBootEntry, error) {
 	files, err := os.ReadDir(entryDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read directory %s:\n%w", entryDir, err)
 	}
 
-	var entries []SystemDBootEntry
+	var entries []cosiapi.SystemDBootEntry
 
 	for _, file := range files {
 		entry, err := parseSystemdBootEntryFromFile(entryDir, file)
@@ -499,7 +500,7 @@ func extractSystemdBootEntries(entryDir string) ([]SystemDBootEntry, error) {
 	return entries, nil
 }
 
-func parseSystemdBootEntryFromFile(entryDir string, file fs.DirEntry) (*SystemDBootEntry, error) {
+func parseSystemdBootEntryFromFile(entryDir string, file fs.DirEntry) (*cosiapi.SystemDBootEntry, error) {
 	if file.IsDir() || !strings.HasSuffix(file.Name(), ".conf") {
 		return nil, nil
 	}
@@ -510,7 +511,7 @@ func parseSystemdBootEntryFromFile(entryDir string, file fs.DirEntry) (*SystemDB
 		return nil, fmt.Errorf("failed to read %s:\n%w", absPath, err)
 	}
 
-	entry := &SystemDBootEntry{
+	entry := &cosiapi.SystemDBootEntry{
 		Path: filepath.Join("/boot/loader/entries", file.Name()),
 	}
 
@@ -555,25 +556,25 @@ func parseSystemdBootEntryFromFile(entryDir string, file fs.DirEntry) (*SystemDB
 			if kernelVer, err := getKernelVersion(filepath.Base(value)); err == nil {
 				entry.Kernel = kernelVer
 			}
-			entry.Type = SystemDBootEntryTypeUKIConfig
+			entry.Type = cosiapi.SystemDBootEntryTypeUKIConfig
 		}
 	}
 
 	// Determine fallback type
 	if entry.Type == "" {
 		if strings.HasSuffix(entry.Kernel, ".efi") {
-			entry.Type = SystemDBootEntryTypeUKIConfig
+			entry.Type = cosiapi.SystemDBootEntryTypeUKIConfig
 		} else {
-			entry.Type = SystemDBootEntryTypeConfig
+			entry.Type = cosiapi.SystemDBootEntryTypeConfig
 		}
 	}
 
 	return entry, nil
 }
 
-func handleBootloaderMetadata(bootloader *CosiBootloader) CosiBootloader {
+func handleBootloaderMetadata(bootloader *cosiapi.Bootloader) cosiapi.Bootloader {
 	if bootloader == nil {
-		return CosiBootloader{}
+		return cosiapi.Bootloader{}
 	}
 	return *bootloader
 }
@@ -601,12 +602,12 @@ func padToMegabyte(imageFile string) error {
 	return nil
 }
 
-// detectBootloaderType reports which bootloader is installed in imageChroot by probing for the presence of any
+// detectcosiapi.BootloaderType reports which bootloader is installed in imageChroot by probing for the presence of any
 // candidate package. The name of the detected package is also returned. toolsChroot has the same semantics as in
 // DistroHandler.IsPackageInstalled.
 func detectBootloaderType(distroHandler DistroHandler, imageChroot safechroot.ChrootInterface,
 	toolsChroot *safechroot.Chroot, grubEfiPackages, systemdBootPackages []string,
-) (BootloaderType, string, error) {
+) (cosiapi.BootloaderType, string, error) {
 	for _, pkg := range grubEfiPackages {
 		logger.Log.Debugf("Checking if package (%s) is installed", pkg)
 		installed, err := distroHandler.IsPackageInstalled(imageChroot, toolsChroot, pkg)
@@ -614,12 +615,12 @@ func detectBootloaderType(distroHandler DistroHandler, imageChroot safechroot.Ch
 			return "", "", err
 		}
 		if installed {
-			return BootloaderTypeGrub, pkg, nil
+			return cosiapi.BootloaderTypeGrub, pkg, nil
 		}
 	}
 	pkg, err := isSystemdBootPackageInstalled(distroHandler, imageChroot, toolsChroot, systemdBootPackages)
 	if err == nil {
-		return BootloaderTypeSystemdBoot, pkg, nil
+		return cosiapi.BootloaderTypeSystemdBoot, pkg, nil
 	}
 
 	allPackages := slices.Concat(grubEfiPackages, systemdBootPackages)

--- a/toolkit/tools/pkg/imagecustomizerlib/cosicommon.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/cosicommon.go
@@ -602,7 +602,7 @@ func padToMegabyte(imageFile string) error {
 	return nil
 }
 
-// detectcosiapi.BootloaderType reports which bootloader is installed in imageChroot by probing for the presence of any
+// detectBootloaderType reports which bootloader is installed in imageChroot by probing for the presence of any
 // candidate package. The name of the detected package is also returned. toolsChroot has the same semantics as in
 // DistroHandler.IsPackageInstalled.
 func detectBootloaderType(distroHandler DistroHandler, imageChroot safechroot.ChrootInterface,

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_deb.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_deb.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/cosiapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/file"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/logger"
@@ -349,7 +350,7 @@ func isPackageInstalledDeb(imageChroot safechroot.ChrootInterface, packageName s
 }
 
 // getAllPackagesFromChrootDeb retrieves all installed packages from a DEB-based system.
-func getAllPackagesFromChrootDeb(imageChroot safechroot.ChrootInterface) ([]OsPackage, error) {
+func getAllPackagesFromChrootDeb(imageChroot safechroot.ChrootInterface) ([]cosiapi.OsPackage, error) {
 	out, _, err := shell.NewExecBuilder("dpkg-query", "-W", "-f=${Package}\t${Version}\t${Architecture}\n").
 		LogLevel(logrus.TraceLevel, logrus.DebugLevel).
 		Chroot(imageChroot.ChrootDir()).
@@ -359,7 +360,7 @@ func getAllPackagesFromChrootDeb(imageChroot safechroot.ChrootInterface) ([]OsPa
 	}
 
 	lines := strings.Split(strings.TrimSpace(out), "\n")
-	var packages []OsPackage
+	var packages []cosiapi.OsPackage
 	for _, line := range lines {
 		if line == "" {
 			continue
@@ -371,7 +372,7 @@ func getAllPackagesFromChrootDeb(imageChroot safechroot.ChrootInterface) ([]OsPa
 
 		// For dpkg, it does not have a separate release field.
 		// Version contains epoch:version-release, use the whole thing as version.
-		packages = append(packages, OsPackage{
+		packages = append(packages, cosiapi.OsPackage{
 			Name:    parts[0],
 			Version: parts[1],
 			// dpkg doesn't have separate release

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_rpm.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_rpm.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/cosiapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/logger"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safechroot"
@@ -339,7 +340,7 @@ func cleanRpmCache(ctx context.Context, imageChroot *safechroot.Chroot, toolsChr
 }
 
 // getAllPackagesFromChrootRpm retrieves all installed packages from an RPM-based system
-func getAllPackagesFromChrootRpm(imageChroot safechroot.ChrootInterface) ([]OsPackage, error) {
+func getAllPackagesFromChrootRpm(imageChroot safechroot.ChrootInterface) ([]cosiapi.OsPackage, error) {
 	out, _, err := shell.NewExecBuilder("rpm", "-qa", "--queryformat", "%{NAME} %{VERSION} %{RELEASE} %{ARCH}\n").
 		LogLevel(logrus.TraceLevel, logrus.DebugLevel).
 		Chroot(imageChroot.ChrootDir()).
@@ -349,13 +350,13 @@ func getAllPackagesFromChrootRpm(imageChroot safechroot.ChrootInterface) ([]OsPa
 	}
 
 	lines := strings.Split(strings.TrimSpace(out), "\n")
-	var packages []OsPackage
+	var packages []cosiapi.OsPackage
 	for _, line := range lines {
 		parts := strings.Fields(line)
 		if len(parts) != 4 {
 			return nil, fmt.Errorf("malformed RPM line encountered while parsing installed RPMs for COSI: %q", line)
 		}
-		packages = append(packages, OsPackage{
+		packages = append(packages, cosiapi.OsPackage{
 			Name:    parts[0],
 			Version: parts[1],
 			Release: parts[2],

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/cosiapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/file"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/imageconnection"
@@ -961,9 +962,9 @@ func getPkgVersionFromChroot(imageConnection *imageconnection.ImageConnection, p
 	return versionOutput, nil
 }
 
-func ensurePackagesInstalled(t *testing.T, installedPackages []OsPackage, packages ...string) {
+func ensurePackagesInstalled(t *testing.T, installedPackages []cosiapi.OsPackage, packages ...string) {
 	for _, packageName := range packages {
-		assert.Truef(t, sliceutils.ContainsFunc(installedPackages, func(installedPackage OsPackage) bool {
+		assert.Truef(t, sliceutils.ContainsFunc(installedPackages, func(installedPackage cosiapi.OsPackage) bool {
 			return packageName == installedPackage.Name
 		}), "package not installed (%s)", packageName)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepartitions_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/cosiapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/file"
@@ -1041,7 +1042,7 @@ func testCustomizeImageAzureDataDiskHelper(t *testing.T, testName string,
 		return
 	}
 
-	expectedCosiMetadata := MetadataJson{}
+	expectedCosiMetadata := cosiapi.MetadataJson{}
 	switch baseImageInfo.Distro {
 	case baseImageDistroAzureLinux:
 		expectedCosiMetadata, err = expectedCosiMetadataForAzureLinux(baseImageInfo)

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/cosiapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safeloopback"
@@ -144,14 +145,14 @@ func testCustomizeImageVerityCosiExtractHelper(t *testing.T, testName string, ba
 		return
 	}
 
-	expectedCosiMetadata := MetadataJson{
-		Disk: Disk{
+	expectedCosiMetadata := cosiapi.MetadataJson{
+		Disk: cosiapi.Disk{
 			Size:       5254 * diskutils.MiB,
 			GptRegions: newTestCosiGptSections([]int{1, 2, 3, 4, 5}),
 		},
-		Images: []FileSystem{
+		Images: []cosiapi.FileSystem{
 			{
-				Image: ImageFile{
+				Image: cosiapi.ImageFile{
 					Path: "images/image_1.raw.zst",
 				},
 				MountPoint: "/boot/efi",
@@ -159,7 +160,7 @@ func testCustomizeImageVerityCosiExtractHelper(t *testing.T, testName string, ba
 				PartType:   imagecustomizerapi.PartitionTypeToUuid[imagecustomizerapi.PartitionTypeESP],
 			},
 			{
-				Image: ImageFile{
+				Image: cosiapi.ImageFile{
 					Path: "images/image_2.raw.zst",
 				},
 				MountPoint: "/boot",
@@ -167,20 +168,20 @@ func testCustomizeImageVerityCosiExtractHelper(t *testing.T, testName string, ba
 				PartType:   imagecustomizerapi.PartitionTypeToUuid[imagecustomizerapi.PartitionTypeLinuxGeneric],
 			},
 			{
-				Image: ImageFile{
+				Image: cosiapi.ImageFile{
 					Path: "images/image_3.raw.zst",
 				},
 				MountPoint: "/",
 				FsType:     "ext4",
 				PartType:   imagecustomizerapi.PartitionTypeToUuid[imagecustomizerapi.PartitionTypeLinuxGeneric],
-				Verity: &VerityConfig{
-					Image: ImageFile{
+				Verity: &cosiapi.VerityConfig{
+					Image: cosiapi.ImageFile{
 						Path: "images/image_4.raw.zst",
 					},
 				},
 			},
 			{
-				Image: ImageFile{
+				Image: cosiapi.ImageFile{
 					Path: "images/image_5.raw.zst",
 				},
 				MountPoint: "/var",
@@ -188,10 +189,10 @@ func testCustomizeImageVerityCosiExtractHelper(t *testing.T, testName string, ba
 				PartType:   imagecustomizerapi.PartitionTypeToUuid[imagecustomizerapi.PartitionTypeLinuxGeneric],
 			},
 		},
-		Bootloader: CosiBootloader{
+		Bootloader: cosiapi.Bootloader{
 			Type: "grub",
 		},
-		Compression: Compression{
+		Compression: cosiapi.Compression{
 			MaxWindowLog: imagecustomizerapi.DefaultCosiCompressionLong,
 		},
 	}
@@ -1094,16 +1095,16 @@ func testCustomizeImageVerityRootInlineCosiHelper(t *testing.T, testName string,
 		return
 	}
 
-	expectedCosiMetadata := MetadataJson{
-		Disk: Disk{
+	expectedCosiMetadata := cosiapi.MetadataJson{
+		Disk: cosiapi.Disk{
 			// 4348 MiB = 1 (alignment) + 250 (esp) + 1024 (boot) + 2048 (root) + 1024 (var) + 1 (secondary GPT).
 			// Tracks the partition layout in verity-root-inline-uki-*.yaml.
 			Size:       4348 * diskutils.MiB,
 			GptRegions: newTestCosiGptSections([]int{1, 2, 3, 4}),
 		},
-		Images: []FileSystem{
+		Images: []cosiapi.FileSystem{
 			{
-				Image: ImageFile{
+				Image: cosiapi.ImageFile{
 					Path: "images/image_1.raw.zst",
 				},
 				MountPoint: "/boot/efi",
@@ -1111,7 +1112,7 @@ func testCustomizeImageVerityRootInlineCosiHelper(t *testing.T, testName string,
 				PartType:   imagecustomizerapi.PartitionTypeToUuid[imagecustomizerapi.PartitionTypeESP],
 			},
 			{
-				Image: ImageFile{
+				Image: cosiapi.ImageFile{
 					Path: "images/image_2.raw.zst",
 				},
 				MountPoint: "/boot",
@@ -1119,20 +1120,20 @@ func testCustomizeImageVerityRootInlineCosiHelper(t *testing.T, testName string,
 				PartType:   imagecustomizerapi.PartitionTypeToUuid[imagecustomizerapi.PartitionTypeLinuxGeneric],
 			},
 			{
-				Image: ImageFile{
+				Image: cosiapi.ImageFile{
 					Path: "images/image_3.raw.zst",
 				},
 				MountPoint: "/",
 				FsType:     "ext4",
 				PartType:   imagecustomizerapi.PartitionTypeToUuid[imagecustomizerapi.PartitionTypeLinuxGeneric],
-				Verity: &VerityConfig{
-					Image: ImageFile{
+				Verity: &cosiapi.VerityConfig{
+					Image: cosiapi.ImageFile{
 						Path: "images/image_3.raw.zst",
 					},
 				},
 			},
 			{
-				Image: ImageFile{
+				Image: cosiapi.ImageFile{
 					Path: "images/image_4.raw.zst",
 				},
 				MountPoint: "/var",
@@ -1140,17 +1141,17 @@ func testCustomizeImageVerityRootInlineCosiHelper(t *testing.T, testName string,
 				PartType:   imagecustomizerapi.PartitionTypeToUuid[imagecustomizerapi.PartitionTypeLinuxGeneric],
 			},
 		},
-		Bootloader: CosiBootloader{
+		Bootloader: cosiapi.Bootloader{
 			Type: "systemd-boot",
-			SystemdBoot: &SystemDBoot{
-				Entries: []SystemDBootEntry{
+			SystemdBoot: &cosiapi.SystemDBoot{
+				Entries: []cosiapi.SystemDBootEntry{
 					{
 						Type: "uki-standalone",
 					},
 				},
 			},
 		},
-		Compression: Compression{
+		Compression: cosiapi.Compression{
 			MaxWindowLog: imagecustomizerapi.DefaultCosiCompressionLong,
 		},
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"slices"
 
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/cosiapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/imageconnection"
@@ -57,10 +58,10 @@ type DistroHandler interface {
 	GetPackageInformation(imageChroot *safechroot.Chroot, packageName string) (*PackageVersionInformation, error)
 
 	// Get all installed packages from the chroot
-	GetAllPackagesFromChroot(imageChroot safechroot.ChrootInterface) ([]OsPackage, error)
+	GetAllPackagesFromChroot(imageChroot safechroot.ChrootInterface) ([]cosiapi.OsPackage, error)
 
 	// Detect the bootloader type installed in the image. toolsChroot has the same semantics as in IsPackageInstalled.
-	DetectBootloaderType(imageChroot safechroot.ChrootInterface, toolsChroot *safechroot.Chroot) (BootloaderType, error)
+	DetectBootloaderType(imageChroot safechroot.ChrootInterface, toolsChroot *safechroot.Chroot) (cosiapi.BootloaderType, error)
 
 	// ValidateUkiDependencies verifies that the necessary dependencies for UKI customization are present in the image.
 	// toolsChroot has the same semantics as in IsPackageInstalled.

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"slices"
 
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/cosiapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/file"
@@ -136,7 +137,7 @@ func (d *aclDistroHandler) GetPackageInformation(imageChroot *safechroot.Chroot,
 	return d.packageManager.getPackageInformation(imageChroot, packageName)
 }
 
-func (d *aclDistroHandler) GetAllPackagesFromChroot(imageChroot safechroot.ChrootInterface) ([]OsPackage, error) {
+func (d *aclDistroHandler) GetAllPackagesFromChroot(imageChroot safechroot.ChrootInterface) ([]cosiapi.OsPackage, error) {
 	// This function is only used for metadata within a COSI file.
 	// So, it doesn't matter too much if the package list can't be provided.
 
@@ -170,9 +171,9 @@ func (d *aclDistroHandler) GetAllPackagesFromChroot(imageChroot safechroot.Chroo
 
 func (d *aclDistroHandler) DetectBootloaderType(imageChroot safechroot.ChrootInterface,
 	toolsChroot *safechroot.Chroot,
-) (BootloaderType, error) {
+) (cosiapi.BootloaderType, error) {
 	// ACL always uses systemd-boot.
-	return BootloaderTypeSystemdBoot, nil
+	return cosiapi.BootloaderTypeSystemdBoot, nil
 }
 
 func (d *aclDistroHandler) ValidateUkiDependencies(imageChroot safechroot.ChrootInterface,

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/cosiapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/installutils"
@@ -90,13 +91,13 @@ func (d *azureLinuxDistroHandler) GetPackageInformation(imageChroot *safechroot.
 	return d.packageManager.getPackageInformation(imageChroot, packageName)
 }
 
-func (d *azureLinuxDistroHandler) GetAllPackagesFromChroot(imageChroot safechroot.ChrootInterface) ([]OsPackage, error) {
+func (d *azureLinuxDistroHandler) GetAllPackagesFromChroot(imageChroot safechroot.ChrootInterface) ([]cosiapi.OsPackage, error) {
 	return getAllPackagesFromChrootRpm(imageChroot)
 }
 
 func (d *azureLinuxDistroHandler) DetectBootloaderType(imageChroot safechroot.ChrootInterface,
 	toolsChroot *safechroot.Chroot,
-) (BootloaderType, error) {
+) (cosiapi.BootloaderType, error) {
 	bootloaderType, _, err := detectBootloaderType(d, imageChroot, toolsChroot, grubEfiPackagesAzl3, systemdBootPackagesAzl3)
 	return bootloaderType, err
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux4.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux4.go
@@ -12,6 +12,7 @@ import (
 	"runtime"
 	"slices"
 
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/cosiapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/installutils"
@@ -108,13 +109,13 @@ func (d *azureLinux4DistroHandler) GetPackageInformation(imageChroot *safechroot
 }
 
 func (d *azureLinux4DistroHandler) GetAllPackagesFromChroot(imageChroot safechroot.ChrootInterface,
-) ([]OsPackage, error) {
+) ([]cosiapi.OsPackage, error) {
 	return getAllPackagesFromChrootRpm(imageChroot)
 }
 
 func (d *azureLinux4DistroHandler) DetectBootloaderType(imageChroot safechroot.ChrootInterface,
 	toolsChroot *safechroot.Chroot,
-) (BootloaderType, error) {
+) (cosiapi.BootloaderType, error) {
 	var grubEfiPackages []string
 	switch runtime.GOARCH {
 	case "amd64":
@@ -127,7 +128,7 @@ func (d *azureLinux4DistroHandler) DetectBootloaderType(imageChroot safechroot.C
 	if err != nil {
 		return bootloaderType, err
 	}
-	if bootloaderType == BootloaderTypeSystemdBoot {
+	if bootloaderType == cosiapi.BootloaderTypeSystemdBoot {
 		d.warnIfUnsignedSystemdBootPackage(detectedPackage)
 	}
 	return bootloaderType, nil

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"slices"
 
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/cosiapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/installutils"
@@ -148,13 +149,13 @@ func (d *fedoraDistroHandler) GetPackageInformation(imageChroot *safechroot.Chro
 	return d.packageManager.getPackageInformation(imageChroot, packageName)
 }
 
-func (d *fedoraDistroHandler) GetAllPackagesFromChroot(imageChroot safechroot.ChrootInterface) ([]OsPackage, error) {
+func (d *fedoraDistroHandler) GetAllPackagesFromChroot(imageChroot safechroot.ChrootInterface) ([]cosiapi.OsPackage, error) {
 	return getAllPackagesFromChrootRpm(imageChroot)
 }
 
 func (d *fedoraDistroHandler) DetectBootloaderType(imageChroot safechroot.ChrootInterface,
 	toolsChroot *safechroot.Chroot,
-) (BootloaderType, error) {
+) (cosiapi.BootloaderType, error) {
 	var grubEfiPackage string
 	switch runtime.GOARCH {
 	case "amd64":

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_ubuntu.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_ubuntu.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"slices"
 
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/cosiapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/installutils"
@@ -119,13 +120,13 @@ func (d *ubuntuDistroHandler) GetPackageInformation(imageChroot *safechroot.Chro
 	return nil, fmt.Errorf("getting package information is not supported yet for Ubuntu images")
 }
 
-func (d *ubuntuDistroHandler) GetAllPackagesFromChroot(imageChroot safechroot.ChrootInterface) ([]OsPackage, error) {
+func (d *ubuntuDistroHandler) GetAllPackagesFromChroot(imageChroot safechroot.ChrootInterface) ([]cosiapi.OsPackage, error) {
 	return getAllPackagesFromChrootDeb(imageChroot)
 }
 
 func (d *ubuntuDistroHandler) DetectBootloaderType(imageChroot safechroot.ChrootInterface,
 	toolsChroot *safechroot.Chroot,
-) (BootloaderType, error) {
+) (cosiapi.BootloaderType, error) {
 	grubEfiPackages := []string{"grub-efi"}
 	switch runtime.GOARCH {
 	case "amd64":

--- a/toolkit/tools/pkg/imagecustomizerlib/extractgpt.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractgpt.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/cosiapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/logger"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/randomization"
@@ -209,7 +210,7 @@ func extractSectorsFromFile(srcFile *os.File, outFile string, sectorSize int,
 }
 
 // buildDiskMetadata constructs the Disk struct from extracted GPT data and partition metadata.
-func buildDiskMetadata(gptData *GptExtractedData, gptImageFile ImageFile, partitionImages map[int]ImageFile) (Disk, error) {
+func buildDiskMetadata(gptData *GptExtractedData, gptImageFile cosiapi.ImageFile, partitionImages map[int]cosiapi.ImageFile) (cosiapi.Disk, error) {
 	pt := gptData.PartitionTable
 
 	sectorSize := pt.SectorSize
@@ -217,17 +218,17 @@ func buildDiskMetadata(gptData *GptExtractedData, gptImageFile ImageFile, partit
 		sectorSize = 512
 	}
 
-	gptRegions := make([]GptDiskRegion, 0, 1+len(pt.Partitions))
+	gptRegions := make([]cosiapi.GptDiskRegion, 0, 1+len(pt.Partitions))
 
-	gptRegions = append(gptRegions, GptDiskRegion{
+	gptRegions = append(gptRegions, cosiapi.GptDiskRegion{
 		Image: gptImageFile,
-		Type:  RegionTypePrimaryGpt,
+		Type:  cosiapi.RegionTypePrimaryGpt,
 	})
 
 	for _, partition := range pt.Partitions {
 		partNum, err := getPartitionNum(partition.Path)
 		if err != nil {
-			return Disk{}, fmt.Errorf("failed to get partition number from path (%s):\n%w", partition.Path, err)
+			return cosiapi.Disk{}, fmt.Errorf("failed to get partition number from path (%s):\n%w", partition.Path, err)
 		}
 
 		partImage, exists := partitionImages[partNum]
@@ -235,17 +236,17 @@ func buildDiskMetadata(gptData *GptExtractedData, gptImageFile ImageFile, partit
 			continue
 		}
 
-		region := GptDiskRegion{
+		region := cosiapi.GptDiskRegion{
 			Image:  partImage,
-			Type:   RegionTypePartition,
+			Type:   cosiapi.RegionTypePartition,
 			Number: &partNum,
 		}
 		gptRegions = append(gptRegions, region)
 	}
 
-	return Disk{
+	return cosiapi.Disk{
 		Size:       gptData.DiskSize,
-		Type:       DiskTypeGpt,
+		Type:       cosiapi.DiskTypeGpt,
 		LbaSize:    sectorSize,
 		GptRegions: gptRegions,
 	}, nil

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
@@ -229,7 +229,7 @@ func TestAddSkippableFrame(t *testing.T) {
 	partitionFilepath, err := addSkippableFrame(tempPartitionFilepath, skippableFrameMetadata, partitionFilename, testDir)
 	assert.NoError(t, err)
 
-	// Verify decosiapi.Compression with skippable frame
+	// Verify decompression with skippable frame
 	err = verifySkippableFrameDecompression(partitionRawFilepath, partitionFilepath)
 	assert.NoError(t, err)
 

--- a/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/extractpartitions_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/klauspost/compress/zstd"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/cosiapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/file"
@@ -27,14 +28,14 @@ import (
 )
 
 var (
-	expectedCosiMetadataForAzlCoreEfi = MetadataJson{
-		Disk: Disk{
+	expectedCosiMetadataForAzlCoreEfi = cosiapi.MetadataJson{
+		Disk: cosiapi.Disk{
 			Size:       4 * diskutils.GiB,
 			GptRegions: newTestCosiGptSections([]int{1, 2}),
 		},
-		Images: []FileSystem{
+		Images: []cosiapi.FileSystem{
 			{
-				Image: ImageFile{
+				Image: cosiapi.ImageFile{
 					Path: "images/image_1.raw.zst",
 				},
 				MountPoint: "/boot/efi",
@@ -42,7 +43,7 @@ var (
 				PartType:   imagecustomizerapi.PartitionTypeToUuid[imagecustomizerapi.PartitionTypeESP],
 			},
 			{
-				Image: ImageFile{
+				Image: cosiapi.ImageFile{
 					Path: "images/image_2.raw.zst",
 				},
 				MountPoint: "/",
@@ -50,10 +51,10 @@ var (
 				PartType:   imagecustomizerapi.PartitionTypeToUuid[imagecustomizerapi.PartitionTypeLinuxGeneric],
 			},
 		},
-		Bootloader: CosiBootloader{
+		Bootloader: cosiapi.Bootloader{
 			Type: "grub",
 		},
-		Compression: Compression{
+		Compression: cosiapi.Compression{
 			MaxWindowLog: imagecustomizerapi.DefaultCosiCompressionLong,
 		},
 	}
@@ -61,14 +62,14 @@ var (
 	// Azure Linux 4.0 core-efi base image has a 15 GiB virtual disk and tags the
 	// rootfs with the discoverable-partitions arch-specific root GUID instead of
 	// the legacy linux-filesystem GUID used by AzL2/AzL3.
-	expectedCosiMetadataForAzl4CoreEfi = MetadataJson{
-		Disk: Disk{
+	expectedCosiMetadataForAzl4CoreEfi = cosiapi.MetadataJson{
+		Disk: cosiapi.Disk{
 			Size:       15 * diskutils.GiB,
 			GptRegions: newTestCosiGptSections([]int{1, 2}),
 		},
-		Images: []FileSystem{
+		Images: []cosiapi.FileSystem{
 			{
-				Image: ImageFile{
+				Image: cosiapi.ImageFile{
 					Path: "images/image_1.raw.zst",
 				},
 				MountPoint: "/boot/efi",
@@ -76,7 +77,7 @@ var (
 				PartType:   imagecustomizerapi.PartitionTypeToUuid[imagecustomizerapi.PartitionTypeESP],
 			},
 			{
-				Image: ImageFile{
+				Image: cosiapi.ImageFile{
 					Path: "images/image_2.raw.zst",
 				},
 				MountPoint: "/",
@@ -84,17 +85,17 @@ var (
 				PartType:   imagecustomizerapi.PartitionTypeToUuid[imagecustomizerapi.PartitionTypeRoot],
 			},
 		},
-		Bootloader: CosiBootloader{
+		Bootloader: cosiapi.Bootloader{
 			Type: "grub",
 		},
-		Compression: Compression{
+		Compression: cosiapi.Compression{
 			MaxWindowLog: imagecustomizerapi.DefaultCosiCompressionLong,
 		},
 	}
 
-	expectedCosiFileSystemsForUbuntu2204 = []FileSystem{
+	expectedCosiFileSystemsForUbuntu2204 = []cosiapi.FileSystem{
 		{
-			Image: ImageFile{
+			Image: cosiapi.ImageFile{
 				Path: "images/image_1.raw.zst",
 			},
 			MountPoint: "/",
@@ -102,7 +103,7 @@ var (
 			PartType:   imagecustomizerapi.PartitionTypeToUuid[imagecustomizerapi.PartitionTypeLinuxGeneric],
 		},
 		{
-			Image: ImageFile{
+			Image: cosiapi.ImageFile{
 				Path: "images/image_15.raw.zst",
 			},
 			MountPoint: "/boot/efi",
@@ -111,37 +112,37 @@ var (
 		},
 	}
 
-	expectedCosiMetadataForUbuntu2204CloudAmd64 = MetadataJson{
-		Disk: Disk{
+	expectedCosiMetadataForUbuntu2204CloudAmd64 = cosiapi.MetadataJson{
+		Disk: cosiapi.Disk{
 			Size:       30721 * diskutils.MiB,
 			GptRegions: newTestCosiGptSections([]int{1, 14, 15}),
 		},
 		Images: expectedCosiFileSystemsForUbuntu2204,
-		Bootloader: CosiBootloader{
+		Bootloader: cosiapi.Bootloader{
 			Type: "grub",
 		},
-		Compression: Compression{
+		Compression: cosiapi.Compression{
 			MaxWindowLog: imagecustomizerapi.DefaultCosiCompressionLong,
 		},
 	}
 
-	expectedCosiMetadataForUbuntu2204CloudArm64 = MetadataJson{
-		Disk: Disk{
+	expectedCosiMetadataForUbuntu2204CloudArm64 = cosiapi.MetadataJson{
+		Disk: cosiapi.Disk{
 			Size:       30721 * diskutils.MiB,
 			GptRegions: newTestCosiGptSections([]int{1, 15}),
 		},
 		Images: expectedCosiFileSystemsForUbuntu2204,
-		Bootloader: CosiBootloader{
+		Bootloader: cosiapi.Bootloader{
 			Type: "grub",
 		},
-		Compression: Compression{
+		Compression: cosiapi.Compression{
 			MaxWindowLog: imagecustomizerapi.DefaultCosiCompressionLong,
 		},
 	}
 
-	expectedCosiFileSystemsForUbuntu2404 = []FileSystem{
+	expectedCosiFileSystemsForUbuntu2404 = []cosiapi.FileSystem{
 		{
-			Image: ImageFile{
+			Image: cosiapi.ImageFile{
 				Path: "images/image_1.raw.zst",
 			},
 			MountPoint: "/",
@@ -149,7 +150,7 @@ var (
 			PartType:   imagecustomizerapi.PartitionTypeToUuid[imagecustomizerapi.PartitionTypeLinuxGeneric],
 		},
 		{
-			Image: ImageFile{
+			Image: cosiapi.ImageFile{
 				Path: "images/image_15.raw.zst",
 			},
 			MountPoint: "/boot/efi",
@@ -157,7 +158,7 @@ var (
 			PartType:   imagecustomizerapi.PartitionTypeToUuid[imagecustomizerapi.PartitionTypeESP],
 		},
 		{
-			Image: ImageFile{
+			Image: cosiapi.ImageFile{
 				Path: "images/image_16.raw.zst",
 			},
 			MountPoint: "/boot",
@@ -166,30 +167,30 @@ var (
 		},
 	}
 
-	expectedCosiMetadataForUbuntu2404CloudAmd64 = MetadataJson{
-		Disk: Disk{
+	expectedCosiMetadataForUbuntu2404CloudAmd64 = cosiapi.MetadataJson{
+		Disk: cosiapi.Disk{
 			Size:       30721 * diskutils.MiB,
 			GptRegions: newTestCosiGptSections([]int{1, 14, 15, 16}),
 		},
 		Images: expectedCosiFileSystemsForUbuntu2404,
-		Bootloader: CosiBootloader{
+		Bootloader: cosiapi.Bootloader{
 			Type: "grub",
 		},
-		Compression: Compression{
+		Compression: cosiapi.Compression{
 			MaxWindowLog: imagecustomizerapi.DefaultCosiCompressionLong,
 		},
 	}
 
-	expectedCosiMetadataForUbuntu2404CloudArm64 = MetadataJson{
-		Disk: Disk{
+	expectedCosiMetadataForUbuntu2404CloudArm64 = cosiapi.MetadataJson{
+		Disk: cosiapi.Disk{
 			Size:       30721 * diskutils.MiB,
 			GptRegions: newTestCosiGptSections([]int{1, 15, 16}),
 		},
 		Images: expectedCosiFileSystemsForUbuntu2404,
-		Bootloader: CosiBootloader{
+		Bootloader: cosiapi.Bootloader{
 			Type: "grub",
 		},
-		Compression: Compression{
+		Compression: cosiapi.Compression{
 			MaxWindowLog: imagecustomizerapi.DefaultCosiCompressionLong,
 		},
 	}
@@ -197,14 +198,14 @@ var (
 
 // expectedCosiMetadataForAzureLinux returns the expected COSI metadata for the given Azure Linux core-efi base image.
 // AzL4 differs from AzL2/AzL3 in disk size and rootfs partition type GUID.
-func expectedCosiMetadataForAzureLinux(baseImageInfo testBaseImageInfo) (MetadataJson, error) {
+func expectedCosiMetadataForAzureLinux(baseImageInfo testBaseImageInfo) (cosiapi.MetadataJson, error) {
 	switch baseImageInfo.Version {
 	case baseImageVersionAzl2, baseImageVersionAzl3:
 		return expectedCosiMetadataForAzlCoreEfi, nil
 	case baseImageVersionAzl4:
 		return expectedCosiMetadataForAzl4CoreEfi, nil
 	default:
-		return MetadataJson{}, fmt.Errorf("unexpected Azure Linux version: %s", baseImageInfo.Version)
+		return cosiapi.MetadataJson{}, fmt.Errorf("unexpected Azure Linux version: %s", baseImageInfo.Version)
 	}
 }
 
@@ -228,7 +229,7 @@ func TestAddSkippableFrame(t *testing.T) {
 	partitionFilepath, err := addSkippableFrame(tempPartitionFilepath, skippableFrameMetadata, partitionFilename, testDir)
 	assert.NoError(t, err)
 
-	// Verify decompression with skippable frame
+	// Verify decosiapi.Compression with skippable frame
 	err = verifySkippableFrameDecompression(partitionRawFilepath, partitionFilepath)
 	assert.NoError(t, err)
 
@@ -271,17 +272,17 @@ func extractZstFile(zstFilePath string, outputFilePath string) error {
 }
 
 func extractCosiAndVerifyMetadata(t *testing.T, cosiFilePath string, partitionsOutputDir string,
-	expectedMetadata MetadataJson,
-) (MetadataJson, bool) {
+	expectedMetadata cosiapi.MetadataJson,
+) (cosiapi.MetadataJson, bool) {
 	partitionsPaths, metadata, err := extractCosi(cosiFilePath, partitionsOutputDir)
 	if !assert.NoError(t, err) {
-		return MetadataJson{}, false
+		return cosiapi.MetadataJson{}, false
 	}
 
 	assert.Equal(t, "1.2", metadata.Version)
 
 	assert.Equal(t, expectedMetadata.Disk.Size, metadata.Disk.Size)
-	assert.Equal(t, DiskTypeGpt, metadata.Disk.Type)
+	assert.Equal(t, cosiapi.DiskTypeGpt, metadata.Disk.Type)
 	assert.Equal(t, 512, metadata.Disk.LbaSize)
 
 	assert.Equal(t, len(expectedMetadata.Disk.GptRegions), len(partitionsPaths))
@@ -343,7 +344,7 @@ func extractCosiAndVerifyMetadata(t *testing.T, cosiFilePath string, partitionsO
 	return metadata, true
 }
 
-func verifyCosiImageFile(t *testing.T, expected ImageFile, actual ImageFile) {
+func verifyCosiImageFile(t *testing.T, expected cosiapi.ImageFile, actual cosiapi.ImageFile) {
 	assert.Equal(t, expected.Path, actual.Path)
 
 	assert.Less(t, uint64(0), actual.CompressedSize)
@@ -351,22 +352,22 @@ func verifyCosiImageFile(t *testing.T, expected ImageFile, actual ImageFile) {
 	assert.Regexp(t, `^[0-9a-fA-F]{96}$`, actual.Sha384)
 }
 
-func extractCosi(cosiFilePath, partitionsOutputDir string) ([]string, MetadataJson, error) {
+func extractCosi(cosiFilePath, partitionsOutputDir string) ([]string, cosiapi.MetadataJson, error) {
 	var extractedParitionsPaths []string
 
 	err := os.MkdirAll(partitionsOutputDir, os.ModePerm)
 	if err != nil {
-		return nil, MetadataJson{}, fmt.Errorf("failed to create output directory:\n%w", err)
+		return nil, cosiapi.MetadataJson{}, fmt.Errorf("failed to create output directory:\n%w", err)
 	}
 
 	// Open the COSI file
 	cosiFile, err := os.Open(cosiFilePath)
 	if err != nil {
-		return nil, MetadataJson{}, fmt.Errorf("failed to open COSI file:\n%w", err)
+		return nil, cosiapi.MetadataJson{}, fmt.Errorf("failed to open COSI file:\n%w", err)
 	}
 	defer cosiFile.Close()
 
-	cosiMetadata := MetadataJson{}
+	cosiMetadata := cosiapi.MetadataJson{}
 	foundCosiMetadata := false
 
 	tarReader := tar.NewReader(cosiFile)
@@ -376,7 +377,7 @@ func extractCosi(cosiFilePath, partitionsOutputDir string) ([]string, MetadataJs
 			break
 		}
 		if err != nil {
-			return nil, MetadataJson{}, fmt.Errorf("error reading tar:\n%w", err)
+			return nil, cosiapi.MetadataJson{}, fmt.Errorf("error reading tar:\n%w", err)
 		}
 
 		// Skip directories
@@ -387,14 +388,14 @@ func extractCosi(cosiFilePath, partitionsOutputDir string) ([]string, MetadataJs
 		// Validate the file path to prevent directory traversal
 		cleanPath := filepath.Clean(header.Name)
 		if strings.Contains(cleanPath, "..") {
-			return nil, MetadataJson{}, fmt.Errorf("invalid file path in tar archive: %s", header.Name)
+			return nil, cosiapi.MetadataJson{}, fmt.Errorf("invalid file path in tar archive: %s", header.Name)
 		}
 
 		switch {
 		case filepath.Ext(header.Name) == ".zst":
 			outputFilePath, err := writeZstAndRawToFile(partitionsOutputDir, header, tarReader)
 			if err != nil {
-				return nil, MetadataJson{}, fmt.Errorf("failed to extract partition from cosi:\n%w", err)
+				return nil, cosiapi.MetadataJson{}, fmt.Errorf("failed to extract partition from cosi:\n%w", err)
 			}
 
 			extractedParitionsPaths = append(extractedParitionsPaths, outputFilePath)
@@ -403,7 +404,7 @@ func extractCosi(cosiFilePath, partitionsOutputDir string) ([]string, MetadataJs
 		case header.Name == CosiMetadataName:
 			cosiMetadata, err = readCosiMetadata(tarReader)
 			if err != nil {
-				return nil, MetadataJson{}, fmt.Errorf("failed to read cosi metadata:\n%w", err)
+				return nil, cosiapi.MetadataJson{}, fmt.Errorf("failed to read cosi metadata:\n%w", err)
 			}
 
 			foundCosiMetadata = true
@@ -411,7 +412,7 @@ func extractCosi(cosiFilePath, partitionsOutputDir string) ([]string, MetadataJs
 	}
 
 	if !foundCosiMetadata {
-		return nil, MetadataJson{}, fmt.Errorf("no %s found in cosi file", CosiMetadataName)
+		return nil, cosiapi.MetadataJson{}, fmt.Errorf("no %s found in cosi file", CosiMetadataName)
 	}
 
 	return extractedParitionsPaths, cosiMetadata, nil
@@ -466,16 +467,16 @@ func writeZstAndRawToFile(outputDir string, header *tar.Header, tarReader io.Rea
 	return outputFilePath, nil
 }
 
-func readCosiMetadata(src io.Reader) (MetadataJson, error) {
+func readCosiMetadata(src io.Reader) (cosiapi.MetadataJson, error) {
 	data, err := io.ReadAll(src)
 	if err != nil {
-		return MetadataJson{}, fmt.Errorf("failed to read metadata.json:\n%w", err)
+		return cosiapi.MetadataJson{}, fmt.Errorf("failed to read metadata.json:\n%w", err)
 	}
 
-	metadata := MetadataJson{}
+	metadata := cosiapi.MetadataJson{}
 	err = json.Unmarshal(data, &metadata)
 	if err != nil {
-		return MetadataJson{}, fmt.Errorf("failed to parse metadata.json:\n%w", err)
+		return cosiapi.MetadataJson{}, fmt.Errorf("failed to parse metadata.json:\n%w", err)
 	}
 
 	return metadata, nil
@@ -660,14 +661,14 @@ func TestCustomizeImageExtractEmptyPartition(t *testing.T) {
 		return
 	}
 
-	expectedCosiMetadata := MetadataJson{
-		Disk: Disk{
+	expectedCosiMetadata := cosiapi.MetadataJson{
+		Disk: cosiapi.Disk{
 			Size:       4130 * diskutils.MiB,
 			GptRegions: newTestCosiGptSections([]int{1, 2, 3}),
 		},
-		Images: []FileSystem{
+		Images: []cosiapi.FileSystem{
 			{
-				Image: ImageFile{
+				Image: cosiapi.ImageFile{
 					Path: "images/image_1.raw.zst",
 				},
 				MountPoint: "/boot/efi",
@@ -675,7 +676,7 @@ func TestCustomizeImageExtractEmptyPartition(t *testing.T) {
 				PartType:   imagecustomizerapi.PartitionTypeToUuid[imagecustomizerapi.PartitionTypeESP],
 			},
 			{
-				Image: ImageFile{
+				Image: cosiapi.ImageFile{
 					Path: "images/image_2.raw.zst",
 				},
 				MountPoint: "/",
@@ -683,10 +684,10 @@ func TestCustomizeImageExtractEmptyPartition(t *testing.T) {
 				PartType:   imagecustomizerapi.PartitionTypeToUuid[imagecustomizerapi.PartitionTypeLinuxGeneric],
 			},
 		},
-		Bootloader: CosiBootloader{
+		Bootloader: cosiapi.Bootloader{
 			Type: "grub",
 		},
-		Compression: Compression{
+		Compression: cosiapi.Compression{
 			MaxWindowLog: imagecustomizerapi.DefaultCosiCompressionLong,
 		},
 	}
@@ -780,10 +781,10 @@ func TestBuildZstdArgs_UltraLevel(t *testing.T) {
 	}
 }
 
-func newTestCosiGptSections(partNums []int) []GptDiskRegion {
-	gptRegions := []GptDiskRegion{
+func newTestCosiGptSections(partNums []int) []cosiapi.GptDiskRegion {
+	gptRegions := []cosiapi.GptDiskRegion{
 		{
-			Image: ImageFile{
+			Image: cosiapi.ImageFile{
 				Path: "images/image_gpt.raw.zst",
 			},
 			Type: "primary-gpt",
@@ -791,8 +792,8 @@ func newTestCosiGptSections(partNums []int) []GptDiskRegion {
 	}
 
 	for _, partNum := range partNums {
-		partition := GptDiskRegion{
-			Image: ImageFile{
+		partition := cosiapi.GptDiskRegion{
+			Image: cosiapi.ImageFile{
 				Path: fmt.Sprintf("images/image_%d.raw.zst", partNum),
 			},
 			Type:   "partition",

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -11,6 +11,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/cosiapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/file"
@@ -105,8 +106,8 @@ type imageMetadata struct {
 
 	partitionsLayout       []fstabEntryPartNum
 	osRelease              string
-	osPackages             []OsPackage
-	cosiBootMetadata       *CosiBootloader
+	osPackages             []cosiapi.OsPackage
+	cosiBootMetadata       *cosiapi.Bootloader
 	distroHandler          DistroHandler
 	partitionOriginalSizes map[string]uint64
 }
@@ -529,8 +530,8 @@ func customizeOSContents(ctx context.Context, rc *ResolvedConfig, toolsChroot *s
 	}
 
 	// collect OS info if generating a COSI image
-	var osPackages []OsPackage
-	var cosiBootMetadata *CosiBootloader
+	var osPackages []cosiapi.OsPackage
+	var cosiBootMetadata *cosiapi.Bootloader
 	if rc.OutputImageFormat == imagecustomizerapi.ImageFormatTypeCosi || rc.OutputImageFormat == imagecustomizerapi.ImageFormatTypeBareMetalImage {
 		osPackages, cosiBootMetadata, err = collectOSInfo(ctx, rc.BuildDirAbs, rc.RawImageFile, partitionsLayout,
 			im.distroHandler, nil)
@@ -763,7 +764,7 @@ func customizeImageHelper(ctx context.Context, rc *ResolvedConfig, partitionsCus
 
 func collectOSInfo(ctx context.Context, buildDir string, rawImageFile string, partitionsLayout []fstabEntryPartNum,
 	distroHandler DistroHandler, toolsChroot *safechroot.Chroot,
-) ([]OsPackage, *CosiBootloader, error) {
+) ([]cosiapi.OsPackage, *cosiapi.Bootloader, error) {
 	imageMountPoint := filepath.Join(buildDir, "imageroot")
 
 	imageConnection, _, err := reconnectToExistingImage(ctx, rawImageFile, buildDir, imageMountPoint, true, true, false,
@@ -788,7 +789,7 @@ func collectOSInfo(ctx context.Context, buildDir string, rawImageFile string, pa
 
 func collectOSInfoHelper(ctx context.Context, buildDir string, imageConnection *imageconnection.ImageConnection,
 	distroHandler DistroHandler, toolsChroot *safechroot.Chroot,
-) ([]OsPackage, *CosiBootloader, error) {
+) ([]cosiapi.OsPackage, *cosiapi.Bootloader, error) {
 	_, span := otel.GetTracerProvider().Tracer(OtelTracerName).Start(ctx, "collect_os_info")
 	defer span.End()
 	osPackages, err := getAllPackagesFromChroot(imageConnection, distroHandler)

--- a/toolkit/tools/pkg/osmodifierlib/modifierutils.go
+++ b/toolkit/tools/pkg/osmodifierlib/modifierutils.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/cosiapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/logger"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safechroot"
@@ -62,7 +63,7 @@ func doModifications(ctx context.Context, baseConfigPath string, osConfig *osmod
 		return err
 	}
 
-	needsBootCustomizer := bootloaderType == imagecustomizerlib.BootloaderTypeGrub &&
+	needsBootCustomizer := bootloaderType == cosiapi.BootloaderTypeGrub &&
 		(osConfig.KernelCommandLine.ExtraCommandLine != nil ||
 			osConfig.Overlays != nil ||
 			osConfig.SELinux.Mode != imagecustomizerapi.SELinuxModeDefault ||
@@ -118,7 +119,7 @@ func doModifications(ctx context.Context, baseConfigPath string, osConfig *osmod
 	}
 
 	if osConfig.SELinux.Mode != imagecustomizerapi.SELinuxModeDefault &&
-		bootloaderType == imagecustomizerlib.BootloaderTypeSystemdBoot {
+		bootloaderType == cosiapi.BootloaderTypeSystemdBoot {
 		err = updateSELinuxForUkiBoot(osConfig.SELinux.Mode, dummyChroot, distroHandler)
 		if err != nil {
 			return err


### PR DESCRIPTION
Move the COSI metadata types into their own package. This will make it clearer when the code is using types that are specific to COSI.

This is being done in preparation of a new feature to create a package manifest, for use when the package tools and database are removed from the image.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
