### PR TITLE
Make lsof call more robust.

### DIFF
--- a/toolkit/tools/internal/processes/processes.go
+++ b/toolkit/tools/internal/processes/processes.go
@@ -86,7 +86,13 @@ func GetProcessesUsingPath(path string) ([]ProcessRecord, error) {
 			}
 
 			record.ProcessRoot, err = os.Readlink(fmt.Sprintf("/proc/%d/root", record.ProcessId))
-			if err != nil && !os.IsNotExist(err) {
+			if err != nil {
+				if os.IsNotExist(err) {
+					// Process no longer exists.
+					// So, skip it.
+					record.ProcessId = -1
+					continue
+				}
 				return nil, fmt.Errorf("failed to read process chroot path (%d):\n%w", record.ProcessId, err)
 			}
 

--- a/toolkit/tools/internal/processes/processes.go
+++ b/toolkit/tools/internal/processes/processes.go
@@ -86,7 +86,7 @@ func GetProcessesUsingPath(path string) ([]ProcessRecord, error) {
 			}
 
 			record.ProcessRoot, err = os.Readlink(fmt.Sprintf("/proc/%d/root", record.ProcessId))
-			if err != nil {
+			if err != nil && os.IsNotExist(err) {
 				return nil, fmt.Errorf("failed to read process chroot path (%d):\n%w", record.ProcessId, err)
 			}
 

--- a/toolkit/tools/internal/processes/processes.go
+++ b/toolkit/tools/internal/processes/processes.go
@@ -86,7 +86,7 @@ func GetProcessesUsingPath(path string) ([]ProcessRecord, error) {
 			}
 
 			record.ProcessRoot, err = os.Readlink(fmt.Sprintf("/proc/%d/root", record.ProcessId))
-			if err != nil && os.IsNotExist(err) {
+			if err != nil && !os.IsNotExist(err) {
 				return nil, fmt.Errorf("failed to read process chroot path (%d):\n%w", record.ProcessId, err)
 			}
 


### PR DESCRIPTION
Image Customizer uses lsof to query for all the running processes in the chroot. But it has to supplement the lsof info with the processes' chroot value. However, sometimes the read of the chroot value fails with file not found. This might be because the process closed in-between the lsof call and the read against `/proc`.

The stop-running-processes operation is best effort anyway. So, just ignore this error to allow any other running processes to be stopped.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
