### PR TITLE
[Backport] Allow `--help` and `--version` to run unprivileged in container

### DIFF
--- a/test/vmtests/vmtests/imagecustomizer/test_help.py
+++ b/test/vmtests/vmtests/imagecustomizer/test_help.py
@@ -1,0 +1,34 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+from docker import DockerClient
+
+from ..utils.docker_utils import container_run
+
+
+# Ensure the --help command can run without the container being privileged.
+def test_container_help(
+    docker_client: DockerClient,
+    image_customizer_container_url: str,
+) -> None:
+    _, _ = container_run(
+        docker_client,
+        image_customizer_container_url,
+        ["--help"],
+        detach=True,
+        privileged=False,
+    )
+
+
+# Ensure the --version command can run without the container being privileged.
+def test_container_version(
+    docker_client: DockerClient,
+    image_customizer_container_url: str,
+) -> None:
+    _, _ = container_run(
+        docker_client,
+        image_customizer_container_url,
+        ["--version"],
+        detach=True,
+        privileged=False,
+    )

--- a/toolkit/tools/imagecustomizer/container/entrypoint.sh
+++ b/toolkit/tools/imagecustomizer/container/entrypoint.sh
@@ -6,17 +6,19 @@
 set -e
 
 ENABLE_TELEMETRY="${ENABLE_TELEMETRY:-true}"
+HELP=false
 
 # Check if --disable-telemetry flag is present in arguments
 for arg in "$@"; do
-    if [[ "$arg" == "--disable-telemetry" ]]; then
-        ENABLE_TELEMETRY=false
-        break
-    fi
+    case "$arg" in
+        "--disable-telemetry") ENABLE_TELEMETRY=false;;
+        "--help") HELP=true;;
+        "--version") HELP=true;;
+    esac
 done
 
 # Start telemetry service if enabled and connection string is set
-if [[ "$ENABLE_TELEMETRY" == "true" ]] && [[ -n "$AZURE_MONITOR_CONNECTION_STRING" ]]; then
+if [[ "$HELP" == "false" ]] && [[ "$ENABLE_TELEMETRY" == "true" ]] && [[ -n "$AZURE_MONITOR_CONNECTION_STRING" ]]; then
 
     export OTEL_PORT=4317
     export OTEL_EXPORTER_OTLP_PROTOCOL="grpc"
@@ -26,8 +28,11 @@ if [[ "$ENABLE_TELEMETRY" == "true" ]] && [[ -n "$AZURE_MONITOR_CONNECTION_STRIN
     sleep 1
 fi
 
-# containerd by default creates /dev as a tmpfs and populates it with a copy of the host's /dev at the time of container
-# creation. Replace it with a real devtmpfs so that partitions are populated when a virtual disk is mounted.
-mount -t devtmpfs devtmpfs /dev
+if [[ "$HELP" == "false" ]]; then
+    # containerd by default creates /dev as a tmpfs and populates it with a copy of the host's /dev at the time of
+    # container creation. Replace it with a real devtmpfs so that partitions are populated when a virtual disk is
+    # mounted.
+    mount -t devtmpfs devtmpfs /dev
+fi
 
 imagecustomizer "$@"


### PR DESCRIPTION
Allow the `--help` and `--version` commands to run without needing to pass `--privileged` to Docker. This will help with the usability of the container.
