### PR TITLE
Trim trailing NUL padding from UKI .cmdline PE sections

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
@@ -8,11 +8,13 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/diskutils"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/file"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/shell"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/testutils"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/unix"
@@ -586,6 +588,20 @@ func verityRootUkiConfigFile(t *testing.T, baseImageInfo testBaseImageInfo) stri
 	}
 }
 
+// verityUsrInlineUkiConfigFile returns the verity-usr-inline-uki test config file appropriate for the
+// given base image version (azl3 vs azl4) and host architecture.
+func verityUsrInlineUkiConfigFile(t *testing.T, baseImageInfo testBaseImageInfo) string {
+	switch baseImageInfo.Version {
+	case baseImageVersionAzl3:
+		return "verity-usr-inline-uki-azl3.yaml"
+	case baseImageVersionAzl4:
+		return fmt.Sprintf("verity-usr-inline-uki-%s-azl4.yaml", runtime.GOARCH)
+	default:
+		t.Fatalf("unsupported base image version for verity-usr-inline-uki test: %s", baseImageInfo.Version)
+		return ""
+	}
+}
+
 // calculateUkiFileChecksums generates SHA256 checksums for a list of UKI files.
 // Returns nil if any error occurs during checksum calculation.
 func calculateUkiFileChecksums(t *testing.T, ukiFiles []string) map[string]string {
@@ -661,4 +677,140 @@ func TestGetKernelNameFromUki(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestCustomizeImageVerityUsrUkiRecustomizeNulPaddedCmdline is the end-to-end regression test for a failure where
+// re-customizing a UKI usr-verity image aborted because its addon `.cmdline` PE section carried trailing NUL padding.
+//
+// The base-image validation reads the UKI addon `.cmdline`, discovers the usr-verity partition, and parses
+// `systemd.verity_usr_options` (including the numeric `hash-offset` at the end), then re-provisions verity and rebuilds
+// the UKI.
+//
+// A `.cmdline` section holds a NUL-terminated string. When a tool rewrites it with shorter content
+// (for example `objcopy --update-section`), the section keeps its original size and the freed bytes are zero-filled,
+// leaving trailing NUL padding after the last argument. If that padding is not stripped, the trailing `hash-offset
+// value fails to parse and customization aborts with "cannot validate target OS of the base image".
+//
+// This test builds an inline-usr-verity UKI image (inline verity, where data and hash is on the same partition, makes
+// IC append `...,hash-offset=<N>` to the addon command line), rewrites the addon `.cmdline` with shorter NUL-terminated
+// content to recreate the padding, then re-customizes and asserts success.
+func TestCustomizeImageVerityUsrUkiRecustomizeNulPaddedCmdline(t *testing.T) {
+	for _, baseImageInfo := range baseImageAzureLinux3Plus {
+		t.Run(baseImageInfo.Name, func(t *testing.T) {
+			testCustomizeImageVerityUsrUkiRecustomizeNulPaddedCmdlineHelper(t, baseImageInfo)
+		})
+	}
+}
+
+func testCustomizeImageVerityUsrUkiRecustomizeNulPaddedCmdlineHelper(t *testing.T, baseImageInfo testBaseImageInfo) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
+
+	for _, command := range []string{"ukify", "objcopy"} {
+		exists, err := file.CommandExists(command)
+		assert.NoError(t, err)
+		if !exists {
+			t.Skipf("The '%s' command is not available", command)
+		}
+	}
+
+	testTempDir := filepath.Join(tmpDir, fmt.Sprintf("TestCustomizeImageVerityUsrUkiRecustomizeNulPaddedCmdline_%s",
+		baseImageInfo.Name))
+	defer os.RemoveAll(testTempDir)
+
+	buildDir := filepath.Join(testTempDir, "build")
+
+	// Build an inline-usr-verity UKI image whose addon command line ends with
+	// `systemd.verity_usr_options=...,hash-offset=<N>`.
+	ukiImageFilePath := filepath.Join(testTempDir, "uki-verity.raw")
+	configFile := filepath.Join(testDir, verityUsrInlineUkiConfigFile(t, baseImageInfo))
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, ukiImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// Rewrite the addon `.cmdline` with shorter, NUL-terminated content so the re-read command line carries trailing
+	// NUL padding after its last argument.
+	if !injectAddonCmdlineNulPadding(t, buildDir, ukiImageFilePath) {
+		return
+	}
+
+	// Re-customize.
+	outImageFilePath := filepath.Join(testTempDir, "recustomized.raw")
+	reinitConfigFile := filepath.Join(testDir, "verity-reinit-usr-uki.yaml")
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, reinitConfigFile, ukiImageFilePath, outImageFilePath,
+		"raw", baseImageInfo.PreviewFeatures)
+	assert.NoError(t, err)
+}
+
+// injectAddonCmdlineNulPadding rewrites every UKI addon `.cmdline` section on the image's ESP with shorter,
+// NUL-terminated content using `objcopy --update-section`, so the re-read command line carries trailing NUL padding
+// after its last argument.
+//
+// `objcopy --update-section` keeps the section's original size and zero-pads the freed bytes, which is how trailing
+// NULs end up in a `.cmdline` section in practice. The content is shortened by dropping the ` rd.info` argument added
+// by the build config, keeping the verity `hash-offset` value last so the padding lands on it.
+//
+// Returns false (after failing the test) if no addon carrying the command line was found to patch.
+func injectAddonCmdlineNulPadding(t *testing.T, buildDir string, imageFilePath string) bool {
+	imageConnection, err := testutils.ConnectToImage(buildDir, imageFilePath, false, /*includeDefaultMounts*/
+		[]testutils.MountPoint{
+			{
+				PartitionNum:   1,
+				Path:           "/boot/efi",
+				FileSystemType: "vfat",
+			},
+		})
+	if !assert.NoError(t, err) {
+		return false
+	}
+	defer imageConnection.Close()
+
+	espDir := filepath.Join(imageConnection.Chroot().RootDir(), "/boot/efi")
+	addonFiles, err := getUkiAddonFiles(espDir)
+	if !assert.NoError(t, err) {
+		return false
+	}
+	if !assert.NotEmpty(t, addonFiles, "expected at least one UKI addon on the ESP") {
+		return false
+	}
+
+	dumpPath := filepath.Join(buildDir, "addon-cmdline-orig.bin")
+	shortPath := filepath.Join(buildDir, "addon-cmdline-short.bin")
+
+	patched := false
+	for _, addonFile := range addonFiles {
+		_, _, err := shell.Execute("objcopy", "--dump-section", ".cmdline="+dumpPath, addonFile)
+		if !assert.NoError(t, err) {
+			return false
+		}
+
+		content, err := os.ReadFile(dumpPath)
+		if !assert.NoError(t, err) {
+			return false
+		}
+
+		// IC writes a clean command line (no NULs). Drop ` rd.info` to make the content shorter than the section, then
+		// re-terminate with a single NUL. objcopy keeps the original section size and zero-pads the freed bytes,
+		// leaving trailing NULs after the last argument.
+		cmdline := string(content)
+		shortened := strings.Replace(cmdline, " rd.info", "", 1)
+		if shortened == cmdline {
+			// Not the addon carrying the verity / rd.info command line; leave it untouched.
+			continue
+		}
+
+		err = os.WriteFile(shortPath, append([]byte(shortened), 0), 0o644)
+		if !assert.NoError(t, err) {
+			return false
+		}
+
+		_, _, err = shell.Execute("objcopy", "--update-section", ".cmdline="+shortPath, addonFile)
+		if !assert.NoError(t, err) {
+			return false
+		}
+		patched = true
+	}
+
+	return assert.True(t, patched, "no addon carrying the ' rd.info' command line was found to patch")
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
@@ -740,7 +740,13 @@ func testCustomizeImageVerityUsrUkiRecustomizeNulPaddedCmdlineHelper(t *testing.
 	reinitConfigFile := filepath.Join(testDir, "verity-reinit-usr-uki.yaml")
 	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, reinitConfigFile, ukiImageFilePath, outImageFilePath,
 		"raw", baseImageInfo.PreviewFeatures)
-	assert.NoError(t, err)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// Validate the re-customized image. Reading the UKI addon command line back is the code path the fix touches, so
+	// this also confirms the usr-verity configuration is well-formed, including a parseable inline hash-offset.
+	verifyUsrInlineVerityUki(t, buildDir, outImageFilePath)
 }
 
 // injectAddonCmdlineNulPadding rewrites every UKI addon `.cmdline` section on the image's ESP with shorter,
