### PR TITLE
Fix UKI create mode rejecting kernel cmdline changes on UKI base images

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/bootcustomizer.go
@@ -77,7 +77,7 @@ func NewBootCustomizer(imageChroot safechroot.ChrootInterface, uki *imagecustomi
 	ukiKernelInfoPath := ""
 	if uki != nil {
 		ukiMode = uki.Mode
-		if ukiMode == imagecustomizerapi.UkiModeModify {
+		if ukiMode == imagecustomizerapi.UkiModeModify || ukiMode == imagecustomizerapi.UkiModeCreate {
 			ukiKernelInfoPath = filepath.Join(buildDir, UkiBuildDir, UkiKernelInfoJson)
 		}
 	}
@@ -99,8 +99,11 @@ func determineBootConfigType(grubCfgContent string, imageChroot safechroot.Chroo
 		espDir := filepath.Join(imageChroot.RootDir(), distroHandler.GetEspDir())
 		ukiFiles, err := getUkiFiles(espDir)
 		if err == nil && len(ukiFiles) > 0 {
-			// UKI images without grub.cfg are in passthrough mode (grub.cfg not regenerated)
-			// For UKI create mode, grub.cfg is regenerated during kernel extraction, so it would exist
+			// The image boots via UKIs and has no grub.cfg. Passthrough mode preserves the
+			// existing UKIs as-is.
+			//
+			// UKI modes create and modify carry any kernel command-line changes through uki-kernel-info.json rather
+			// than a grub.cfg, which is never regenerated for a UKI base image.
 			return bootConfigTypeUki, nil
 		}
 		return "", ErrBootNoConfigFound
@@ -141,12 +144,12 @@ func (b *BootCustomizer) AddKernelCommandLine(extraCommandLine []string) error {
 		b.grubCfgContent = grubCfgContent
 
 	case bootConfigTypeUki:
-		// UKI passthrough mode: preserve existing UKI boot configuration.
-		// Cmdline args cannot be modified in passthrough mode.
-		if b.ukiMode != imagecustomizerapi.UkiModeModify {
+		// The image boots via UKIs. Passthrough mode preserves the existing UKIs, so the
+		// kernel command-line cannot be changed. Create and modify mode both regenerate the
+		// UKI boot data from uki-kernel-info.json, so the args are applied there.
+		if b.ukiMode != imagecustomizerapi.UkiModeModify && b.ukiMode != imagecustomizerapi.UkiModeCreate {
 			return ErrBootUkiPassthroughCmdlineModified
 		}
-		// For modify mode, append args to the UKI cmdline file.
 		err := b.appendToUkiCmdlineFile(combinedArgs)
 		if err != nil {
 			return err

--- a/toolkit/tools/pkg/imagecustomizerlib/customizebootloader.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizebootloader.go
@@ -40,7 +40,9 @@ func handleBootLoader(ctx context.Context, rc *ResolvedConfig, imageConnection *
 		}
 
 	default:
-		// Append the kernel command-line args to the existing grub config.
+		// Append the kernel command-line args to the image's existing boot config: the grub
+		// config for grub-based images, or the UKI cmdline (uki-kernel-info.json) for UKI
+		// images in create or modify mode.
 		err := AddKernelCommandLine(ctx, rc.BuildDirAbs, rc.OsKernelCommandLine.ExtraCommandLine, imageConnection.Chroot(), rc.Uki, distroHandler)
 		if err != nil {
 			return fmt.Errorf("%w:\n%w", ErrBootloaderKernelCommandLineAdd, err)

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
@@ -43,9 +43,10 @@ func doOsCustomizations(ctx context.Context, rc *ResolvedConfig, imageConnection
 		return err
 	}
 
-	// If UKI mode is 'create' and base image has UKIs, extract kernel and
-	// initramfs from existing UKIs for re-customization. For 'passthrough'
-	// mode, we skip extraction to preserve existing UKIs.
+	// If UKI mode is 'create' and the base image has UKIs, prepare for re-customization:
+	// extract the kernel and initramfs from the existing UKIs, and save their base kernel
+	// command-line so that os.kernelCommandLine changes can be applied to the regenerated
+	// UKIs. 'passthrough' mode skips this to preserve the existing UKIs.
 	if rc.Uki != nil && rc.Uki.Mode == imagecustomizerapi.UkiModeCreate {
 		// Check if base image has UKIs to determine if extraction is needed
 		hasUkis, err := baseImageHasUkis(imageChroot, distroHandler)
@@ -56,6 +57,18 @@ func doOsCustomizations(ctx context.Context, rc *ResolvedConfig, imageConnection
 		if hasUkis {
 			// Base image has UKIs and mode is create - extract for re-customization
 			err = extractKernelAndInitramfsFromUkis(ctx, imageChroot, rc.BuildDirAbs, distroHandler)
+			if err != nil {
+				return err
+			}
+
+			// Save the base kernel command-line now so that we can apply those changes later via uki-kernel-info.json
+			ukiBuildDir := filepath.Join(rc.BuildDirAbs, UkiBuildDir)
+			err = os.MkdirAll(ukiBuildDir, os.ModePerm)
+			if err != nil {
+				return fmt.Errorf("failed to create UKI build directory:\n%w", err)
+			}
+
+			err = saveUkiBaseCmdlineForCreate(rc.BuildDirAbs, imageChroot, distroHandler)
 			if err != nil {
 				return err
 			}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki.go
@@ -228,6 +228,33 @@ func extractAndSaveUkiCmdline(buildDir string, imageChroot *safechroot.Chroot, d
 	return nil
 }
 
+// saveUkiBaseCmdlineForCreate extracts the current kernel command-line from each existing UKI
+// (main UKI plus addons) and saves them to uki-kernel-info.json. A UKI base image has no
+// grub.cfg, so the cmdline is read directly from the UKIs.
+func saveUkiBaseCmdlineForCreate(buildDir string, imageChroot *safechroot.Chroot,
+	distroHandler DistroHandler,
+) error {
+	espDir := filepath.Join(imageChroot.RootDir(), distroHandler.GetEspDir())
+
+	kernelToArgs, err := extractKernelCmdlineFromUkiEfis(espDir, buildDir)
+	if err != nil {
+		return fmt.Errorf("failed to extract base kernel command-line from UKIs:\n%w", err)
+	}
+
+	kernelInfo := make(map[string]UkiKernelInfo, len(kernelToArgs))
+	for kernel, cmdline := range kernelToArgs {
+		kernelInfo[kernel] = UkiKernelInfo{Cmdline: cmdline}
+	}
+
+	ukiKernelInfoPath := filepath.Join(buildDir, UkiBuildDir, UkiKernelInfoJson)
+	err = writeUkiKernelInfoFile(ukiKernelInfoPath, kernelInfo)
+	if err != nil {
+		return fmt.Errorf("failed to write UKI kernel info file:\n%w", err)
+	}
+
+	return nil
+}
+
 func prepareUki(ctx context.Context, buildDir string, uki *imagecustomizerapi.Uki,
 	imageChroot *safechroot.Chroot, toolsChroot *safechroot.Chroot, distroHandler DistroHandler,
 ) error {

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
@@ -119,6 +119,8 @@ func testCustomizeImageVerityUsrUkiRecustomizeHelper(t *testing.T, baseImageInfo
 		return
 	}
 
+	// Re-customize the UKI image with 'os.uki.mode: create', os.kernelCommandLine.extraCommandLine, and
+	// 'os.bootloader.resetType: hard-reset'.
 	outImageFilePath2 := filepath.Join(testTempDir, "image2.raw")
 	configFile2 := filepath.Join(testDir, "verity-reinit-usr-uki.yaml")
 
@@ -133,66 +135,9 @@ func testCustomizeImageVerityUsrUkiRecustomizeHelper(t *testing.T, baseImageInfo
 		return
 	}
 
-	// With UKI addon architecture:
-	// - Main UKI (kernel + os-release + initramfs) should NOT change when only verity is re-initialized
-	// - Addon (cmdline with verity hashes) SHOULD change when verity is re-initialized
-	for ukiFile := range ukiFilesChecksums {
-		oldChecksum := ukiFilesChecksums[ukiFile]
-		newChecksum, exists := newUkiFilesChecksums[ukiFile]
-		assert.True(t, exists, "UKI file should exist after re-customization: %s", ukiFile)
-		// Main UKI should stay the same since initramfs doesn't change
-		assert.Equal(t, oldChecksum, newChecksum, "Main UKI checksum should NOT change (only cmdline in addon changes): %s", ukiFile)
-	}
-
-	// Addon checksums should change because verity hashes in cmdline change
-	for addonFile, oldAddonChecksum := range addonFilesChecksums {
-		newAddonChecksum, exists := newAddonFilesChecksums[addonFile]
-		assert.True(t, exists, "Addon file should exist after re-customization: %s", addonFile)
-		assert.NotEqual(t, oldAddonChecksum, newAddonChecksum, "Addon checksum should change after verity re-initialization: %s", addonFile)
-	}
-
-	mountPoints := []testutils.MountPoint{
-		{
-			PartitionNum:   1,
-			Path:           "/boot/efi",
-			FileSystemType: "vfat",
-		},
-		{
-			PartitionNum:   2,
-			Path:           "/boot",
-			FileSystemType: "ext4",
-		},
-		{
-			PartitionNum:   5,
-			Path:           "/",
-			FileSystemType: "ext4",
-		},
-	}
-
-	imageConnection, err := testutils.ConnectToImage(buildDir, outImageFilePath2, false /*includeDefaultMounts*/, mountPoints)
-	if !assert.NoError(t, err) {
-		return
-	}
-	defer imageConnection.Close()
-
-	bootPath := filepath.Join(imageConnection.Chroot().RootDir(), "/boot")
-	bootEntries, err := os.ReadDir(bootPath)
-	assert.NoError(t, err)
-
-	// /boot should only contain "efi" and optionally "lost+found" directories.
-	assert.LessOrEqual(t, len(bootEntries), 2, "/boot should contain at most 2 entries: 'efi' and 'lost+found'")
-
-	// Verify all entries are either "efi" or "lost+found"
-	hasEfi := false
-	for _, entry := range bootEntries {
-		assert.True(t, entry.Name() == "efi" || entry.Name() == "lost+found",
-			"unexpected entry in /boot: %s (expected only 'efi' and 'lost+found')", entry.Name())
-		assert.True(t, entry.IsDir(), "%s should be a directory", entry.Name())
-		if entry.Name() == "efi" {
-			hasEfi = true
-		}
-	}
-	assert.True(t, hasEfi, "/boot must contain the 'efi' directory")
+	verifyUsrVerityUkiRecustomized(t, buildDir, outImageFilePath2,
+		ukiFilesChecksums, newUkiFilesChecksums, addonFilesChecksums, newAddonFilesChecksums,
+		"rd.info")
 }
 
 func TestCustomizeImageVerityUsrUkiPassthrough(t *testing.T) {
@@ -301,6 +246,135 @@ func testCustomizeImageVerityRootUkiHelper(t *testing.T, baseImageInfo testBaseI
 	}
 
 	verifyRootVerityUki(t, buildDir, outImageFilePath2, nil)
+}
+
+func TestCustomizeImageVerityUsrUkiRecustomizeCmdline(t *testing.T) {
+	for _, baseImageInfo := range baseImageAzureLinux3Plus {
+		t.Run(baseImageInfo.Name, func(t *testing.T) {
+			testCustomizeImageVerityUsrUkiRecustomizeCmdlineHelper(t, baseImageInfo)
+		})
+	}
+}
+
+func testCustomizeImageVerityUsrUkiRecustomizeCmdlineHelper(t *testing.T, baseImageInfo testBaseImageInfo) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
+
+	ukifyExists, err := file.CommandExists("ukify")
+	assert.NoError(t, err)
+	if !ukifyExists {
+		t.Skip("The 'ukify' command is not available")
+	}
+
+	testTempDir := filepath.Join(tmpDir, fmt.Sprintf("TestCustomizeImageVerityUsrUkiRecustomizeCmdline_%s", baseImageInfo.Name))
+	defer os.RemoveAll(testTempDir)
+
+	buildDir := filepath.Join(testTempDir, "build")
+
+	// Pass 1: turn the grub-based base image into a UKI image. IC removes grub.cfg and writes
+	// UKIs to the ESP, matching the ACL template image layout (UKIs present, no grub.cfg).
+	outImageFilePath1 := filepath.Join(testTempDir, "uki-base.raw")
+	configFile1 := filepath.Join(testDir, verityUsrUkiConfigFile(t, baseImageInfo))
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile1, baseImage, outImageFilePath1, "raw",
+		baseImageInfo.PreviewFeatures)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	ukiFilesChecksums1, addonFilesChecksums1, ok := verifyUsrVerity(t, buildDir, outImageFilePath1, nil, nil)
+	if !ok {
+		return
+	}
+
+	// Pass 2: re-customize that UKI image with 'os.uki.mode: create' and os.kernelCommandLine.extraCommandLine but no
+	// 'os.bootloader.resetType: hard-reset'.
+	outImageFilePath2 := filepath.Join(testTempDir, "image.raw")
+	configFile2 := filepath.Join(testDir, "verity-reinit-usr-uki-cmdline.yaml")
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile2, outImageFilePath1, outImageFilePath2, "raw",
+		baseImageInfo.PreviewFeatures)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	ukiFilesChecksums2, addonFilesChecksums2, ok := verifyUsrVerity(t, buildDir, outImageFilePath2, nil, nil)
+	if !ok {
+		return
+	}
+
+	// Create mode must preserve each main UKI while regenerating the addon, and the gb200
+	// extraCommandLine must have reached the regenerated UKIs — the specific behaviour this test
+	// exercises via the default (non hard-reset) AddKernelCommandLine path.
+	verifyUsrVerityUkiRecustomized(t, buildDir, outImageFilePath2,
+		ukiFilesChecksums1, ukiFilesChecksums2, addonFilesChecksums1, addonFilesChecksums2,
+		"console=ttyAMA0,115200n8")
+}
+
+// verifyUsrVerityUkiRecustomized checks that re-customizing a usr-verity UKI image in create mode
+// preserved each main UKI (kernel/initramfs/os-release unchanged) while regenerating its addon
+// (cmdline changed), and that /boot contains only the ESP. When expectedCmdlineArgs are given, it
+// also asserts every regenerated UKI's kernel command-line contains each of them.
+func verifyUsrVerityUkiRecustomized(t *testing.T, buildDir string, imagePath string,
+	oldUkiChecksums, newUkiChecksums, oldAddonChecksums, newAddonChecksums map[string]string,
+	expectedCmdlineArgs ...string,
+) {
+	// The main UKI (kernel + os-release + initramfs) must not change; only the addon (cmdline) does.
+	for ukiFile, oldChecksum := range oldUkiChecksums {
+		newChecksum, exists := newUkiChecksums[ukiFile]
+		assert.True(t, exists, "UKI file should exist after re-customization: %s", ukiFile)
+		assert.Equal(t, oldChecksum, newChecksum,
+			"Main UKI checksum should NOT change (only cmdline in addon changes): %s", ukiFile)
+	}
+
+	// The addon (cmdline) must change.
+	for addonFile, oldChecksum := range oldAddonChecksums {
+		newChecksum, exists := newAddonChecksums[addonFile]
+		assert.True(t, exists, "Addon file should exist after re-customization: %s", addonFile)
+		assert.NotEqual(t, oldChecksum, newChecksum,
+			"Addon checksum should change after re-customization: %s", addonFile)
+	}
+
+	// Mount parent-first (/, then /boot, then the ESP) so the ESP is actually exposed for reads.
+	mountPoints := []testutils.MountPoint{
+		{PartitionNum: 5, Path: "/", FileSystemType: "ext4"},
+		{PartitionNum: 2, Path: "/boot", FileSystemType: "ext4"},
+		{PartitionNum: 1, Path: "/boot/efi", FileSystemType: "vfat"},
+	}
+	imageConnection, err := testutils.ConnectToImage(buildDir, imagePath, false /*includeDefaultMounts*/, mountPoints)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer imageConnection.Close()
+
+	// /boot should only contain "efi" and optionally "lost+found".
+	bootPath := filepath.Join(imageConnection.Chroot().RootDir(), "/boot")
+	bootEntries, err := os.ReadDir(bootPath)
+	assert.NoError(t, err)
+	assert.LessOrEqual(t, len(bootEntries), 2, "/boot should contain at most 2 entries: 'efi' and 'lost+found'")
+	hasEfi := false
+	for _, entry := range bootEntries {
+		assert.True(t, entry.Name() == "efi" || entry.Name() == "lost+found",
+			"unexpected entry in /boot: %s (expected only 'efi' and 'lost+found')", entry.Name())
+		assert.True(t, entry.IsDir(), "%s should be a directory", entry.Name())
+		if entry.Name() == "efi" {
+			hasEfi = true
+		}
+	}
+	assert.True(t, hasEfi, "/boot must contain the 'efi' directory")
+
+	// Optionally verify specific kernel command-line args reached the regenerated UKIs.
+	if len(expectedCmdlineArgs) > 0 {
+		espPath := filepath.Join(imageConnection.Chroot().RootDir(), "/boot/efi")
+		kernelToArgs, err := extractKernelCmdlineFromUkiEfis(espPath, buildDir)
+		if !assert.NoError(t, err) {
+			return
+		}
+		assert.GreaterOrEqual(t, len(kernelToArgs), 1, "expected at least one UKI in the ESP")
+		for kernel, args := range kernelToArgs {
+			for _, expected := range expectedCmdlineArgs {
+				assert.Contains(t, args, expected,
+					"regenerated UKI for kernel (%s) should contain cmdline arg (%s)", kernel, expected)
+			}
+		}
+	}
 }
 
 func verifyUsrVerity(t *testing.T, buildDir string, imagePath string,

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-reinit-usr-uki-cmdline.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-reinit-usr-uki-cmdline.yaml
@@ -1,0 +1,14 @@
+previewFeatures:
+- reinitialize-verity
+- uki
+
+storage:
+  reinitializeVerity: all
+
+os:
+  kernelCommandLine:
+    extraCommandLine:
+    - console=ttyAMA0,115200n8
+
+  uki:
+    mode: create


### PR DESCRIPTION
Image Customizer now applies `os.kernelCommandLine.extraCommandLine` when re-customizing a UKI base image with `os.uki.mode: create`, which previously failed with `cannot modify kernel command-line in UKI passthrough mode`.

## Why it broke

A UKI base image has its UKIs in the ESP and no `grub.cfg`, so `determineBootConfigType` classifies it as a UKI image. The UKI branch of `AddKernelCommandLine` only accepted modify mode, so create mode was misrejected as passthrough. Converting a grub image to UKI with create mode works only because the command line rides through `grub.cfg`, which a UKI base image does not have.

## The fix

Modify mode already carries the command line through `uki-kernel-info.json`, and create mode now does the same. passthrough mode is still rejected

## Testing

Added `TestCustomizeImageVerityUsrUkiRecustomizeCmdline`, a functional test that reproduces the reported scenario. It re-customizes a usr-verity UKI image with create mode plus `extraCommandLine` and no bootloader hard-reset, then asserts the new args reached every regenerated UKI. Not setting hard-reset is key to exercise this path.

---

### **Checklist**
- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
