### PR TITLE
Strip NUL padding from UKI .cmdline PE section dumps

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
@@ -1148,7 +1148,9 @@ func extractCmdlineFromSinglePE(originalPath, buildDir string) (string, error) {
 		return "", fmt.Errorf("failed to read kernel cmdline args from dumped file (%s):\n%w", cmdlinePath.Name(), err)
 	}
 
-	return string(content), nil
+	// objcopy --dump-section writes NUL padding up to PE FileAlignment;
+	// strings.TrimSpace in callers doesn't strip NUL. Strip here.
+	return strings.Trim(string(content), "\x00"), nil
 }
 
 func extractKernelCmdlineHelper(bootPartition diskutils.PartitionInfo, bootDirPath string, buildDir string,


### PR DESCRIPTION
objcopy --dump-section writes the raw on-disk PE section bytes, padded to FileAlignment (typically 512 bytes) with NUL fill. strings.TrimSpace in callers doesn't strip NUL (unicode.IsSpace excludes 0x00), so the padding survives into downstream parsers — notably strconv.ParseUint on verity hash-offset= values, which fails with invalid syntax. Fix at the single choke point in extractCmdlineFromSinglePE.

Reproduces reliably on ACL-T images (main UKI has no .cmdline; verity options come from an addon in *.efi.extra.d/, whose section is padded).