### PR TITLE
Pad the UKI NUL-cmdline test by stripping rd.debug, not rd.info

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
@@ -20,6 +20,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const nulPaddingFillerArg = "rd.debug"
+
 func TestCustomizeImageVerityUsrUki(t *testing.T) {
 	for _, baseImageInfo := range baseImageAzureLinux3Plus {
 		t.Run(baseImageInfo.Name, func(t *testing.T) {
@@ -754,8 +756,9 @@ func testCustomizeImageVerityUsrUkiRecustomizeNulPaddedCmdlineHelper(t *testing.
 // after its last argument.
 //
 // `objcopy --update-section` keeps the section's original size and zero-pads the freed bytes, which is how trailing
-// NULs end up in a `.cmdline` section in practice. The content is shortened by dropping the ` rd.info` argument added
-// by the build config, keeping the verity `hash-offset` value last so the padding lands on it.
+// NULs end up in a `.cmdline` section in practice. The content is shortened by dropping the throwaway
+// nulPaddingFillerArg argument added by the build config, keeping the verity `hash-offset` value last so the padding
+// lands on it.
 //
 // Returns false (after failing the test) if no addon carrying the command line was found to patch.
 func injectAddonCmdlineNulPadding(t *testing.T, buildDir string, imageFilePath string) bool {
@@ -796,13 +799,13 @@ func injectAddonCmdlineNulPadding(t *testing.T, buildDir string, imageFilePath s
 			return false
 		}
 
-		// IC writes a clean command line (no NULs). Drop ` rd.info` to make the content shorter than the section, then
-		// re-terminate with a single NUL. objcopy keeps the original section size and zero-pads the freed bytes,
-		// leaving trailing NULs after the last argument.
+		// IC writes a clean command line (no NULs). Drop the throwaway nulPaddingFillerArg to make the content shorter
+		// than the section, then re-terminate with a single NUL. objcopy keeps the original section size and zero-pads
+		// the freed bytes, leaving trailing NULs after the last argument.
 		cmdline := string(content)
-		shortened := strings.Replace(cmdline, " rd.info", "", 1)
+		shortened := strings.Replace(cmdline, " "+nulPaddingFillerArg, "", 1)
 		if shortened == cmdline {
-			// Not the addon carrying the verity / rd.info command line; leave it untouched.
+			// Not the addon carrying the padded command line; leave it untouched.
 			continue
 		}
 
@@ -818,7 +821,7 @@ func injectAddonCmdlineNulPadding(t *testing.T, buildDir string, imageFilePath s
 		patched = true
 	}
 
-	return assert.True(t, patched, "no addon carrying the ' rd.info' command line was found to patch")
+	return assert.True(t, patched, "no addon carrying the throwaway "+nulPaddingFillerArg+" argument was found to patch")
 }
 
 // verifyUsrInlineVerityUki validates that an inline-usr-verity UKI image is well-formed. It reads the usr-verity

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-inline-uki-base.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-inline-uki-base.yaml
@@ -63,6 +63,7 @@ os:
   kernelCommandLine:
     extraCommandLine:
     - rd.info
+    - rd.debug
 
   uki:
     mode: create


### PR DESCRIPTION
Fixes the AZL4 post-merge functional failure of the UKI NUL-padded cmdline regression test added in #840. The #840 fix itself is fine -- re-customization succeeds and the inline `hash-offset` parses cleanly. The problem was the test's own assertion in `TestCustomizeImageVerityUsrUkiRecustomizeNulPaddedCmdline`.

**What was wrong:** to recreate the trailing NUL padding, the test stripped ` rd.info` from the UKI addon `.cmdline`, then asserted `rd.info` survived re-customization. Whether it survives depends on where the cmdline is re-read from, so the assertion was flaky by platform:

| Distro | Cmdline re-read from | `rd.info` after re-customize |
| --- | --- | --- |
| AZL4 | the stripped UKI addon | gone, so the assertion failed |
| AZL3 | grub.cfg | survived, so the assertion passed |

**Fix:** the build config now adds a second argument (`rd.debug`) after `rd.info`, and the test strips that one to create the padding, leaving `rd.info` untouched. The padding still lands on the verity `hash-offset` (the last argument), so the NUL-trim regression is still exercised, and the `rd.info` assertion is now reliable on every platform.

Verified by running the AZL3 functional subtest locally. It passes with the restored `rd.info` assertion.

---

### **Checklist**
- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines