### PR TITLE
Populate COSI osPackages for ACL images when rpm db is unavailable

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
@@ -131,8 +131,9 @@ func (d *aclDistroHandler) GetAllPackagesFromChroot(imageChroot safechroot.Chroo
 	if toolsChroot == nil {
 		_, err := shell.LookPathChroot("rpm", imageChroot.ChrootDir())
 		if err != nil {
-			// RPM command is not found.
-			return nil, nil
+			// RPM command is not found. Return an empty list so the COSI
+			// metadata's osPackages field is populated (as []) rather than null.
+			return []cosiapi.OsPackage{}, nil
 		}
 	}
 
@@ -144,8 +145,9 @@ func (d *aclDistroHandler) GetAllPackagesFromChroot(imageChroot safechroot.Chroo
 	}
 
 	if !exists {
-		// RPM database doesn't exist.
-		return nil, nil
+		// RPM database doesn't exist. Return an empty list so the COSI
+		// metadata's osPackages field is populated (as []) rather than null.
+		return []cosiapi.OsPackage{}, nil
 	}
 
 	// Get the list of packages.

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_test.go
@@ -10,8 +10,26 @@ import (
 	"testing"
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safechroot"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/targetos"
 	"github.com/stretchr/testify/assert"
 )
+
+// Ensure the ACL package list is populated as an empty (non-nil) list when the
+// rpm database can't be read, so the COSI metadata's osPackages field
+// serializes as [] rather than null.
+func TestAclGetAllPackagesFromChrootReturnsEmptyListWhenNoRpm(t *testing.T) {
+	handler := newAclDistroHandler(targetos.TargetOsAzureContainerLinux3)
+
+	// An empty chroot dir has no rpm command and no rpm database.
+	chrootDir := t.TempDir()
+	chroot := safechroot.NewChroot(chrootDir, true)
+
+	packages, err := handler.GetAllPackagesFromChroot(chroot, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, packages)
+	assert.Empty(t, packages)
+}
 
 // Ensure unsupported-distro-version preview feature flag is required when distro version can't be parsed.
 func TestCustomizeImageDistroVersionInvalid(t *testing.T) {


### PR DESCRIPTION
Trident requires an os-packages list (even if it is empty):

| `osPackages` | [OsPackage](#ospackage-object)[]       | 1.0      | Yes (since 1.1) | The list of packages installed in the OS.        |

ImageCustomizer is specifying nil for the list currently for ACL.  This PR creates an empty list of os packages if rpm/rpmdb cannot be found.