### PR TITLE
Docs: Fix comment for RPM repo priority.

### DIFF
--- a/docs/imagecustomizer/api/cli/create.md
+++ b/docs/imagecustomizer/api/cli/create.md
@@ -97,11 +97,11 @@ Can be one of:
   environment and the URL will be replaced with the chroot equivalent URL. A
   `file+rel://` URL is handled similarly but the host path is relative to the repo
   file's parent directory. A `file+chroot://` URL refers to a file within the chroot
-  itself. If the tools chroot is being used (e.g. when using the [create](create.md)
-  subcommand), then this path is within the tools chroot instead of the OS chroot.
+  itself. If the tools chroot is being used, then this path is within the tools chroot
+  instead of the OS chroot.
 
-  If you use a repo file pointing to local directory containing RPM files, then you must
-  call `createrepo_c` (or `createrepo`) on the directory before using it as a repo:
+  If you use a repo file pointing to a local directory containing RPM files, then you
+  must call `createrepo_c` (or `createrepo`) on the directory before using it as a repo:
 
   ```bash
   createrepo_c --compatibility --update <rpms-directory>

--- a/docs/imagecustomizer/api/cli/create.md
+++ b/docs/imagecustomizer/api/cli/create.md
@@ -94,13 +94,24 @@ Can be one of:
 
   If the repo file's `baseurl` or `gpgkey` fields contain a `file://` URL, then the
   host's directories pointed to by the URL will be bind mounted into the chroot
-  environment and the URL will be replaced with the chroot equivalent URL.
+  environment and the URL will be replaced with the chroot equivalent URL. A
+  `file+rel://` URL is handled similarly but the host path is relative to the repo
+  file's parent directory. A `file+chroot://` URL refers to a file within the chroot
+  itself. If the tools chroot is being used (e.g. when using the [create](create.md)
+  subcommand), then this path is within the tools chroot instead of the OS chroot.
+
+  If you use a repo file pointing to local directory containing RPM files, then you must
+  call `createrepo_c` (or `createrepo`) on the directory before using it as a repo:
+
+  ```bash
+  createrepo_c --compatibility --update <rpms-directory>
+  ```
 
   GPG signature checking is enabled by default.
   If you wish to disable GPG checking, then set both `gpgcheck` and `repo_gpgcheck` to
   `0` in the repo file.
 
-  The repo file will only be used during image creation and will not be added to
+  The repo file will only be used during image customization and will not be added to
   the image.
   If you want to add the repo file to the image, then use
   [additionalFiles](../configuration/os.md#additionalfiles-additionalfile) to place
@@ -108,7 +119,8 @@ Can be one of:
 
 This option can be specified multiple times.
 
-RPM sources are specified in the order of priority from lowest to highest.
+If you need to prioritize one repo over another, then use a `*.repo` file and specify
+the `priority` field.
 
 See, [Building custom packages](../../reference/building-packages.md) for a guide on how to
 build your own packages for Azure Linux.

--- a/docs/imagecustomizer/api/cli/customize.md
+++ b/docs/imagecustomizer/api/cli/customize.md
@@ -204,6 +204,13 @@ Can be one of:
   itself. If the tools chroot is being used (e.g. when using the [create](create.md)
   subcommand), then this path is within the tools chroot instead of the OS chroot.
 
+  If you use a repo file pointing to local directory containing RPM files, then you must
+  call `createrepo_c` (or `createrepo`) on the directory before using it as a repo:
+
+  ```bash
+  createrepo_c --compatibility --update <rpms-directory>
+  ```
+
   GPG signature checking is enabled by default.
   If you wish to disable GPG checking, then set both `gpgcheck` and `repo_gpgcheck` to
   `0` in the repo file.
@@ -216,9 +223,8 @@ Can be one of:
 
 This option can be specified multiple times.
 
-RPM sources are specified in the order or priority from lowest to highest.
-If `--disable-base-image-rpm-repos` is not specified, then the in-built RPM repos are
-given the lowest priority.
+If you need to prioritize one repo over another, then use a `*.repo` file and specify
+the `priority` field.
 
 See, [Building custom packages](../../reference/building-packages.md) for a guide on how to
 build your own packages for Azure Linux.

--- a/docs/imagecustomizer/api/cli/customize.md
+++ b/docs/imagecustomizer/api/cli/customize.md
@@ -201,11 +201,11 @@ Can be one of:
   environment and the URL will be replaced with the chroot equivalent URL. A
   `file+rel://` URL is handled similarly but the host path is relative to the repo
   file's parent directory. A `file+chroot://` URL refers to a file within the chroot
-  itself. If the tools chroot is being used (e.g. when using the [create](create.md)
-  subcommand), then this path is within the tools chroot instead of the OS chroot.
+  itself. If the tools chroot is being used, then this path is within the tools chroot
+  instead of the OS chroot.
 
-  If you use a repo file pointing to local directory containing RPM files, then you must
-  call `createrepo_c` (or `createrepo`) on the directory before using it as a repo:
+  If you use a repo file pointing to a local directory containing RPM files, then you
+  must call `createrepo_c` (or `createrepo`) on the directory before using it as a repo:
 
   ```bash
   createrepo_c --compatibility --update <rpms-directory>

--- a/toolkit/tools/pkg/imagecustomizerlib/rpmsourcesmounts.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/rpmsourcesmounts.go
@@ -84,9 +84,6 @@ func (m *rpmSourcesMounts) mountRpmSourcesHelper(buildDir string, imageChroot *s
 
 	m.rpmsMountParentDirCreated = true
 
-	// Unfortunatley, tdnf doesn't support the repository priority field.
-	// So, to ensure repos are used in the correct order, create a single config file containing all the repos, specified
-	// in the order of highest priority to lowest priority.
 	allReposConfig := ini.Empty()
 
 	// Include base image's RPM sources.


### PR DESCRIPTION
The current docs claims the repos are prioritized in the order in which they are specified. However, this comment is incorrect. It was based on the early days of Azure Linux 2.0, where the tdnf version didn't support the repo priortization API of dnf. This changes fixes the docs.

Also, mention the `createrepo_c` command in the docs, for when a user wants to use a local RPMs directory in a `*.repo` file.

Also, unify the `--rpm-source` docs for `customize` and `create`.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
