### PR TITLE
[Backport] Fix ISO->ISO customization with initrd.img distros. (#818)

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoartifactstore.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoartifactstore.go
@@ -481,7 +481,7 @@ func createIsoFilesStoreFromIsoImage(isoImageFile, storeDir string) (filesStore 
 		for _, f := range isoFiles {
 			base := filepath.Base(f)
 			isInitrd := strings.HasPrefix(base, initramfsPrefix) || strings.HasPrefix(base, initrdPrefix)
-			if isInitrd && strings.HasSuffix(base, ".img") {
+			if isInitrd {
 				initrdPath = f
 				break
 			}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
@@ -681,9 +681,17 @@ func testCustomizeImageLiveOSMultiKernel(t *testing.T, baseImageInfo testBaseIma
 // - ISO  {bootstrap}  to ISO {bootstrap}    , with no OS changes
 // - ISO  {bootstrap}  to ISO {full-os}      , with selinux disabled
 func TestCustomizeImageLiveOSInitramfs1(t *testing.T) {
-	baseImage, baseImageInfo := checkSkipForCustomizeDefaultAzureLinuxImage(t)
+	for _, baseImageInfo := range baseImageAzureLinuxAll {
+		t.Run(baseImageInfo.Name, func(t *testing.T) {
+			testCustomizeImageLiveOSInitramfs1Helper(t, baseImageInfo)
+		})
+	}
+}
 
-	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageLiveOSInitramfs1")
+func testCustomizeImageLiveOSInitramfs1Helper(t *testing.T, baseImageInfo testBaseImageInfo) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
+
+	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageLiveOSInitramfs1"+baseImageInfo.Name)
 	defer os.RemoveAll(testTempDir)
 
 	buildDir := filepath.Join(testTempDir, "build")


### PR DESCRIPTION
The logic for finding initramfs files for ISO distro detection when `initrd.img-*` names are used is wrong.