### PR TITLE
Fix dnf log handling.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_rpm.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_rpm.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/cosiapi"
@@ -21,29 +19,19 @@ import (
 func managePackagesRpm(ctx context.Context, buildDir string, baseConfigPath string, config *imagecustomizerapi.OS,
 	imageChroot *safechroot.Chroot, toolsChroot *safechroot.Chroot, rpmsSources []string, useBaseImageRpmRepos bool,
 	snapshotTime imagecustomizerapi.PackageSnapshotTime, pmHandler rpmPackageManagerHandler,
-) error {
-	var err error
-
+) (err error) {
 	packageManagerChroot := imageChroot
 	if toolsChroot != nil {
 		packageManagerChroot = toolsChroot
 	}
 
-	// Validate that snapshot time is only used with package managers that support it
-	if snapshotTime != "" && !pmHandler.supportsSnapshotTime() {
-		return fmt.Errorf("%w: package manager %s does not support snapshot time",
-			ErrSnapshotTimeNotSupported, pmHandler.getPackageManagerBinary())
-	}
-
-	// Setup distribution-specific configuration if needed
-	if pmHandler.supportsSnapshotTime() && snapshotTime != "" {
-		// Setup Azure Linux specific TDNF configuration with snapshot
-		err = createTempTdnfConfigWithSnapshot(packageManagerChroot, snapshotTime)
+	if snapshotTime != "" {
+		cleanup, err := pmHandler.configureSnapshotTime(packageManagerChroot, snapshotTime)
 		if err != nil {
 			return err
 		}
 		defer func() {
-			if cleanupErr := cleanupSnapshotTimeConfig(packageManagerChroot); cleanupErr != nil && err == nil {
+			if cleanupErr := cleanup(); cleanupErr != nil && err == nil {
 				err = cleanupErr
 			}
 		}()
@@ -108,30 +96,6 @@ func managePackagesRpm(ctx context.Context, buildDir string, baseConfigPath stri
 	return nil
 }
 
-// executeRpmPackageManagerCommand runs a package manager command with proper chroot handling
-func executeRpmPackageManagerCommand(args []string, imageChroot *safechroot.Chroot,
-	toolsChroot *safechroot.Chroot, pmHandler rpmPackageManagerHandler,
-) error {
-	pmChroot := imageChroot
-	if toolsChroot != nil {
-		pmChroot = toolsChroot
-	}
-
-	if _, err := os.Stat(filepath.Join(pmChroot.RootDir(), pmHandler.getConfigFile())); err == nil {
-		args = append([]string{"--config", "/" + pmHandler.getConfigFile()}, args...)
-	}
-
-	// Use package manager specific output callback
-	stdoutCallback := pmHandler.createOutputCallback()
-
-	return shell.NewExecBuilder(pmHandler.getPackageManagerBinary(), args...).
-		StdoutCallback(stdoutCallback).
-		LogLevel(shell.LogDisabledLevel, logrus.DebugLevel).
-		ErrorStderrLines(1).
-		Chroot(pmChroot.ChrootDir()).
-		Execute()
-}
-
 func installRpmPackages(ctx context.Context, allPackages []string,
 	imageChroot *safechroot.Chroot, toolsChroot *safechroot.Chroot, pmHandler rpmPackageManagerHandler,
 ) error {
@@ -145,7 +109,7 @@ func installRpmPackages(ctx context.Context, allPackages []string,
 	defer span.End()
 
 	// Build command arguments directly
-	args := []string{pmHandler.getVerbosityOption(), "install", "--assumeyes", "--cacheonly"}
+	args := []string{"install", "--assumeyes", "--cacheonly"}
 
 	args = append(args, "--setopt=reposdir="+rpmsMountParentDirInChroot)
 
@@ -162,7 +126,7 @@ func installRpmPackages(ctx context.Context, allPackages []string,
 		}, args...)
 	}
 
-	err := executeRpmPackageManagerCommand(args, imageChroot, toolsChroot, pmHandler)
+	err := pmHandler.executeCommand(args, imageChroot, toolsChroot)
 	if err != nil {
 		return fmt.Errorf("%w (%v):\n%w", ErrPackageInstall, allPackages, err)
 	}
@@ -182,7 +146,7 @@ func updateRpmPackages(ctx context.Context, allPackages []string,
 	defer span.End()
 
 	// Build command arguments directly
-	args := []string{pmHandler.getVerbosityOption(), "update", "--assumeyes", "--cacheonly"}
+	args := []string{"update", "--assumeyes", "--cacheonly"}
 
 	args = append(args, "--setopt=reposdir="+rpmsMountParentDirInChroot)
 
@@ -199,7 +163,7 @@ func updateRpmPackages(ctx context.Context, allPackages []string,
 		}, args...)
 	}
 
-	err := executeRpmPackageManagerCommand(args, imageChroot, toolsChroot, pmHandler)
+	err := pmHandler.executeCommand(args, imageChroot, toolsChroot)
 	if err != nil {
 		return fmt.Errorf("%w (%v):\n%w", ErrPackageUpdate, allPackages, err)
 	}
@@ -216,7 +180,7 @@ func updateExistingRpmPackages(ctx context.Context, imageChroot *safechroot.Chro
 	defer span.End()
 
 	// Build command arguments directly
-	args := []string{pmHandler.getVerbosityOption(), "update", "--assumeyes", "--cacheonly"}
+	args := []string{"update", "--assumeyes", "--cacheonly"}
 
 	args = append(args, "--setopt=reposdir="+rpmsMountParentDirInChroot)
 
@@ -231,7 +195,7 @@ func updateExistingRpmPackages(ctx context.Context, imageChroot *safechroot.Chro
 		}, args...)
 	}
 
-	err := executeRpmPackageManagerCommand(args, imageChroot, toolsChroot, pmHandler)
+	err := pmHandler.executeCommand(args, imageChroot, toolsChroot)
 	if err != nil {
 		return fmt.Errorf("%w:\n%w", ErrPackagesUpdateInstalled, err)
 	}
@@ -252,7 +216,7 @@ func removeRpmPackages(ctx context.Context, allPackagesToRemove []string, imageC
 	defer span.End()
 
 	// Build command arguments directly
-	args := []string{pmHandler.getVerbosityOption(), "remove", "--assumeyes", "--disablerepo", "*"}
+	args := []string{"remove", "--assumeyes", "--disablerepo", "*"}
 	args = append(args, allPackagesToRemove...)
 
 	if toolsChroot != nil {
@@ -261,7 +225,7 @@ func removeRpmPackages(ctx context.Context, allPackagesToRemove []string, imageC
 			args...)
 	}
 
-	err := executeRpmPackageManagerCommand(args, imageChroot, toolsChroot, pmHandler)
+	err := pmHandler.executeCommand(args, imageChroot, toolsChroot)
 	if err != nil {
 		return fmt.Errorf("%w (%v):\n%w", ErrPackageRemove, allPackagesToRemove, err)
 	}
@@ -288,7 +252,7 @@ func refreshRpmPackageMetadata(ctx context.Context, imageChroot *safechroot.Chro
 	// package install operations and to catch any typos in user-provided repository configuration. Otherwise, the wrong
 	// package versions might be silently installed.
 	args := []string{
-		pmHandler.getVerbosityOption(), "check-update", "--refresh", "--assumeyes",
+		"check-update", "--refresh", "--assumeyes",
 		"--setopt=skip_if_unavailable=False",
 	}
 
@@ -301,7 +265,7 @@ func refreshRpmPackageMetadata(ctx context.Context, imageChroot *safechroot.Chro
 		}, args...)
 	}
 
-	err = executeRpmPackageManagerCommand(args, imageChroot, toolsChroot, pmHandler)
+	err = pmHandler.executeCommand(args, imageChroot, toolsChroot)
 	if err != nil {
 		// For DNF/TDNF check-update, exit code 100 means updates are available
 		var exitErr *exec.ExitError
@@ -323,7 +287,7 @@ func cleanRpmCache(ctx context.Context, imageChroot *safechroot.Chroot, toolsChr
 	defer span.End()
 
 	// Build command arguments directly
-	args := []string{pmHandler.getVerbosityOption(), "clean", "all"}
+	args := []string{"clean", "all"}
 
 	if toolsChroot != nil {
 		args = append([]string{
@@ -332,7 +296,7 @@ func cleanRpmCache(ctx context.Context, imageChroot *safechroot.Chroot, toolsChr
 		}, args...)
 	}
 
-	err := executeRpmPackageManagerCommand(args, imageChroot, toolsChroot, pmHandler)
+	err := pmHandler.executeCommand(args, imageChroot, toolsChroot)
 	if err != nil {
 		return fmt.Errorf("%w:\n%w", ErrPackageCacheClean, err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_rpm.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_rpm.go
@@ -389,7 +389,7 @@ func rpmEnsurePackagesRemoved(imageChroot *safechroot.Chroot, pmHandler rpmPacka
 		}, args...)
 	}
 
-	err := executeRpmPackageManagerCommand(args, imageChroot, toolsChroot, pmHandler)
+	err := pmHandler.executeCommand(args, imageChroot, toolsChroot)
 	if err != nil {
 		return fmt.Errorf("%w (%v):\n%w", ErrPackageRemove, packagesToRemove, err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_rpm.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_rpm.go
@@ -26,7 +26,8 @@ func managePackagesRpm(ctx context.Context, buildDir string, baseConfigPath stri
 	}
 
 	if snapshotTime != "" {
-		cleanup, err := pmHandler.configureSnapshotTime(packageManagerChroot, snapshotTime)
+		var cleanup func() error
+		cleanup, err = pmHandler.configureSnapshotTime(packageManagerChroot, snapshotTime)
 		if err != nil {
 			return err
 		}

--- a/toolkit/tools/pkg/imagecustomizerlib/packagemanager_dnf.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/packagemanager_dnf.go
@@ -46,9 +46,6 @@ func (pm *dnfPackageManager) executeCommand(args []string, imageChroot *safechro
 		pmChroot = toolsChroot
 	}
 
-	fullArgs := []string{}
-	fullArgs = append(fullArgs, args...)
-
 	seenTransactionErrorMessage := false
 	stderrCallback := func(line string) {
 		switch {
@@ -68,7 +65,7 @@ func (pm *dnfPackageManager) executeCommand(args []string, imageChroot *safechro
 		}
 	}
 
-	return shell.NewExecBuilder(packageManagerDNF, fullArgs...).
+	return shell.NewExecBuilder(packageManagerDNF, args...).
 		LogLevel(logrus.DebugLevel, shell.LogDisabledLevel).
 		StderrCallback(stderrCallback).
 		Chroot(pmChroot.ChrootDir()).

--- a/toolkit/tools/pkg/imagecustomizerlib/packagemanager_dnf.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/packagemanager_dnf.go
@@ -7,9 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
-	"regexp"
 	"strings"
 
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/logger"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safechroot"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/shell"
@@ -25,162 +25,54 @@ func newDnfPackageManager(version string) *dnfPackageManager {
 	return &dnfPackageManager{version: version}
 }
 
-func (pm *dnfPackageManager) getPackageManagerBinary() string { return packageManagerDNF }
-func (pm *dnfPackageManager) getReleaseVersion() string       { return pm.version }
-func (pm *dnfPackageManager) getConfigFile() string           { return "etc/dnf/dnf.conf" }
-
-// getVerbosityOption returns the package manager-specific verbosity flag
-func (pm *dnfPackageManager) getVerbosityOption() string { return "--setopt=debuglevel=10" }
+func (pm *dnfPackageManager) getReleaseVersion() string { return pm.version }
 
 // getCacheOnlyOptions returns DNF-specific cache options for install/update operations
 func (pm *dnfPackageManager) getCacheOnlyOptions() []string {
 	return []string{"--setopt=cacheonly=metadata"}
 }
 
-// supportsSnapshotTime returns whether DNF supports snapshot time functionality
-func (pm *dnfPackageManager) supportsSnapshotTime() bool {
-	return false // DNF does not support snapshot time for Fedora
+func (pm *dnfPackageManager) configureSnapshotTime(packageManagerChroot *safechroot.Chroot,
+	snapshotTime imagecustomizerapi.PackageSnapshotTime,
+) (func() error, error) {
+	return nil, fmt.Errorf("%w:\npackage manager dnf does not support snapshot time", ErrSnapshotTimeNotSupported)
 }
 
-// DNF-specific constants and output handling
-const (
-	dnfDownloadPattern = `^\s*([a-zA-Z0-9\-._+]+(?:\.[a-zA-Z0-9_]+)*\.rpm)\s+.*\d+.*[kMG]B/s.*\|\s*\d+`
-)
+func (pm *dnfPackageManager) executeCommand(args []string, imageChroot *safechroot.Chroot,
+	toolsChroot *safechroot.Chroot,
+) error {
+	pmChroot := imageChroot
+	if toolsChroot != nil {
+		pmChroot = toolsChroot
+	}
 
-func (pm *dnfPackageManager) createOutputCallback() func(string) {
-	dnfDownloadRegex := regexp.MustCompile(dnfDownloadPattern)
+	fullArgs := []string{}
+	fullArgs = append(fullArgs, args...)
 
-	lastDownloadPackageSeen := ""
-	inTransactionSummary := false
-	inInstallSection := false
-	inUpgradeSection := false
-	inRemoveSection := false
 	seenTransactionErrorMessage := false
-	transactionStarted := false
-
-	return func(line string) {
-		trimmedLine := strings.TrimSpace(line)
-
-		// Check for transaction errors first
-		if !seenTransactionErrorMessage {
-			if strings.HasPrefix(trimmedLine, "Error:") || strings.HasPrefix(trimmedLine, "Problem:") {
-				seenTransactionErrorMessage = true
-				logger.Log.Warn(line)
-				return
-			}
-		}
-
-		// If we've seen an error, log everything as warning
-		if seenTransactionErrorMessage {
-			logger.Log.Warn(line)
-			return
-		}
-
+	stderrCallback := func(line string) {
 		switch {
-		// DNF Transaction Summary section
-		case strings.Contains(trimmedLine, "Transaction Summary"):
-			inTransactionSummary = true
-			logger.Log.Debug(line)
+		case line == "Failed to resolve the transaction:" || strings.HasPrefix(line, "Transaction failed:"):
+			seenTransactionErrorMessage = true
+			fallthrough
 
-		case inTransactionSummary && trimmedLine == "":
-			inTransactionSummary = false
-			logger.Log.Trace(line)
-
-		case inTransactionSummary:
-			logger.Log.Debug(line)
-
-		// DNF package operations during transaction
-		case strings.HasPrefix(trimmedLine, "Installing :"):
-			transactionStarted = true
-			logger.Log.Debug(line)
-
-		case strings.HasPrefix(trimmedLine, "Upgrading  :"):
-			transactionStarted = true
-			logger.Log.Debug(line)
-
-		case strings.HasPrefix(trimmedLine, "Removing   :"):
-			transactionStarted = true
-			logger.Log.Debug(line)
-
-		case strings.HasPrefix(trimmedLine, "Running scriptlet:"):
-			if transactionStarted {
+		case seenTransactionErrorMessage:
+			if line == "" {
 				logger.Log.Debug(line)
 			} else {
-				logger.Log.Trace(line)
+				logger.Log.Warn(line)
 			}
 
-		case strings.HasPrefix(trimmedLine, "Verifying  :"):
-			logger.Log.Debug(line)
-
-		// DNF download progress
-		case strings.Contains(trimmedLine, "MB/s") &&
-			(strings.Contains(trimmedLine, ".rpm") || strings.Contains(trimmedLine, "kB")):
-			match := dnfDownloadRegex.FindStringSubmatch(line)
-			if match != nil && len(match) > 1 {
-				packageName := match[1]
-				if packageName != lastDownloadPackageSeen {
-					lastDownloadPackageSeen = packageName
-					logger.Log.Debug(line)
-				}
-			} else {
-				logger.Log.Debug(line)
-			}
-
-		// DNF dependency resolution
-		case strings.HasPrefix(trimmedLine, "Dependencies resolved."):
-			logger.Log.Debug(line)
-
-		case strings.HasPrefix(trimmedLine, "Installing dependencies:"):
-			inInstallSection = true
-			logger.Log.Debug(line)
-
-		case strings.HasPrefix(trimmedLine, "Installing weak dependencies:"):
-			inInstallSection = true
-			logger.Log.Debug(line)
-
-		case strings.HasPrefix(trimmedLine, "Upgrading:"):
-			inUpgradeSection = true
-			logger.Log.Debug(line)
-
-		case strings.HasPrefix(trimmedLine, "Removing:"):
-			inRemoveSection = true
-			logger.Log.Debug(line)
-
-		// Package lists in dependency sections
-		case (inInstallSection || inUpgradeSection || inRemoveSection) && trimmedLine == "":
-			inInstallSection = false
-			inUpgradeSection = false
-			inRemoveSection = false
-			logger.Log.Trace(line)
-
-		case (inInstallSection || inUpgradeSection || inRemoveSection):
-			logger.Log.Debug(line)
-
-		// DNF metadata operations
-		case strings.Contains(trimmedLine, "metadata") &&
-			(strings.Contains(trimmedLine, "downloading") || strings.Contains(trimmedLine, "using")):
-			logger.Log.Debug(line)
-
-		case strings.HasPrefix(trimmedLine, "Last metadata expiration check:"):
-			logger.Log.Debug(line)
-
-		// DNF progress indicators
-		case strings.Contains(trimmedLine, "[") &&
-			strings.Contains(trimmedLine, "]") && strings.Contains(trimmedLine, "%"):
-			logger.Log.Debug(line)
-
-		// DNF completion messages
-		case strings.HasPrefix(trimmedLine, "Complete!"):
-			logger.Log.Debug(line)
-
-		case strings.HasPrefix(trimmedLine, "Nothing to do."):
-			logger.Log.Debug(line)
-
-		// Default: trace level for other output
 		default:
-			logger.Log.Trace(line)
+			logger.Log.Debug(line)
 		}
 	}
+
+	return shell.NewExecBuilder(packageManagerDNF, fullArgs...).
+		LogLevel(logrus.DebugLevel, shell.LogDisabledLevel).
+		StderrCallback(stderrCallback).
+		Chroot(pmChroot.ChrootDir()).
+		Execute()
 }
 
 func (pm *dnfPackageManager) isPackageInstalled(imageChroot safechroot.ChrootInterface,

--- a/toolkit/tools/pkg/imagecustomizerlib/packagemanager_rpm.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/packagemanager_rpm.go
@@ -3,24 +3,24 @@
 
 package imagecustomizerlib
 
-import "github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safechroot"
+import (
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safechroot"
+)
 
 // rpmPackageManagerHandler represents the interface for RPM-based package managers (TDNF, DNF)
 type rpmPackageManagerHandler interface {
 	// Package manager configuration
-	getPackageManagerBinary() string
 	getReleaseVersion() string
-	getConfigFile() string
-	getVerbosityOption() string
 
-	// Package manager specific output handling
-	createOutputCallback() func(string)
+	executeCommand(args []string, imageChroot *safechroot.Chroot, toolsChroot *safechroot.Chroot) error
 
 	// Package manager specific cache options for install/update operations
 	getCacheOnlyOptions() []string
 
-	// Package manager specific snapshot time support
-	supportsSnapshotTime() bool
+	configureSnapshotTime(packageManagerChroot *safechroot.Chroot,
+		snapshotTime imagecustomizerapi.PackageSnapshotTime,
+	) (func() error, error)
 
 	// isPackageInstalled reports whether packageName is installed. When toolsChroot is non-nil, the query is issued
 	// from inside toolsChroot against installroot=/_imageroot (the bind-mounted image root), so it works on images

--- a/toolkit/tools/pkg/imagecustomizerlib/packagemanager_tdnf.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/packagemanager_tdnf.go
@@ -146,7 +146,7 @@ func (pm *tdnfPackageManager) isPackageInstalled(imageChroot safechroot.ChrootIn
 	chroot := imageChroot
 	if toolsChroot != nil {
 		// Run tdnf from inside the tools chroot against the image bind-mounted at /_imageroot — needed when
-		// imageChroot has no in-image tdnf (e.g. ACL). Matches the executeRpmPackageManagerCommand pattern.
+		// imageChroot has no in-image tdnf (e.g. ACL).
 		args = append([]string{
 			"--releasever=" + pm.getReleaseVersion(),
 			"--installroot=/" + toolsRootImageDir,
@@ -179,7 +179,7 @@ func (pm *tdnfPackageManager) getPackageInformation(imageChroot *safechroot.Chro
 	chroot := imageChroot
 	if toolsChroot != nil {
 		// Run tdnf from inside the tools chroot against the image bind-mounted at /_imageroot — needed when
-		// imageChroot has no in-image tdnf (e.g. ACL). Matches the executeRpmPackageManagerCommand pattern.
+		// imageChroot has no in-image tdnf (e.g. ACL).
 		args = append([]string{
 			"--releasever=" + pm.getReleaseVersion(),
 			"--installroot=/" + toolsRootImageDir,

--- a/toolkit/tools/pkg/imagecustomizerlib/packagemanager_tdnf.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/packagemanager_tdnf.go
@@ -6,11 +6,14 @@ package imagecustomizerlib
 import (
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"slices"
 	"strings"
 
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/logger"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safechroot"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/shell"
@@ -26,21 +29,11 @@ func newTdnfPackageManager(version string) *tdnfPackageManager {
 	return &tdnfPackageManager{version: version}
 }
 
-func (pm *tdnfPackageManager) getPackageManagerBinary() string { return packageManagerTDNF }
-func (pm *tdnfPackageManager) getReleaseVersion() string       { return pm.version }
-func (pm *tdnfPackageManager) getConfigFile() string           { return customTdnfConfRelPath }
-
-// getVerbosityOption returns the package manager-specific verbosity flag
-func (pm *tdnfPackageManager) getVerbosityOption() string { return "-v" }
+func (pm *tdnfPackageManager) getReleaseVersion() string { return pm.version }
 
 // getCacheOnlyOptions returns TDNF-specific cache options for install/update operations
 func (pm *tdnfPackageManager) getCacheOnlyOptions() []string {
 	return nil // TDNF doesn't need additional cache options
-}
-
-// supportsSnapshotTime returns whether TDNF supports snapshot time functionality
-func (pm *tdnfPackageManager) supportsSnapshotTime() bool {
-	return true // TDNF supports snapshot time for Azure Linux
 }
 
 // TDNF-specific constants and output handling
@@ -65,12 +58,43 @@ var (
 	tdnfDownloadRegex         = regexp.MustCompile(tdnfDownloadPattern)
 )
 
-func (pm *tdnfPackageManager) createOutputCallback() func(string) {
+func (pm *tdnfPackageManager) configureSnapshotTime(packageManagerChroot *safechroot.Chroot,
+	snapshotTime imagecustomizerapi.PackageSnapshotTime,
+) (func() error, error) {
+	cleanup := func() error {
+		return cleanupSnapshotTimeConfig(packageManagerChroot)
+	}
+
+	// Setup Azure Linux specific TDNF configuration with snapshot
+	err := createTempTdnfConfigWithSnapshot(packageManagerChroot, snapshotTime)
+	if err != nil {
+		return nil, err
+	}
+
+	return cleanup, nil
+}
+
+func (pm *tdnfPackageManager) executeCommand(args []string, imageChroot *safechroot.Chroot,
+	toolsChroot *safechroot.Chroot,
+) error {
+	pmChroot := imageChroot
+	if toolsChroot != nil {
+		pmChroot = toolsChroot
+	}
+
+	fullArgs := []string{"-v"}
+
+	if _, err := os.Stat(filepath.Join(pmChroot.RootDir(), customTdnfConfRelPath)); err == nil {
+		fullArgs = append(fullArgs, "--config", "/"+customTdnfConfRelPath)
+	}
+
+	fullArgs = append(fullArgs, args...)
+
 	lastDownloadPackageSeen := ""
 	inSummary := false
 	seenTransactionErrorMessage := false
 
-	return func(line string) {
+	stdoutCallback := func(line string) {
 		if !seenTransactionErrorMessage {
 			seenTransactionErrorMessage = tdnfTransactionErrorRegex.MatchString(line)
 		}
@@ -106,6 +130,13 @@ func (pm *tdnfPackageManager) createOutputCallback() func(string) {
 			logger.Log.Trace(line)
 		}
 	}
+
+	return shell.NewExecBuilder(packageManagerTDNF, fullArgs...).
+		StdoutCallback(stdoutCallback).
+		LogLevel(shell.LogDisabledLevel, logrus.DebugLevel).
+		ErrorStderrLines(1).
+		Chroot(pmChroot.ChrootDir()).
+		Execute()
 }
 
 func (pm *tdnfPackageManager) isPackageInstalled(imageChroot safechroot.ChrootInterface,


### PR DESCRIPTION
The handling of the dnf logs is pretty broken. In particular, unlike tdnf which prints all its logs to stdout, dnf splits its logs between stdout and stderr. So, handling dnf logs needs to be done in a different way to tdnf. Hence, this change moves the `executeRpmPackageManagerCommand` function into the `rpmPackageManagerHandler` interface (as `executeCommand`).

That being said, dnf logs aren't all that spammy (compared to tdnf). So, there isn't a need to do extensive filtering of the dnf logs. Therefore, this change also drastically simplifies the dnf log filtering logic.

Also, this change fixes an issue where the dnf transaction error logs are not printed as warning logs. (These can help the user diagnose package installation problems).

This change also moves the handling of the snapshot time into `tdnfPackageManager`.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
