### PR TITLE
Fix safechroot teardown.

### DIFF
--- a/toolkit/tools/internal/imageconnection/imageConnection.go
+++ b/toolkit/tools/internal/imageconnection/imageConnection.go
@@ -13,10 +13,9 @@ import (
 )
 
 type ImageConnection struct {
-	loopback            *safeloopback.Loopback
-	chroot              *safechroot.Chroot
-	chrootIsExistingDir bool
-	ownedDirectories    []string
+	loopback         *safeloopback.Loopback
+	chroot           *safechroot.Chroot
+	ownedDirectories []string
 }
 
 func NewImageConnection() *ImageConnection {
@@ -49,7 +48,6 @@ func (c *ImageConnection) ConnectChroot(rootDir string, isExistingDir bool, extr
 		return err
 	}
 	c.chroot = chroot
-	c.chrootIsExistingDir = isExistingDir
 
 	return nil
 }
@@ -68,7 +66,7 @@ func (c *ImageConnection) Loopback() *safeloopback.Loopback {
 
 func (c *ImageConnection) Close() {
 	if c.chroot != nil {
-		c.chroot.Close(c.chrootIsExistingDir)
+		c.chroot.Close()
 	}
 
 	for _, dir := range slices.Backward(c.ownedDirectories) {
@@ -81,7 +79,7 @@ func (c *ImageConnection) Close() {
 }
 
 func (c *ImageConnection) CleanClose() error {
-	err := c.chroot.Close(c.chrootIsExistingDir)
+	err := c.chroot.Close()
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/internal/safechroot/safechroot.go
+++ b/toolkit/tools/internal/safechroot/safechroot.go
@@ -168,9 +168,6 @@ func NewChroot(rootDir string, isExistingDir bool) *Chroot {
 func (c *Chroot) Initialize(tarPath string, extraDirectories []string, extraMountPoints []*MountPoint,
 	includeDefaultMounts bool,
 ) (err error) {
-	// On failed initialization, cleanup all chroot files
-	const leaveChrootOnDisk = false
-
 	// Acquire a lock on the global activeChrootsMutex to ensure SIGTERM
 	// teardown doesn't happen mid-initialization.
 	activeChrootsMutex.Lock()
@@ -206,7 +203,7 @@ func (c *Chroot) Initialize(tarPath string, extraDirectories []string, extraMoun
 		if err != nil {
 			// mount/unmount is only supported in regular pipeline
 			// Best effort cleanup in case mountpoint creation failed mid-way through. We will not try again so treat as final attempt.
-			cleanupErr := c.unmountAndRemove(leaveChrootOnDisk, unmountTypeLazy)
+			cleanupErr := c.unmountAndRemove(unmountTypeLazy)
 			if cleanupErr != nil {
 				logger.Log.Warnf("Failed to cleanup chroot (%s) during failed initialization:\n%s", c.rootDir, cleanupErr)
 			}
@@ -382,7 +379,7 @@ func (c *Chroot) ChrootDir() string {
 // Close will unmount the chroot and cleanup its files.
 // This call will block until the chroot cleanup runs.
 // Only one Chroot will close at a given time.
-func (c *Chroot) Close(leaveOnDisk bool) (err error) {
+func (c *Chroot) Close() (err error) {
 	// Acquire a lock on the global activeChrootsMutex to ensure SIGTERM
 	// teardown doesn't happen mid-close.
 	activeChrootsMutex.Lock()
@@ -410,10 +407,10 @@ func (c *Chroot) Close(leaveOnDisk bool) (err error) {
 	}
 
 	// mount is only supported in regular pipeline
-	err = c.unmountAndRemove(leaveOnDisk, unmountTypeNormal)
+	err = c.unmountAndRemove(unmountTypeNormal)
 	if err != nil {
 		logger.Log.Warnf("Chroot cleanup failed, will retry with lazy unmount. Error: %s", err)
-		err = c.unmountAndRemove(leaveOnDisk, unmountTypeLazy)
+		err = c.unmountAndRemove(unmountTypeLazy)
 	}
 	if err == nil {
 		const emptyLen = 0
@@ -458,8 +455,6 @@ func cleanupAllChroots() {
 	// but really it has already been cleaned up.
 
 	const (
-		// On cleanup, remove all chroot files
-		leaveChrootOnDisk = false
 		// On cleanup SIGKILL all children processes.
 		stopSignal = unix.SIGKILL
 	)
@@ -478,7 +473,7 @@ func cleanupAllChroots() {
 	logger.Log.Debug("Cleaning up all active chroots")
 	for i := len(activeChroots) - 1; i >= 0; i-- {
 		logger.Log.Debugf("Cleaning up chroot (%s)", activeChroots[i].rootDir)
-		err := activeChroots[i].unmountAndRemove(leaveChrootOnDisk, unmountTypeLazy)
+		err := activeChroots[i].unmountAndRemove(unmountTypeLazy)
 		// Perform best effort cleanup: unmount as many chroots as possible,
 		// even if one fails.
 		if err != nil {
@@ -499,7 +494,7 @@ func cleanupAllChroots() {
 // This is to avoid leaving folders like /dev mounted when the chroot folder is forcefully deleted in cleanup.
 // Iff all mounts were successfully unmounted, the chroot's root directory will be removed if requested.
 // If doLazyUnmount is true, use the lazy unmount flag which will allow the unmount to succeed even if the mount point is busy.
-func (c *Chroot) unmountAndRemove(leaveOnDisk, lazyUnmount bool) (err error) {
+func (c *Chroot) unmountAndRemove(lazyUnmount bool) (err error) {
 	const (
 		retryDuration      = time.Second
 		totalAttempts      = 3
@@ -560,7 +555,7 @@ func (c *Chroot) unmountAndRemove(leaveOnDisk, lazyUnmount bool) (err error) {
 		}
 	}
 
-	if !leaveOnDisk {
+	if !c.isExistingDir {
 		err = os.RemoveAll(c.rootDir)
 	}
 

--- a/toolkit/tools/internal/safechroot/safechroot_test.go
+++ b/toolkit/tools/internal/safechroot/safechroot_test.go
@@ -80,28 +80,6 @@ func TestCloseShouldRemoveRoot(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 }
 
-func TestCloseShouldLeaveRootOnRequest(t *testing.T) {
-	extraMountPoints := []*MountPoint{}
-	extraDirectories := []string{}
-
-	dir := filepath.Join(t.TempDir(), "TestCloseShouldLeaveRootOnRequest")
-	chroot := NewChroot(dir, true)
-
-	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints, true)
-	assert.NoError(t, err)
-
-	err = chroot.Close()
-	assert.NoError(t, err)
-
-	_, err = os.Stat(dir)
-	assert.True(t, !os.IsNotExist(err))
-
-	// Since the chroot dir will be left on disk but unmounted,
-	// manually clean it up.
-	err = os.RemoveAll(dir)
-	assert.NoError(t, err)
-}
-
 func TestRootDirShouldReturnRootDir(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "TestRootDirShouldReturnRootDir")
 	chroot := NewChroot(dir, false)

--- a/toolkit/tools/internal/safechroot/safechroot_test.go
+++ b/toolkit/tools/internal/safechroot/safechroot_test.go
@@ -14,11 +14,9 @@ import (
 )
 
 const (
-	testTar            = "testchroot.tar.gz"
-	emptyPath          = ""
-	emptyFlags         = 0
-	isExistingDir      = false
-	defaultLeaveOnDisk = false
+	testTar    = "testchroot.tar.gz"
+	emptyPath  = ""
+	emptyFlags = 0
 )
 
 var (
@@ -52,12 +50,12 @@ func TestInitializeShouldCreateRoot(t *testing.T) {
 	extraDirectories := []string{}
 
 	dir := filepath.Join(t.TempDir(), "TestInitializeShouldCreateRoot")
-	chroot := NewChroot(dir, isExistingDir)
+	chroot := NewChroot(dir, false)
 
 	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints, true)
 	assert.NoError(t, err)
 
-	defer chroot.Close(defaultLeaveOnDisk)
+	defer chroot.Close()
 
 	_, err = os.Stat(chroot.RootDir())
 	assert.True(t, !os.IsNotExist(err))
@@ -68,14 +66,14 @@ func TestCloseShouldRemoveRoot(t *testing.T) {
 	extraDirectories := []string{}
 
 	dir := filepath.Join(t.TempDir(), "TestCloseShouldRemoveRoot")
-	chroot := NewChroot(dir, isExistingDir)
+	chroot := NewChroot(dir, false)
 
 	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints, true)
 	assert.NoError(t, err)
 
 	// save away chroot location and close
 	chrootDir := chroot.RootDir()
-	err = chroot.Close(defaultLeaveOnDisk)
+	err = chroot.Close()
 	assert.NoError(t, err)
 
 	_, err = os.Stat(chrootDir)
@@ -83,19 +81,16 @@ func TestCloseShouldRemoveRoot(t *testing.T) {
 }
 
 func TestCloseShouldLeaveRootOnRequest(t *testing.T) {
-	// this test only apply to "regular build" pipeline
-	const leaveOnDisk = true
-
 	extraMountPoints := []*MountPoint{}
 	extraDirectories := []string{}
 
 	dir := filepath.Join(t.TempDir(), "TestCloseShouldLeaveRootOnRequest")
-	chroot := NewChroot(dir, isExistingDir)
+	chroot := NewChroot(dir, true)
 
 	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints, true)
 	assert.NoError(t, err)
 
-	err = chroot.Close(leaveOnDisk)
+	err = chroot.Close()
 	assert.NoError(t, err)
 
 	_, err = os.Stat(dir)
@@ -109,7 +104,7 @@ func TestCloseShouldLeaveRootOnRequest(t *testing.T) {
 
 func TestRootDirShouldReturnRootDir(t *testing.T) {
 	dir := filepath.Join(t.TempDir(), "TestRootDirShouldReturnRootDir")
-	chroot := NewChroot(dir, isExistingDir)
+	chroot := NewChroot(dir, false)
 	assert.Equal(t, dir, chroot.RootDir())
 }
 
@@ -121,11 +116,11 @@ func TestInitializeShouldExtractTar(t *testing.T) {
 	extraDirectories := []string{}
 
 	dir := filepath.Join(t.TempDir(), "TestInitializeShouldExtractTar")
-	chroot := NewChroot(dir, isExistingDir)
+	chroot := NewChroot(dir, false)
 
 	err := chroot.Initialize(tarPath, extraDirectories, extraMountPoints, true)
 	assert.NoError(t, err)
-	defer chroot.Close(defaultLeaveOnDisk)
+	defer chroot.Close()
 
 	fullPath := filepath.Join(chroot.RootDir(), expectedFile)
 	_, err = os.Stat(fullPath)
@@ -142,11 +137,11 @@ func TestInitializeShouldCreateCustomMountPoints(t *testing.T) {
 	}
 
 	dir := filepath.Join(t.TempDir(), "TestInitializeShouldCreateCustomMountPoints")
-	chroot := NewChroot(dir, isExistingDir)
+	chroot := NewChroot(dir, false)
 
 	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints, true)
 	assert.NoError(t, err)
-	defer chroot.Close(defaultLeaveOnDisk)
+	defer chroot.Close()
 
 	fullPath := filepath.Join(dir, expectedFile)
 	_, err = os.Stat(fullPath)
@@ -162,7 +157,7 @@ func TestInitializeShouldCleanupOnBadMountPoint(t *testing.T) {
 	}
 
 	dir := filepath.Join(t.TempDir(), "TestInitializeShouldCleanupOnBadMountPoint")
-	chroot := NewChroot(dir, isExistingDir)
+	chroot := NewChroot(dir, false)
 
 	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints, true)
 	assert.Error(t, err)
@@ -178,11 +173,11 @@ func TestInitializeShouldCreateExtraDirectories(t *testing.T) {
 	extraMountPoints := []*MountPoint{}
 
 	dir := filepath.Join(t.TempDir(), "TestInitializeShouldCreateExtraDirectories")
-	chroot := NewChroot(dir, isExistingDir)
+	chroot := NewChroot(dir, false)
 
 	err := chroot.Initialize(emptyPath, extraDirectories, extraMountPoints, true)
 	assert.NoError(t, err)
-	defer chroot.Close(defaultLeaveOnDisk)
+	defer chroot.Close()
 
 	fullPath := filepath.Join(chroot.RootDir(), expectedExtraDirectory)
 	_, err = os.Stat(fullPath)

--- a/toolkit/tools/pkg/imagecustomizerlib/customizefiles_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizefiles_test.go
@@ -31,7 +31,7 @@ func TestCopyAdditionalFiles(t *testing.T) {
 
 	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{}, false)
 	assert.NoError(t, err)
-	defer chroot.Close(false)
+	defer chroot.Close()
 
 	copy_2_filemode := os.FileMode(0o777)
 
@@ -173,7 +173,7 @@ func TestCopyAdditionalDirs(t *testing.T) {
 
 	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{}, false)
 	assert.NoError(t, err)
-	defer chroot.Close(false)
+	defer chroot.Close()
 
 	// Copy the directory.
 	err = copyAdditionalDirs(t.Context(), baseConfigPath,

--- a/toolkit/tools/pkg/imagecustomizerlib/customizehostname_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizehostname_test.go
@@ -27,7 +27,7 @@ func TestUpdateHostname(t *testing.T) {
 	chroot := safechroot.NewChroot(proposedDir, false)
 	err := chroot.Initialize("", []string{}, []*safechroot.MountPoint{}, false)
 	assert.NoError(t, err)
-	defer chroot.Close(false)
+	defer chroot.Close()
 
 	err = os.MkdirAll(filepath.Join(chroot.RootDir(), "etc"), os.ModePerm)
 	assert.NoError(t, err)

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoartifactstore.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoartifactstore.go
@@ -429,7 +429,7 @@ func createIsoInfoStoreFromMountedImage(buildDir string, imageRootDir string, di
 	if chroot == nil {
 		return nil, fmt.Errorf("failed to create a new chroot object for (%s)", chrootDir)
 	}
-	defer chroot.Close(true /*leaveOnDisk*/)
+	defer chroot.Close()
 
 	err = chroot.Initialize("", nil, nil, true /*includeDefaultMounts*/)
 	if err != nil {
@@ -461,7 +461,7 @@ func createIsoInfoStoreFromMountedImage(buildDir string, imageRootDir string, di
 		}
 	}
 
-	err = chroot.Close(true /*leaveOnDisk*/)
+	err = chroot.Close()
 	if err != nil {
 		return nil, err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/liveosisoimages.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/liveosisoimages.go
@@ -170,7 +170,7 @@ func createBootstrapInitrdImage(writeableRootfsDir, kernelVersion, outputInitrdP
 	if chroot == nil {
 		return fmt.Errorf("failed to create a new chroot object for (%s)", chrootDir)
 	}
-	defer chroot.Close(true /*leaveOnDisk*/)
+	defer chroot.Close()
 
 	err = chroot.Initialize("", nil, nil, true /*includeDefaultMounts*/)
 	if err != nil {
@@ -205,7 +205,7 @@ func createBootstrapInitrdImage(writeableRootfsDir, kernelVersion, outputInitrdP
 		return fmt.Errorf("failed to run dracut:\n%w", err)
 	}
 
-	err = chroot.Close(true /*leaveOnDisk*/)
+	err = chroot.Close()
 	if err != nil {
 		return err
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/toolschroot.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/toolschroot.go
@@ -63,7 +63,7 @@ func (t *ToolsChroot) CleanClose() error {
 	}
 	t.resolvConf = nil
 
-	if err := t.chroot.Close(true); err != nil {
+	if err := t.chroot.Close(); err != nil {
 		return fmt.Errorf("failed to close tools chroot (%s):\n%w", t.toolsDir, err)
 	}
 
@@ -81,7 +81,7 @@ func (t *ToolsChroot) Close() {
 	}
 
 	if t.chroot != nil {
-		if err := t.chroot.Close(true); err != nil {
+		if err := t.chroot.Close(); err != nil {
 			logger.Log.Warnf("Failed to close tools chroot (%s): %v", t.toolsDir, err)
 		}
 	}


### PR DESCRIPTION
When safechroot.Chroot is torndown due to a initialization error or Ctrl+C, then the files of the chroot are always deleted regardless of if it was existing directory or not.

A particularly bad version of this is when a user passes `/` as the `--tools-dir` which fails because there is already a `/dev`, which then causes deletion of all the files under `/`.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