@@ -813,4 +819,39 @@ func injectAddonCmdlineNulPadding(t *testing.T, buildDir string, imageFilePath s
 	}
 
 	return assert.True(t, patched, "no addon carrying the ' rd.info' command line was found to patch")
+}
+
+// verifyUsrInlineVerityUki validates that an inline-usr-verity UKI image is well-formed. It reads the usr-verity
+// kernel command line back from the UKI addons on the ESP (the code path the NUL-trim fix touches), checks the
+// systemd.verity_usr_* arguments including a parseable inline hash-offset, and runs `veritysetup verify` against the
+// usr partition.
+func verifyUsrInlineVerityUki(t *testing.T, buildDir string, imageFilePath string) {
+	imageConnection, err := testutils.ConnectToImage(buildDir, imageFilePath, false, /*includeDefaultMounts*/
+		[]testutils.MountPoint{
+			{
+				PartitionNum:   1,
+				Path:           "/boot/efi",
+				FileSystemType: "vfat",
+			},
+		})
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer imageConnection.Close()
+
+	partitions, err := getDiskPartitionsMap(imageConnection.Loopback().DevicePath())
+	if !assert.NoError(t, err, "get disk partitions") {
+		return
+	}
+
+	// Inline verity keeps the usr data and hash tree on the same partition, so the data and hash device and id are
+	// both the usr partition.
+	espPath := filepath.Join(imageConnection.Chroot().RootDir(), "/boot/efi")
+	usrDevice := testutils.PartitionDevPath(imageConnection, 3)
+	usrPartUuid := "PARTUUID=" + partitions[3].PartUuid
+	verifyVerityUki(t, espPath, usrDevice, usrDevice, usrPartUuid, usrPartUuid, "usr", buildDir, "rd.info",
+		"panic-on-corruption", true /*inlineVerity*/)
+
+	err = imageConnection.CleanClose()
+	assert.NoError(t, err)
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
@@ -1148,7 +1148,14 @@ func extractCmdlineFromSinglePE(originalPath, buildDir string) (string, error) {
 		return "", fmt.Errorf("failed to read kernel cmdline args from dumped file (%s):\n%w", cmdlinePath.Name(), err)
 	}
 
-	return string(content), nil
+	// The `.cmdline` PE section holds a NUL-terminated string. Tools that rewrite the section with
+	// shorter content (for example `objcopy --update-section`) keep the section's original size and
+	// zero-pad the freed bytes, so the dumped contents may carry trailing NUL padding. Trim the
+	// trailing NUL bytes so the padding is not treated as part of the command line, which would
+	// otherwise corrupt downstream parsing (e.g. the numeric hash-offset in systemd.verity_*_options).
+	cmdline := strings.TrimRight(string(content), "\x00")
+
+	return cmdline, nil
 }
 
 func extractKernelCmdlineHelper(bootPartition diskutils.PartitionInfo, bootDirPath string, buildDir string,

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-inline-uki-amd64-azl4.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-inline-uki-amd64-azl4.yaml
@@ -1,0 +1,24 @@
+# Differs from verity-usr-inline-uki-azl3 in its use of systemd-boot-unsigned (not systemd-boot) and grub2-efi-x64 (not grub2-efi-binary), and in replacing the iptables-move post-customization script with an rpm-based grub2-efi-x64 removal.
+previewFeatures:
+- base-configs
+
+baseConfigs:
+- path: verity-usr-inline-uki-base.yaml
+
+os:
+  packages:
+    install:
+    - openssh-server
+    - veritysetup
+    - systemd-boot-unsigned
+    - device-mapper
+
+scripts:
+  postCustomization:
+  - content: |
+      # Workaround: shim-<arch> 15.8 has a hard Requires on grub2-efi-<arch>, so dnf
+      # refuses to remove grub2-efi-<arch> while shim is installed. Removing shim
+      # is not an option because shim is needed for the secure boot chain
+      # (UEFI -> shim -> systemd-boot -> kernel) and its EFI binaries on the ESP
+      # are extracted as build artifacts. Use rpm --nodeps to bypass this.
+      rpm -e --nodeps grub2-efi-x64

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-inline-uki-arm64-azl4.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-inline-uki-arm64-azl4.yaml
@@ -1,0 +1,24 @@
+# Differs from verity-usr-inline-uki-amd64-azl4 in its removal of grub2-efi-aa64 (not grub2-efi-x64).
+previewFeatures:
+- base-configs
+
+baseConfigs:
+- path: verity-usr-inline-uki-base.yaml
+
+os:
+  packages:
+    install:
+    - openssh-server
+    - veritysetup
+    - systemd-boot-unsigned
+    - device-mapper
+
+scripts:
+  postCustomization:
+  - content: |
+      # Workaround: shim-<arch> 15.8 has a hard Requires on grub2-efi-<arch>, so dnf
+      # refuses to remove grub2-efi-<arch> while shim is installed. Removing shim
+      # is not an option because shim is needed for the secure boot chain
+      # (UEFI -> shim -> systemd-boot -> kernel) and its EFI binaries on the ESP
+      # are extracted as build artifacts. Use rpm --nodeps to bypass this.
+      rpm -e --nodeps grub2-efi-aa64

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-inline-uki-azl3.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-inline-uki-azl3.yaml
@@ -1,0 +1,26 @@
+previewFeatures:
+- base-configs
+
+baseConfigs:
+- path: verity-usr-inline-uki-base.yaml
+
+os:
+  packages:
+    remove:
+    - grub2-efi-binary
+
+    install:
+    - openssh-server
+    - veritysetup
+    - systemd-boot
+    - device-mapper
+
+scripts:
+  postCustomization:
+  - content: |
+      set -eux
+
+      # Move iptables script off of the / partition, so that the iptables service can run even though / has the noexec
+      # mount flag.
+      mv /etc/systemd/scripts /usr/bin/
+      ln -sr /usr/bin/scripts /etc/systemd/scripts

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-inline-uki-base.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-inline-uki-base.yaml
@@ -1,0 +1,68 @@
+previewFeatures:
+- uki
+
+storage:
+  bootType: efi
+  disks:
+  - partitionTableType: gpt
+    partitions:
+    - id: esp
+      type: esp
+      size: 250M
+
+    - id: boot
+      size: 1G
+
+    - id: usr
+      size: 2G
+
+    - id: root
+      size: 2G
+
+    - id: var
+      size: 1G
+
+  verity:
+  - id: verityusr
+    name: usr
+    dataDeviceId: usr
+    hashDeviceId: usr
+    corruptionOption: panic
+
+  filesystems:
+  - deviceId: esp
+    type: fat32
+    mountPoint:
+      path: /boot/efi
+      options: umask=0077
+
+  - deviceId: boot
+    type: ext4
+    mountPoint: /boot
+
+  - deviceId: root
+    type: ext4
+    mountPoint:
+      path: /
+      options: noexec
+
+  - deviceId: verityusr
+    type: ext4
+    mountPoint:
+      path: /usr
+      options: ro
+
+  - deviceId: var
+    type: ext4
+    mountPoint: /var
+
+os:
+  bootloader:
+    resetType: hard-reset
+
+  kernelCommandLine:
+    extraCommandLine:
+    - rd.info
+
+  uki:
+    mode: create


### PR DESCRIPTION
Trims trailing NUL padding from a UKI addon's `.cmdline` PE section when reading it back, so re-customizing a UKI usr-verity image no longer aborts during base-image validation.

### What was happening
`extractCmdlineFromSinglePE` returned the `.cmdline` section's bytes verbatim. A `.cmdline` section holds a NUL-terminated string, but tools that rewrite it with shorter content (for example `objcopy --update-section`) keep the section's original size and zero-fill the freed bytes. The dumped command line therefore ended in trailing NULs, which corrupted parsing of the last argument -- notably the numeric `hash-offset` in `systemd.verity_usr_options` -- and aborted the re-customization.

### Fix
Trim trailing NUL bytes from the section contents when reading it back.

### Test
Adds an end-to-end regression test (`TestCustomizeImageVerityUsrUkiRecustomizeNulPaddedCmdline`) that builds an inline-usr-verity UKI image (inline verity is what emits the numeric `hash-offset`), rewrites the addon `.cmdline` with shorter NUL-terminated content to recreate the padding, then re-customizes and asserts success. The test and its `verity-usr-inline-uki-*` config family are parameterized across azl3 and azl4.

### Checklist
- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
