### PR TITLE
Allow LiveOS creation with --tools-dir.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler.go
@@ -55,7 +55,7 @@ type DistroHandler interface {
 	IsPackageInstalled(imageChroot safechroot.ChrootInterface, toolsChroot *safechroot.Chroot, packageName string) (bool, error)
 
 	// GetPackageInformation queries the installed-package database for packageName and returns its parsed information.
-	GetPackageInformation(imageChroot *safechroot.Chroot, packageName string) (*PackageVersionInformation, error)
+	GetPackageInformation(imageChroot *safechroot.Chroot, toolsChroot *safechroot.Chroot, packageName string) (*PackageVersionInformation, error)
 
 	// Get all installed packages from the chroot.
 	// toolsChroot has the same semantics as in IsPackageInstalled.

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
@@ -114,9 +114,10 @@ func (d *aclDistroHandler) IsPackageInstalled(imageChroot safechroot.ChrootInter
 	return d.packageManager.isPackageInstalled(imageChroot, toolsChroot, packageName)
 }
 
-func (d *aclDistroHandler) GetPackageInformation(imageChroot *safechroot.Chroot, packageName string,
+func (d *aclDistroHandler) GetPackageInformation(imageChroot *safechroot.Chroot, toolsChroot *safechroot.Chroot,
+	packageName string,
 ) (*PackageVersionInformation, error) {
-	return d.packageManager.getPackageInformation(imageChroot, packageName)
+	return d.packageManager.getPackageInformation(imageChroot, toolsChroot, packageName)
 }
 
 func (d *aclDistroHandler) GetAllPackagesFromChroot(imageChroot safechroot.ChrootInterface,

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux.go
@@ -88,9 +88,10 @@ func (d *azureLinuxDistroHandler) IsPackageInstalled(imageChroot safechroot.Chro
 	return d.packageManager.isPackageInstalled(imageChroot, toolsChroot, packageName)
 }
 
-func (d *azureLinuxDistroHandler) GetPackageInformation(imageChroot *safechroot.Chroot, packageName string,
+func (d *azureLinuxDistroHandler) GetPackageInformation(imageChroot *safechroot.Chroot, toolsChroot *safechroot.Chroot,
+	packageName string,
 ) (*PackageVersionInformation, error) {
-	return d.packageManager.getPackageInformation(imageChroot, packageName)
+	return d.packageManager.getPackageInformation(imageChroot, toolsChroot, packageName)
 }
 
 func (d *azureLinuxDistroHandler) GetAllPackagesFromChroot(imageChroot safechroot.ChrootInterface,

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux4.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux4.go
@@ -146,9 +146,10 @@ func (d *azureLinux4DistroHandler) IsPackageInstalled(imageChroot safechroot.Chr
 	return d.packageManager.isPackageInstalled(imageChroot, toolsChroot, packageName)
 }
 
-func (d *azureLinux4DistroHandler) GetPackageInformation(imageChroot *safechroot.Chroot, packageName string,
+func (d *azureLinux4DistroHandler) GetPackageInformation(imageChroot *safechroot.Chroot, toolsChroot *safechroot.Chroot,
+	packageName string,
 ) (*PackageVersionInformation, error) {
-	return d.packageManager.getPackageInformation(imageChroot, packageName)
+	return d.packageManager.getPackageInformation(imageChroot, toolsChroot, packageName)
 }
 
 func (d *azureLinux4DistroHandler) GetAllPackagesFromChroot(imageChroot safechroot.ChrootInterface,

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
@@ -166,9 +166,10 @@ func (d *fedoraDistroHandler) IsPackageInstalled(imageChroot safechroot.ChrootIn
 	return d.packageManager.isPackageInstalled(imageChroot, toolsChroot, packageName)
 }
 
-func (d *fedoraDistroHandler) GetPackageInformation(imageChroot *safechroot.Chroot, packageName string,
+func (d *fedoraDistroHandler) GetPackageInformation(imageChroot *safechroot.Chroot, toolsChroot *safechroot.Chroot,
+	packageName string,
 ) (*PackageVersionInformation, error) {
-	return d.packageManager.getPackageInformation(imageChroot, packageName)
+	return d.packageManager.getPackageInformation(imageChroot, toolsChroot, packageName)
 }
 
 func (d *fedoraDistroHandler) GetAllPackagesFromChroot(imageChroot safechroot.ChrootInterface,

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_ubuntu.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_ubuntu.go
@@ -117,7 +117,8 @@ func (d *ubuntuDistroHandler) IsPackageInstalled(imageChroot safechroot.ChrootIn
 	return isPackageInstalledDeb(imageChroot, packageName)
 }
 
-func (d *ubuntuDistroHandler) GetPackageInformation(imageChroot *safechroot.Chroot, packageName string,
+func (d *ubuntuDistroHandler) GetPackageInformation(imageChroot *safechroot.Chroot, toolsChroot *safechroot.Chroot,
+	packageName string,
 ) (*PackageVersionInformation, error) {
 	return nil, fmt.Errorf("getting package information is not supported yet for Ubuntu images")
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imagecustomizer.go
@@ -618,7 +618,7 @@ func convertWriteableFormatToOutputImage(ctx context.Context, rc *ResolvedConfig
 		if rebuildFullOsImage {
 			requestedSELinuxMode := rc.SELinux.Mode
 			err := createLiveOSFromRaw(ctx, rc.BuildDirAbs, inputIsoArtifacts, requestedSELinuxMode, rc.Iso, rc.Pxe,
-				rc.RawImageFile, rc.OutputImageFormat, rc.OutputImageFile, im.distroHandler)
+				rc.RawImageFile, rc.OutputImageFormat, rc.OutputImageFile, im.distroHandler, toolsChroot)
 			if err != nil {
 				return fmt.Errorf("%w:\n%w", ErrCreateLiveOSArtifacts, err)
 			}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoartifactstore.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoartifactstore.go
@@ -16,7 +16,9 @@ import (
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/file"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/logger"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safechroot"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safemount"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/sliceutils"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -407,42 +409,67 @@ func createIsoFilesStoreFromMountedImage(inputArtifactsStore *IsoArtifactsStore,
 }
 
 func createIsoInfoStoreFromMountedImage(buildDir string, imageRootDir string, distroHandler DistroHandler,
+	toolsChroot *safechroot.Chroot,
 ) (infoStore *IsoInfoStore, err error) {
 	infoStore = &IsoInfoStore{}
 
-	chroot := safechroot.NewChroot(imageRootDir, true /*isExistingDir*/)
+	var bindMount *safemount.Mount
+	chrootDir := imageRootDir
+	if toolsChroot != nil {
+		chrootDir = filepath.Join(toolsChroot.RootDir(), toolsRootImageDir)
+
+		bindMount, err = safemount.NewMount(imageRootDir, chrootDir, "", unix.MS_BIND, "", true)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create image bind mount in tools dir:\n%w", err)
+		}
+		defer bindMount.Close()
+	}
+
+	chroot := safechroot.NewChroot(chrootDir, true /*isExistingDir*/)
 	if chroot == nil {
-		return nil, fmt.Errorf("failed to create a new chroot object for (%s)", imageRootDir)
+		return nil, fmt.Errorf("failed to create a new chroot object for (%s)", chrootDir)
 	}
 	defer chroot.Close(true /*leaveOnDisk*/)
 
 	err = chroot.Initialize("", nil, nil, true /*includeDefaultMounts*/)
 	if err != nil {
-		return nil, fmt.Errorf("failed to initialize chroot object for (%s):\n%w", imageRootDir, err)
+		return nil, fmt.Errorf("failed to initialize chroot object for (%s):\n%w", chrootDir, err)
 	}
 
 	imageSELinuxMode, err := getSELinuxMode(buildDir, chroot, distroHandler)
 	if err != nil {
-		return nil, fmt.Errorf("failed to determine SELinux mode for (%s):\n%w", imageRootDir, err)
+		return nil, fmt.Errorf("failed to determine SELinux mode for (%s):\n%w", chrootDir, err)
 	}
 	infoStore.seLinuxMode = imageSELinuxMode
 
-	infoStore.dracutPackageInfo, err = distroHandler.GetPackageInformation(chroot, "dracut")
+	infoStore.dracutPackageInfo, err = distroHandler.GetPackageInformation(chroot, toolsChroot, "dracut")
 	if err != nil {
-		return nil, fmt.Errorf("failed to determine package information for dracut under (%s):\n%w", imageRootDir, err)
+		return nil, fmt.Errorf("failed to determine package information for dracut under (%s):\n%w", chrootDir, err)
 	}
 
 	// Note the MIC allows the user to install other selinux policy packages.
 	// So, the absence of selinux-policy does not mean that there are no selinux
 	// policy packages.
-	selinuxPolicyInstalled, err := distroHandler.IsPackageInstalled(chroot, nil, "selinux-policy")
+	selinuxPolicyInstalled, err := distroHandler.IsPackageInstalled(chroot, toolsChroot, "selinux-policy")
 	if err != nil {
-		return nil, fmt.Errorf("failed to check if selinux-policy is installed under (%s):\n%w", imageRootDir, err)
+		return nil, fmt.Errorf("failed to check if selinux-policy is installed under (%s):\n%w", chrootDir, err)
 	}
 	if selinuxPolicyInstalled {
-		infoStore.selinuxPolicyPackageInfo, err = distroHandler.GetPackageInformation(chroot, "selinux-policy")
+		infoStore.selinuxPolicyPackageInfo, err = distroHandler.GetPackageInformation(chroot, toolsChroot, "selinux-policy")
 		if err != nil {
-			return nil, fmt.Errorf("failed to determine package information for selinux-policy under (%s):\n%w", imageRootDir, err)
+			return nil, fmt.Errorf("failed to determine package information for selinux-policy under (%s):\n%w", chrootDir, err)
+		}
+	}
+
+	err = chroot.Close(true /*leaveOnDisk*/)
+	if err != nil {
+		return nil, err
+	}
+
+	if bindMount != nil {
+		err := bindMount.CleanClose()
+		if err != nil {
+			return nil, err
 		}
 	}
 
@@ -592,7 +619,7 @@ func createIsoInfoStoreFromIsoImage(savedConfigFile string) (infoStore *IsoInfoS
 }
 
 func createIsoArtifactStoreFromMountedImage(inputArtifactsStore *IsoArtifactsStore, imageRootDir string,
-	storeDir string, distroHandler DistroHandler,
+	storeDir string, distroHandler DistroHandler, toolsChroot *safechroot.Chroot,
 ) (artifactStore *IsoArtifactsStore, err error) {
 	err = os.MkdirAll(storeDir, os.ModePerm)
 	if err != nil {
@@ -607,7 +634,7 @@ func createIsoArtifactStoreFromMountedImage(inputArtifactsStore *IsoArtifactsSto
 	}
 	artifactStore.files = filesStore
 
-	infoStore, err := createIsoInfoStoreFromMountedImage(storeDir, imageRootDir, distroHandler)
+	infoStore, err := createIsoInfoStoreFromMountedImage(storeDir, imageRootDir, distroHandler, toolsChroot)
 	if err != nil {
 		return nil, err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder.go
@@ -12,6 +12,7 @@ import (
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/isogenerator"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/logger"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safechroot"
 )
 
 const (
@@ -129,7 +130,7 @@ func populateWriteableRootfsDir(sourceDir, writeableRootfsDir string) error {
 func createLiveOSFromRaw(ctx context.Context, buildDir string, inputArtifactsStore *IsoArtifactsStore,
 	requestedSelinuxMode imagecustomizerapi.SELinuxMode, resolvedIso imagecustomizerapi.Iso,
 	resolvedPxe imagecustomizerapi.Pxe, rawImageFile string, outputFormat imagecustomizerapi.ImageFormatType,
-	outputPath string, distroHandler DistroHandler,
+	outputPath string, distroHandler DistroHandler, toolsChroot *safechroot.Chroot,
 ) (err error) {
 	logger.Log.Infof("Creating Live OS artifacts using customized full OS image")
 
@@ -139,7 +140,7 @@ func createLiveOSFromRaw(ctx context.Context, buildDir string, inputArtifactsSto
 	}
 
 	err = createLiveOSFromRawHelper(ctx, buildDir, inputArtifactsStore, requestedSelinuxMode, liveosConfig,
-		rawImageFile, outputFormat, outputPath, distroHandler)
+		rawImageFile, outputFormat, outputPath, distroHandler, toolsChroot)
 	if err != nil {
 		return fmt.Errorf("failed to create live OS artifacts:\n%w", err)
 	}
@@ -183,7 +184,7 @@ func isIsoBootImageNeeded(outputFormat imagecustomizerapi.ImageFormatType, initr
 
 func createLiveOSFromRawHelper(ctx context.Context, buildDir string, inputArtifactsStore *IsoArtifactsStore, requestedSelinuxMode imagecustomizerapi.SELinuxMode,
 	liveosConfig LiveOSConfig, rawImageFile string, outputFormat imagecustomizerapi.ImageFormatType,
-	outputPath string, distroHandler DistroHandler,
+	outputPath string, distroHandler DistroHandler, toolsChroot *safechroot.Chroot,
 ) (err error) {
 	isoBuildDir := filepath.Join(buildDir, "liveosbuild")
 	defer func() {
@@ -245,7 +246,7 @@ func createLiveOSFromRawHelper(ctx context.Context, buildDir string, inputArtifa
 	// Create the ISO artifacts store
 	storeFolder := filepath.Join(isoBuildDir, "from-iso-and-raw")
 	artifactsStore, err := createIsoArtifactStoreFromMountedImage(inputArtifactsStore, writeableRootfsDir, storeFolder,
-		distroHandler)
+		distroHandler, toolsChroot)
 	if err != nil {
 		return err
 	}
@@ -314,7 +315,7 @@ func createLiveOSFromRawHelper(ctx context.Context, buildDir string, inputArtifa
 		// Generate the initrd image(s)
 		for kernelVersion, kernelBootFiles := range artifactsStore.files.kernelBootFiles {
 			err = createBootstrapInitrdImage(writeableRootfsDir, kernelVersion, kernelBootFiles.initrdImagePath,
-				distroHandler)
+				distroHandler, toolsChroot)
 			if err != nil {
 				return fmt.Errorf("failed to create initrd image:\n%w", err)
 			}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisobuilder_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safeloopback"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safemount"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/tarutils"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/testutils"
 
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/unix"
@@ -27,11 +28,13 @@ import (
 
 func createConfig(t *testing.T, baseImageVersion string, fileNames, kernelParameter string, initramfsType imagecustomizerapi.InitramfsImageType,
 	bootstrapFileUrl string, enlargeDisk, enableOsConfig, bootstrapPrereqs, twoKernels bool, kdumpBootFiles imagecustomizerapi.KdumpBootFilesType,
-	selinuxMode imagecustomizerapi.SELinuxMode,
+	selinuxMode imagecustomizerapi.SELinuxMode, removeToolsPackages bool,
 ) *imagecustomizerapi.Config {
 	fileNamesArray := strings.Split(fileNames, ";")
 
 	pkgsToInstall := []string{}
+	baseConfigs := []imagecustomizerapi.BaseConfig{}
+
 	if bootstrapPrereqs {
 		liveOSRequiredPackages := liveOSRequiredPackagesAzl3
 		if baseImageVersion == baseImageVersionAzl4 {
@@ -59,12 +62,28 @@ func createConfig(t *testing.T, baseImageVersion string, fileNames, kernelParame
 		pkgsToInstall = append(pkgsToInstall, kernelPackageName)
 	}
 
+	if removeToolsPackages {
+		toolsBaseConfig := ""
+		switch baseImageVersion {
+		case baseImageVersionAzl2, baseImageVersionAzl3:
+			toolsBaseConfig = "toolsdir-azl3.yaml"
+		case baseImageVersionAzl4:
+			toolsBaseConfig = "toolsdir-azl4.yaml"
+		default:
+			assert.NoError(t, fmt.Errorf("undefined image version"), "unsupported distro version")
+		}
+
+		baseConfigs = append(baseConfigs, imagecustomizerapi.BaseConfig{Path: toolsBaseConfig})
+	}
+
 	perms0o644 := imagecustomizerapi.FilePermissions(0o644)
 
 	config := imagecustomizerapi.Config{
 		PreviewFeatures: []imagecustomizerapi.PreviewFeature{
 			imagecustomizerapi.PreviewFeatureKdumpBootFiles,
+			imagecustomizerapi.PreviewFeatureBaseConfigs,
 		},
+		BaseConfigs: baseConfigs,
 		Iso: &imagecustomizerapi.Iso{
 			KdumpBootFiles: &kdumpBootFiles,
 			KernelCommandLine: imagecustomizerapi.KernelCommandLine{
@@ -489,7 +508,7 @@ func testCustomizeImageLiveOSKeepKdumpFilesA(t *testing.T, baseImageInfo testBas
 	configA0 := createConfig(t, baseImageInfo.Version, kudmpFilePaths, "rd.info",
 		imagecustomizerapi.InitramfsImageTypeFullOS,
 		"" /*pxe url*/, false /*enlarge disk*/, true /*enable os config*/, false /*bootstrap prereqs*/, false, /*2 kernels*/
-		imagecustomizerapi.KdumpBootFilesTypeKeep, imagecustomizerapi.SELinuxModeDisabled)
+		imagecustomizerapi.KdumpBootFilesTypeKeep, imagecustomizerapi.SELinuxModeDisabled, false /*useToolsDir*/)
 
 	err := basicCustomizeImage(t.Context(), buildDir, testDir, configA0, baseImage, outImageFilePath,
 		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
@@ -607,7 +626,7 @@ func testCustomizeImageLiveOSKeepKdumpFilesBC(t *testing.T, baseImageInfo testBa
 	//
 	configB := createConfig(t, baseImageInfo.Version, "a.txt;boot/vmlinuz-6.6.65.1-2.npi", "rd.info", imagecustomizerapi.InitramfsImageTypeFullOS,
 		"" /*pxe url*/, false /*enlarge disk*/, true /*enable os config*/, false /*bootstrap prereqs*/, false, /*2 kernels*/
-		imagecustomizerapi.KdumpBootFilesTypeKeep, imagecustomizerapi.SELinuxModeDisabled)
+		imagecustomizerapi.KdumpBootFilesTypeKeep, imagecustomizerapi.SELinuxModeDisabled, false /*useToolsDir*/)
 
 	err := basicCustomizeImage(t.Context(), buildDir, testDir, configB, baseImage, outImageFilePath,
 		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
@@ -629,7 +648,7 @@ func testCustomizeImageLiveOSKeepKdumpFilesBC(t *testing.T, baseImageInfo testBa
 	configC := createConfig(t, baseImageInfo.Version, "boot/initramfs-6.6.65.1-2.npikdump.img;boot/vmlinuz-6.6.65.1-2.npi", "rd.info",
 		imagecustomizerapi.InitramfsImageTypeFullOS,
 		"" /*pxe url*/, false /*enlarge disk*/, true /*enable os config*/, false /*bootstrap prereqs*/, false, /*2 kernels*/
-		imagecustomizerapi.KdumpBootFilesTypeNone, imagecustomizerapi.SELinuxModeDisabled)
+		imagecustomizerapi.KdumpBootFilesTypeNone, imagecustomizerapi.SELinuxModeDisabled, false /*useToolsDir*/)
 
 	err = basicCustomizeImage(t.Context(), buildDir, testDir, configC, baseImage, outImageFilePath,
 		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
@@ -668,7 +687,7 @@ func testCustomizeImageLiveOSMultiKernel(t *testing.T, baseImageInfo testBaseIma
 
 	configA := createConfig(t, baseImageInfo.Version, "a.txt", "rd.info", imagecustomizerapi.InitramfsImageTypeBootstrap,
 		"" /*pxe url*/, true /*enlarge disk*/, true /*enable os config*/, true /*bootstrap prereqs*/, true, /*2 kernels*/
-		imagecustomizerapi.KdumpBootFilesTypeNone, selinuxMode)
+		imagecustomizerapi.KdumpBootFilesTypeNone, selinuxMode, false /*useToolsDir*/)
 
 	err := basicCustomizeImage(t.Context(), buildDir, testDir, configA, baseImage, outImageFilePath,
 		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
@@ -697,15 +716,27 @@ func testCustomizeImageLiveOSMultiKernel(t *testing.T, baseImageInfo testBaseIma
 func TestCustomizeImageLiveOSInitramfs1(t *testing.T) {
 	for _, baseImageInfo := range baseImageAzureLinuxAll {
 		t.Run(baseImageInfo.Name, func(t *testing.T) {
-			testCustomizeImageLiveOSInitramfs1Helper(t, baseImageInfo)
+			testCustomizeImageLiveOSInitramfs1Helper(t, baseImageInfo, false)
+		})
+
+		t.Run(baseImageInfo.Name+"ToolsDir", func(t *testing.T) {
+			testCustomizeImageLiveOSInitramfs1Helper(t, baseImageInfo, true)
 		})
 	}
 }
 
-func testCustomizeImageLiveOSInitramfs1Helper(t *testing.T, baseImageInfo testBaseImageInfo) {
+func testCustomizeImageLiveOSInitramfs1Helper(t *testing.T, baseImageInfo testBaseImageInfo, useToolsDir bool) {
 	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
 
+	toolsDir := ""
+	if useToolsDir {
+		toolsDir = testutils.GetDownloadedToolsDir(t, testutilsDir, baseImageInfo.Distro, baseImageInfo.Version)
+	}
+
 	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageLiveOSInitramfs1"+baseImageInfo.Name)
+	if useToolsDir {
+		testTempDir += "ToolsDir"
+	}
 	defer os.RemoveAll(testTempDir)
 
 	buildDir := filepath.Join(testTempDir, "build")
@@ -717,13 +748,27 @@ func testCustomizeImageLiveOSInitramfs1Helper(t *testing.T, baseImageInfo testBa
 		selinuxMode = imagecustomizerapi.SELinuxModeDisabled
 	}
 
+	previewFeatures := []imagecustomizerapi.PreviewFeature(nil)
+	previewFeatures = append(previewFeatures, baseImageInfo.PreviewFeatures...)
+	if useToolsDir {
+		previewFeatures = append(previewFeatures, imagecustomizerapi.PreviewFeatureToolsDir)
+	}
+
 	configA := createConfig(t, baseImageInfo.Version, "a.txt", "rd.info", imagecustomizerapi.InitramfsImageTypeBootstrap,
 		"" /*pxe url*/, false /*enlarge disk*/, true /*enable os config*/, true /*bootstrap prereqs*/, false, /*2 kernels*/
-		imagecustomizerapi.KdumpBootFilesTypeNone, selinuxMode)
+		imagecustomizerapi.KdumpBootFilesTypeNone, selinuxMode, useToolsDir)
 
 	// vhdx {raw} to ISO {bootstrap}, selinux enforcing + bootstrap prereqs
-	err := basicCustomizeImage(t.Context(), buildDir, testDir, configA, baseImage, outImageFilePath,
-		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
+	err := CustomizeImage(t.Context(), testDir, configA, ImageCustomizerOptions{
+		BuildDir:             buildDir,
+		InputImageFile:       baseImage,
+		OutputImageFile:      outImageFilePath,
+		OutputImageFormat:    imagecustomizerapi.ImageFormatTypeIso,
+		UseBaseImageRpmRepos: true,
+		PreviewFeatures:      previewFeatures,
+		SetFilesContext:      *setfilesContext,
+		ToolsDir:             toolsDir,
+	})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -733,10 +778,18 @@ func testCustomizeImageLiveOSInitramfs1Helper(t *testing.T, baseImageInfo testBa
 	// ISO  {bootstrap} to ISO {bootstrap}, with no OS changes
 	configB := createConfig(t, baseImageInfo.Version, "b.txt", "rd.debug", imagecustomizerapi.InitramfsImageTypeBootstrap,
 		"" /*pxe url*/, false /*enlarge disk*/, false /*enable os config*/, false /*bootstrap prereqs*/, false, /*2 kernels*/
-		imagecustomizerapi.KdumpBootFilesTypeNone, imagecustomizerapi.SELinuxModeDefault)
+		imagecustomizerapi.KdumpBootFilesTypeNone, imagecustomizerapi.SELinuxModeDefault, false)
 
-	err = basicCustomizeImage(t.Context(), buildDir, testDir, configB, outImageFilePath, outImageFilePath,
-		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
+	err = CustomizeImage(t.Context(), testDir, configB, ImageCustomizerOptions{
+		BuildDir:             buildDir,
+		InputImageFile:       outImageFilePath,
+		OutputImageFile:      outImageFilePath,
+		OutputImageFormat:    imagecustomizerapi.ImageFormatTypeIso,
+		UseBaseImageRpmRepos: true,
+		PreviewFeatures:      previewFeatures,
+		SetFilesContext:      *setfilesContext,
+		ToolsDir:             toolsDir,
+	})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -746,10 +799,18 @@ func testCustomizeImageLiveOSInitramfs1Helper(t *testing.T, baseImageInfo testBa
 	// - ISO {bootstrap} to ISO {full-os}, with selinux disabled
 	configC := createConfig(t, baseImageInfo.Version, "c.txt", "rd.shell", imagecustomizerapi.InitramfsImageTypeFullOS,
 		"" /*pxe url*/, false /*enlarge disk*/, true /*enable os config*/, false /*bootstrap prereqs*/, false, /*2 kernels*/
-		imagecustomizerapi.KdumpBootFilesTypeNone, imagecustomizerapi.SELinuxModeDisabled)
+		imagecustomizerapi.KdumpBootFilesTypeNone, imagecustomizerapi.SELinuxModeDisabled, false)
 
-	err = basicCustomizeImage(t.Context(), buildDir, testDir, configC, outImageFilePath, outImageFilePath,
-		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
+	err = CustomizeImage(t.Context(), testDir, configC, ImageCustomizerOptions{
+		BuildDir:             buildDir,
+		InputImageFile:       outImageFilePath,
+		OutputImageFile:      outImageFilePath,
+		OutputImageFormat:    imagecustomizerapi.ImageFormatTypeIso,
+		UseBaseImageRpmRepos: true,
+		PreviewFeatures:      previewFeatures,
+		SetFilesContext:      *setfilesContext,
+		ToolsDir:             toolsDir,
+	})
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -775,7 +836,7 @@ func TestCustomizeImageLiveOSInitramfs2(t *testing.T) {
 	// vhdx {raw} to ISO {full-os}, with selinux disabled
 	configA := createConfig(t, baseImageInfo.Version, "a.txt", "rd.info", imagecustomizerapi.InitramfsImageTypeFullOS,
 		"" /*pxe url*/, false /*enlarge disk*/, true /*enable os config*/, false /*bootstrap prereqs*/, false, /*2 kernels*/
-		imagecustomizerapi.KdumpBootFilesTypeNone, imagecustomizerapi.SELinuxModeDisabled)
+		imagecustomizerapi.KdumpBootFilesTypeNone, imagecustomizerapi.SELinuxModeDisabled, false /*useToolsDir*/)
 
 	err := basicCustomizeImage(t.Context(), buildDir, testDir, configA, baseImage, outImageFilePath,
 		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
@@ -788,7 +849,7 @@ func TestCustomizeImageLiveOSInitramfs2(t *testing.T) {
 	// ISO  {full-os} to ISO {full-os}, with selinux disabled
 	configB := createConfig(t, baseImageInfo.Version, "b.txt", "rd.shell", imagecustomizerapi.InitramfsImageTypeFullOS,
 		"" /*pxe url*/, false /*enlarge disk*/, true /*enable os config*/, true /*bootstrap prereqs*/, false, /*2 kernels*/
-		imagecustomizerapi.KdumpBootFilesTypeNone, imagecustomizerapi.SELinuxModeDisabled)
+		imagecustomizerapi.KdumpBootFilesTypeNone, imagecustomizerapi.SELinuxModeDisabled, false /*useToolsDir*/)
 
 	err = basicCustomizeImage(t.Context(), buildDir, testDir, configB, outImageFilePath, outImageFilePath, string(imagecustomizerapi.ImageFormatTypeIso),
 		baseImageInfo.PreviewFeatures)
@@ -808,7 +869,7 @@ func TestCustomizeImageLiveOSInitramfs2(t *testing.T) {
 
 	configC := createConfig(t, baseImageInfo.Version, "c.txt", "rd.shell", imagecustomizerapi.InitramfsImageTypeBootstrap,
 		"" /*pxe url*/, false /*enlarge disk*/, true /*enable os config*/, true /*bootstrap prereqs*/, false, /*2 kernels*/
-		imagecustomizerapi.KdumpBootFilesTypeNone, selinuxMode)
+		imagecustomizerapi.KdumpBootFilesTypeNone, selinuxMode, false /*useToolsDir*/)
 
 	err = basicCustomizeImage(t.Context(), buildDir, testDir, configC, outImageFilePath, outImageFilePath,
 		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
@@ -833,7 +894,7 @@ func TestCustomizeImageLiveOSInitramfs3(t *testing.T) {
 	// vhdx {raw} to ISO {full-os}, with selinux disabled
 	configA := createConfig(t, baseImageInfo.Version, "a.txt", "rd.info", imagecustomizerapi.InitramfsImageTypeFullOS,
 		"" /*pxe url*/, false /*enlarge disk*/, true /*enable os config*/, false /*bootstrap prereqs*/, false, /*2 kernels*/
-		imagecustomizerapi.KdumpBootFilesTypeNone, imagecustomizerapi.SELinuxModeEnforcing)
+		imagecustomizerapi.KdumpBootFilesTypeNone, imagecustomizerapi.SELinuxModeEnforcing, false /*useToolsDir*/)
 
 	err := basicCustomizeImage(t.Context(), buildDir, testDir, configA, baseImage, outImageFilePath,
 		string(imagecustomizerapi.ImageFormatTypeIso), baseImageInfo.PreviewFeatures)
@@ -858,7 +919,7 @@ func TestCustomizeImageLiveOSPxe1(t *testing.T) {
 
 	config := createConfig(t, baseImageInfo.Version, "a.txt", "rd.info", imagecustomizerapi.InitramfsImageTypeBootstrap,
 		pxeBootstrapUrl, false /*enlarge disk*/, true /*enable os config*/, true /*bootstrap prereqs*/, false, /*2 kernels*/
-		imagecustomizerapi.KdumpBootFilesTypeNone, imagecustomizerapi.SELinuxModeEnforcing)
+		imagecustomizerapi.KdumpBootFilesTypeNone, imagecustomizerapi.SELinuxModeEnforcing, false /*useToolsDir*/)
 
 	err := basicCustomizeImage(t.Context(), buildDir, testDir, config, baseImage, outImageFilePath,
 		string(imagecustomizerapi.ImageFormatTypePxeTar), baseImageInfo.PreviewFeatures)
@@ -886,7 +947,7 @@ func TestCustomizeImageLiveOSPxe2(t *testing.T) {
 
 	config := createConfig(t, baseImageInfo.Version, "a.txt", "rd.info", imagecustomizerapi.InitramfsImageTypeFullOS,
 		"" /*pxe url*/, false /*enlarge disk*/, true /*enable os config*/, false /*bootstrap prereqs*/, false, /*2 kernels*/
-		imagecustomizerapi.KdumpBootFilesTypeNone, imagecustomizerapi.SELinuxModeDisabled)
+		imagecustomizerapi.KdumpBootFilesTypeNone, imagecustomizerapi.SELinuxModeDisabled, false /*useToolsDir*/)
 
 	err := basicCustomizeImage(t.Context(), buildDir, testDir, config, baseImage, outImageFilePath,
 		string(imagecustomizerapi.ImageFormatTypePxeTar), baseImageInfo.PreviewFeatures)

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoimages.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoimages.go
@@ -24,6 +24,7 @@ import (
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/shell"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/targetos"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -140,7 +141,7 @@ func createFullOSInitrdImage(writeableRootfsDir string, kernelKdumpFiles *imagec
 }
 
 func createBootstrapInitrdImage(writeableRootfsDir, kernelVersion, outputInitrdPath string,
-	distroHandler DistroHandler,
+	distroHandler DistroHandler, toolsChroot *safechroot.Chroot,
 ) error {
 	logger.Log.Infof("Creating bootstrap initrd for %s", kernelVersion)
 
@@ -153,21 +154,33 @@ func createBootstrapInitrdImage(writeableRootfsDir, kernelVersion, outputInitrdP
 	}
 	defer os.Remove(dracutConfigFile)
 
-	chroot := safechroot.NewChroot(writeableRootfsDir, true /*isExistingDir*/)
+	var bindMount *safemount.Mount
+	chrootDir := writeableRootfsDir
+	if toolsChroot != nil {
+		chrootDir = filepath.Join(toolsChroot.RootDir(), toolsRootImageDir)
+
+		bindMount, err = safemount.NewMount(writeableRootfsDir, chrootDir, "", unix.MS_BIND, "", true)
+		if err != nil {
+			return fmt.Errorf("failed to create image bind mount in toold dir:\n%w", err)
+		}
+		defer bindMount.Close()
+	}
+
+	chroot := safechroot.NewChroot(chrootDir, true /*isExistingDir*/)
 	if chroot == nil {
-		return fmt.Errorf("failed to create a new chroot object for (%s)", writeableRootfsDir)
+		return fmt.Errorf("failed to create a new chroot object for (%s)", chrootDir)
 	}
 	defer chroot.Close(true /*leaveOnDisk*/)
 
 	err = chroot.Initialize("", nil, nil, true /*includeDefaultMounts*/)
 	if err != nil {
-		return fmt.Errorf("failed to initialize chroot object for %s:\n%w", writeableRootfsDir, err)
+		return fmt.Errorf("failed to initialize chroot object for %s:\n%w", chrootDir, err)
 	}
 
 	requiredPackages := distroHandler.LiveOSRequiredPackages()
 	for _, requiredPackage := range requiredPackages {
 		logger.Log.Debugf("Checking if (%s) is installed", requiredPackage)
-		installed, err := distroHandler.IsPackageInstalled(chroot, nil, requiredPackage)
+		installed, err := distroHandler.IsPackageInstalled(chroot, toolsChroot, requiredPackage)
 		if err != nil {
 			return fmt.Errorf("failed to check if package (%s) is installed:\n%w", requiredPackage, err)
 		}
@@ -190,6 +203,18 @@ func createBootstrapInitrdImage(writeableRootfsDir, kernelVersion, outputInitrdP
 		Execute()
 	if err != nil {
 		return fmt.Errorf("failed to run dracut:\n%w", err)
+	}
+
+	err = chroot.Close(true /*leaveOnDisk*/)
+	if err != nil {
+		return err
+	}
+
+	if bindMount != nil {
+		err := bindMount.CleanClose()
+		if err != nil {
+			return err
+		}
 	}
 
 	generatedInitrdPath := filepath.Join(writeableRootfsDir, initrdPathInChroot)

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoimages.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoimages.go
@@ -161,7 +161,7 @@ func createBootstrapInitrdImage(writeableRootfsDir, kernelVersion, outputInitrdP
 
 		bindMount, err = safemount.NewMount(writeableRootfsDir, chrootDir, "", unix.MS_BIND, "", true)
 		if err != nil {
-			return fmt.Errorf("failed to create image bind mount in toold dir:\n%w", err)
+			return fmt.Errorf("failed to create image bind mount in tools dir:\n%w", err)
 		}
 		defer bindMount.Close()
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/packagemanager_dnf.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/packagemanager_dnf.go
@@ -217,16 +217,26 @@ func (pm *dnfPackageManager) isPackageInstalled(imageChroot safechroot.ChrootInt
 	return true, nil
 }
 
-func (pm *dnfPackageManager) getPackageInformation(imageChroot *safechroot.Chroot, packageName string,
+func (pm *dnfPackageManager) getPackageInformation(imageChroot *safechroot.Chroot, toolsChroot *safechroot.Chroot,
+	packageName string,
 ) (*PackageVersionInformation, error) {
 	// Use `rpm -q --queryformat` rather than `dnf info --installed` here for the same reason as in isPackageInstalled.
 	//
 	// Use `--queryformat` to get a single-line, parser-friendly output that matches what parsePackageInfoOutput
 	// already expects from `tdnf info` (Name/Version/Release labels), so we share the parser.
-	packageInfo, _, err := shell.NewExecBuilder("rpm", "-q", "--queryformat",
-		"Name : %{NAME}\nVersion : %{VERSION}\nRelease : %{RELEASE}\n", "--", packageName).
+	args := []string{"-q", "--queryformat",
+		"Name : %{NAME}\nVersion : %{VERSION}\nRelease : %{RELEASE}\n", "--", packageName}
+	chroot := imageChroot
+	if toolsChroot != nil {
+		// Run rpm from inside the tools chroot against the image bind-mounted at /_imageroot — needed when
+		// imageChroot has no in-image rpm.
+		args = append([]string{"--root", "/" + toolsRootImageDir}, args...)
+		chroot = toolsChroot
+	}
+
+	packageInfo, _, err := shell.NewExecBuilder("rpm", args...).
 		LogLevel(logrus.TraceLevel, logrus.DebugLevel).
-		Chroot(imageChroot.ChrootDir()).
+		Chroot(chroot.ChrootDir()).
 		ExecuteCaptureOutput()
 	if err != nil {
 		return nil, fmt.Errorf("failed to query (%s) package information via rpm:\n%w", packageName, err)

--- a/toolkit/tools/pkg/imagecustomizerlib/packagemanager_rpm.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/packagemanager_rpm.go
@@ -29,7 +29,7 @@ type rpmPackageManagerHandler interface {
 
 	// getPackageInformation queries the package database for packageName and returns its parsed version,
 	// release, and distro fields.
-	getPackageInformation(imageChroot *safechroot.Chroot, packageName string) (*PackageVersionInformation, error)
+	getPackageInformation(imageChroot *safechroot.Chroot, toolsChroot *safechroot.Chroot, packageName string) (*PackageVersionInformation, error)
 
 	importGpgKeys(imageChroot *safechroot.Chroot, toolsChroot *safechroot.Chroot, chrootGpgKeys []string,
 		uriGpgKeys []string,

--- a/toolkit/tools/pkg/imagecustomizerlib/packagemanager_tdnf.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/packagemanager_tdnf.go
@@ -141,11 +141,24 @@ func (pm *tdnfPackageManager) isPackageInstalled(imageChroot safechroot.ChrootIn
 	return true, nil
 }
 
-func (pm *tdnfPackageManager) getPackageInformation(imageChroot *safechroot.Chroot, packageName string,
+func (pm *tdnfPackageManager) getPackageInformation(imageChroot *safechroot.Chroot, toolsChroot *safechroot.Chroot,
+	packageName string,
 ) (*PackageVersionInformation, error) {
-	packageInfo, _, err := shell.NewExecBuilder(packageManagerTDNF, "info", packageName, "--repo", "@system").
+	args := []string{"info", packageName, "--repo", "@system"}
+	chroot := imageChroot
+	if toolsChroot != nil {
+		// Run tdnf from inside the tools chroot against the image bind-mounted at /_imageroot — needed when
+		// imageChroot has no in-image tdnf (e.g. ACL). Matches the executeRpmPackageManagerCommand pattern.
+		args = append([]string{
+			"--releasever=" + pm.getReleaseVersion(),
+			"--installroot=/" + toolsRootImageDir,
+		}, args...)
+		chroot = toolsChroot
+	}
+
+	packageInfo, _, err := shell.NewExecBuilder(packageManagerTDNF, args...).
 		LogLevel(logrus.TraceLevel, logrus.DebugLevel).
-		Chroot(imageChroot.ChrootDir()).
+		Chroot(chroot.ChrootDir()).
 		ExecuteCaptureOutput()
 	if err != nil {
 		return nil, fmt.Errorf("failed to query (%s) package information via tdnf:\n%w", packageName, err)


### PR DESCRIPTION
Allow LiveOS (ISO and PXE) images to be created when the `--tools-dir` API is used.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
