### PR TITLE
Add `removePackageManager` API.

### DIFF
--- a/docs/imagecustomizer/api/configuration/baseConfig.md
+++ b/docs/imagecustomizer/api/configuration/baseConfig.md
@@ -31,6 +31,7 @@ Customizer multiple times instead of using the `baseConfigs` API.
 - `.output.artifacts.path`
 - `.os.hostname`
 - `.os.imageHistory`
+- `.os.packages.removePackageManager`
 - `.os.selinux`
 - `.os.uki`
 - `.iso.initramfsType`

--- a/docs/imagecustomizer/api/configuration/config.md
+++ b/docs/imagecustomizer/api/configuration/config.md
@@ -163,6 +163,11 @@ Supported options:
 
   Added in v1.5.
 
+- `remove-package-manager`: Enables support for the
+  ([os.packages.removePackageManager](./packages.md#removepackagemanager-bool)) API.
+
+  Added in v1.6.
+
 ## output [[output](./output.md)]
 
 Specifies the configuration for the output image and artifacts.

--- a/docs/imagecustomizer/api/configuration/configuration.md
+++ b/docs/imagecustomizer/api/configuration/configuration.md
@@ -73,24 +73,27 @@ The top level type for the YAML file is the [config](./config.md) type.
 
 17. Run ([postCustomization](./scripts.md#postcustomization-script)) scripts.
 
-18. Restore the `/etc/resolv.conf` file.
+18. If ([os.packages.removePackageManager](./packages.md#removepackagemanager-bool)) is
+    specified, then remove the package manager tools.
 
-19. If SELinux is enabled, call `setfiles`.
+19. Restore the `/etc/resolv.conf` file.
 
-20. Run finalize image scripts. ([finalizeCustomization](./scripts.md#finalizecustomization-script))
+20. If SELinux is enabled, call `setfiles`.
 
-21. If `--output-image-format` is `cosi` or `baremetal-image`, then shrink the file systems.
+21. Run finalize image scripts. ([finalizeCustomization](./scripts.md#finalizecustomization-script))
 
-22. If a ([verity](./storage.md#verity-verity)) device is specified, then
+22. If `--output-image-format` is `cosi` or `baremetal-image`, then shrink the file systems.
+
+23. If a ([verity](./storage.md#verity-verity)) device is specified, then
     create the hash tree and update the grub config.
 
-23. If ([output.artifacts](./output.md#artifacts-outputartifacts)) is
+24. If ([output.artifacts](./output.md#artifacts-outputartifacts)) is
     specified, then copy the artifacts to the specified output directory.
 
-24. If ([output.selinuxPolicyPath](./output.md#selinuxpolicypath-string)) is
+25. If ([output.selinuxPolicyPath](./output.md#selinuxpolicypath-string)) is
     specified, then extract the SELinux policy files from the customized image.
 
-25. If the output format is set to `iso` or `pxe`, copy additional iso media files.
+26. If the output format is set to `iso` or `pxe`, copy additional iso media files.
     ([iso](./iso.md) or [pxe](./pxe.md))
 
 ## /etc/resolv.conf

--- a/docs/imagecustomizer/api/configuration/packages.md
+++ b/docs/imagecustomizer/api/configuration/packages.md
@@ -180,3 +180,46 @@ os:
 ```
 
 Added in v0.15.
+
+## removePackageManager [bool]
+
+Optional.
+
+This is a preview feature.
+Its API and behavior is subject to change.
+You must enable this feature by specifying `remove-package-manager` in the
+[previewFeatures](./config.md#previewfeatures-string) API.
+
+When set to true, the package manager tooling (e.g. tdnf, dnf, apt, etc.) and all the
+package management files (e.g. databases, package cache) will be removed from the image.
+
+This operation includes removing any packages that are considered "unused dependencies"
+by the package manager. If this removes a package required in your image, then mark the
+required package in a [postCustomization](./scripts.md#postcustomization-script) script
+to prevent this:
+
+- Azure Linux 3: `tdnf mark install <package>`
+- Azure Linux 4 / Fedora: `dnf mark install <package>`
+- Ubuntu: `apt-mark install <package>`
+
+This operation occurs after the `postCustomization` scripts and before the
+`finalizeCustomization` scripts. See,
+[Operation Ordering](./configuration.md#operation-ordering) for details.
+
+Note: If this API is used when the
+[output format](../cli/customize.md#--output-image-formatformat)
+is either `iso`, `pxe-dir`, `pxe-tar`, `cosi`, or `baremetal-image`, then the build will
+fail. This is planned to be fixed in a future release.
+
+Example:
+
+```yaml
+previewFeatures:
+- remove-package-manager
+
+os:
+  packages:
+    removePackageManager: true
+```
+
+Added in v1.6.

--- a/docs/imagecustomizer/api/configuration/packages.md
+++ b/docs/imagecustomizer/api/configuration/packages.md
@@ -193,6 +193,9 @@ You must enable this feature by specifying `remove-package-manager` in the
 When set to true, the package manager tooling (e.g. tdnf, dnf, apt, etc.) and all the
 package management files (e.g. databases, package cache) will be removed from the image.
 
+Note: For Ubuntu, the dpkg package and its related files are not removed since it is a
+dependency of some fundamental system packages (e.g. `grub-efi-amd64-signed`).
+
 This operation includes removing any packages that are considered "unused dependencies"
 by the package manager. If this removes a package required in your image, then mark the
 required package in a [postCustomization](./scripts.md#postcustomization-script) script

--- a/toolkit/tools/imagecustomizerapi/config.go
+++ b/toolkit/tools/imagecustomizerapi/config.go
@@ -89,6 +89,11 @@ func (c *Config) IsValid() (err error) {
 		if c.OS.Packages.SnapshotTime != "" && !sliceutils.ContainsValue(c.PreviewFeatures, PreviewFeaturePackageSnapshotTime) {
 			return fmt.Errorf("the 'package-snapshot-time' preview feature must be enabled to use 'os.packages.snapshotTime'")
 		}
+
+		if c.OS.Packages.RemovePackageManager != nil && !sliceutils.ContainsValue(c.PreviewFeatures, PreviewFeatureRemovePackageManager) {
+			return fmt.Errorf("the '%s' preview feature must be enabled to use 'os.packages.removePackageManager'",
+				PreviewFeatureRemovePackageManager)
+		}
 	}
 
 	err = c.Scripts.IsValid()

--- a/toolkit/tools/imagecustomizerapi/config_test.go
+++ b/toolkit/tools/imagecustomizerapi/config_test.go
@@ -882,3 +882,17 @@ func TestConfigIsValidWithBtrfsFilesystemNoPreviewFeature(t *testing.T) {
 	assert.Error(t, err)
 	assert.ErrorContains(t, err, "the 'btrfs' preview feature must be enabled to use btrfs filesystems")
 }
+
+func TestConfigIsValidMissingRemovePackageManagerPreviewFeature(t *testing.T) {
+	config := &Config{
+		PreviewFeatures: []PreviewFeature{},
+		OS: &OS{
+			Packages: Packages{
+				RemovePackageManager: ptrutils.PtrTo(true),
+			},
+		},
+	}
+
+	err := config.IsValid()
+	assert.ErrorContains(t, err, "the 'remove-package-manager' preview feature must be enabled to use 'os.packages.removePackageManager'")
+}

--- a/toolkit/tools/imagecustomizerapi/packages.go
+++ b/toolkit/tools/imagecustomizerapi/packages.go
@@ -12,4 +12,5 @@ type Packages struct {
 	UpdateLists            []string            `yaml:"updateLists" json:"-"`
 	Update                 []string            `yaml:"update" json:"update,omitempty"`
 	SnapshotTime           PackageSnapshotTime `yaml:"snapshotTime" json:"snapshotTime,omitempty"`
+	RemovePackageManager   *bool               `yaml:"removePackageManager" json:"removePackageManager,omitempty"`
 }

--- a/toolkit/tools/imagecustomizerapi/previewfeaturetype.go
+++ b/toolkit/tools/imagecustomizerapi/previewfeaturetype.go
@@ -51,7 +51,7 @@ const (
 	// PreviewFeatureToolsDir enables support for specifying a tools directory.
 	PreviewFeatureToolsDir PreviewFeature = "tools-dir"
 
-	// PreviewFeatureRemovePackageManager enables support for the '.os.package.removePackageManager' API.
+	// PreviewFeatureRemovePackageManager enables support for the '.os.packages.removePackageManager' API.
 	PreviewFeatureRemovePackageManager PreviewFeature = "remove-package-manager"
 )
 

--- a/toolkit/tools/imagecustomizerapi/previewfeaturetype.go
+++ b/toolkit/tools/imagecustomizerapi/previewfeaturetype.go
@@ -50,6 +50,9 @@ const (
 
 	// PreviewFeatureToolsDir enables support for specifying a tools directory.
 	PreviewFeatureToolsDir PreviewFeature = "tools-dir"
+
+	// PreviewFeatureRemovePackageManager enables support for the '.os.package.removePackageManager' API.
+	PreviewFeatureRemovePackageManager PreviewFeature = "remove-package-manager"
 )
 
 func (pf PreviewFeature) IsValid() error {
@@ -57,7 +60,8 @@ func (pf PreviewFeature) IsValid() error {
 	case PreviewFeatureUki, PreviewFeatureOutputArtifacts, PreviewFeatureInjectFiles, PreviewFeatureReinitializeVerity,
 		PreviewFeaturePackageSnapshotTime, PreviewFeatureKdumpBootFiles, PreviewFeatureDistroVersion,
 		PreviewFeatureBaseConfigs, PreviewFeatureInputImageOci, PreviewFeatureOutputSelinuxPolicy, PreviewFeatureBtrfs,
-		PreviewFeatureCreate, PreviewFeatureUnsupportedDistroVersion, PreviewFeatureToolsDir:
+		PreviewFeatureCreate, PreviewFeatureUnsupportedDistroVersion, PreviewFeatureToolsDir,
+		PreviewFeatureRemovePackageManager:
 		return nil
 	default:
 		return fmt.Errorf("invalid preview feature: %s", pf)

--- a/toolkit/tools/imagecustomizerapi/schema.json
+++ b/toolkit/tools/imagecustomizerapi/schema.json
@@ -543,6 +543,9 @@
         },
         "snapshotTime": {
           "type": "string"
+        },
+        "removePackageManager": {
+          "type": "boolean"
         }
       },
       "additionalProperties": false,

--- a/toolkit/tools/pkg/imagecustomizerlib/configvalidation.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/configvalidation.go
@@ -56,6 +56,7 @@ var (
 	ErrInputImageAzureLinuxNotFound         = NewImageCustomizerError("Validation:InputImageAzureLinuxNotFound", "input.image.azureLinux not found")
 	ErrInputImageOciNotFound                = NewImageCustomizerError("Validation:InputImageOciNotFound", "input.image.oci not found")
 	ErrStorageMoreThanOne                   = NewImageCustomizerError("Validation:StorageMoreThanOne", "storage may only be specified in one config file:\nstorage merging logic not yet implemented")
+	ErrRemovePackageManagerBadOutputFormat  = NewImageCustomizerError("Validation:RemovePackageManagerBadOutputFormat", "removePackageManager API does not work yet with output format")
 )
 
 // ValidateConfigWithConfigFileOptions validates a configuration file without performing customization.
@@ -260,6 +261,16 @@ func ValidateConfig(ctx context.Context, baseConfigPath string, config *imagecus
 	rc.ImageHistory = resolveImageHistory(rc.ConfigChain)
 
 	rc.RemovePackageManager = resolveRemovePackageManager(rc.ConfigChain)
+
+	if rc.RemovePackageManager {
+		switch rc.OutputImageFormat {
+		case imagecustomizerapi.ImageFormatTypeIso, imagecustomizerapi.ImageFormatTypePxeDir,
+			imagecustomizerapi.ImageFormatTypePxeTar, imagecustomizerapi.ImageFormatTypeCosi,
+			imagecustomizerapi.ImageFormatTypeBareMetalImage:
+
+			return nil, fmt.Errorf("%w (format='%s')", ErrRemovePackageManagerBadOutputFormat, rc.OutputImageFormat)
+		}
+	}
 
 	return rc, nil
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/configvalidation.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/configvalidation.go
@@ -259,6 +259,8 @@ func ValidateConfig(ctx context.Context, baseConfigPath string, config *imagecus
 
 	rc.ImageHistory = resolveImageHistory(rc.ConfigChain)
 
+	rc.RemovePackageManager = resolveRemovePackageManager(rc.ConfigChain)
+
 	return rc, nil
 }
 
@@ -1108,4 +1110,14 @@ func resolveImageHistory(configChain []*ConfigWithBasePath) imagecustomizerapi.I
 	}
 
 	return imagecustomizerapi.ImageHistoryDefault
+}
+
+func resolveRemovePackageManager(configChain []*ConfigWithBasePath) bool {
+	for _, configWithBase := range slices.Backward(configChain) {
+		if configWithBase.Config.OS != nil && configWithBase.Config.OS.Packages.RemovePackageManager != nil {
+			return *configWithBase.Config.OS.Packages.RemovePackageManager
+		}
+	}
+
+	return false
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/configvalidation_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/configvalidation_test.go
@@ -4,6 +4,8 @@
 package imagecustomizerlib
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
@@ -1215,4 +1217,20 @@ func TestResolveRemovePackageManagerOverride(t *testing.T) {
 
 	result := resolveRemovePackageManager(configChain)
 	assert.Equal(t, false, result)
+}
+
+func TestCustomizeImageRemovePackageManagerBadOutputFormat(t *testing.T) {
+	baseImage, baseImageInfo := checkSkipForCustomizeDefaultAzureLinuxImage(t)
+
+	testTempDir := filepath.Join(tmpDir, "TestCustomizeImageRemovePackageManagerBadOutputFormat")
+	defer os.RemoveAll(testTempDir)
+
+	buildDir := filepath.Join(testTempDir, "build")
+	outImageFilePath := filepath.Join(testTempDir, "image.cosi")
+	configFile := filepath.Join(testDir, "remove-package-manager.yaml")
+
+	// Customize image.
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "cosi",
+		baseImageInfo.PreviewFeatures)
+	assert.ErrorIs(t, err, ErrRemovePackageManagerBadOutputFormat)
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/configvalidation_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/configvalidation_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/ptrutils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -1164,4 +1165,54 @@ func TestResolvePxeBootstrapFileUrl_UnspecifiedInCurrentUsesBase(t *testing.T) {
 
 	result := resolvePxeConfig(configChain)
 	assert.Equal(t, "http://base.example.com/pxe/base.iso", result.BootstrapFileUrl)
+}
+
+func TestResolveRemovePackageManagerInBase(t *testing.T) {
+	configChain := []*ConfigWithBasePath{
+		{
+			Config: &imagecustomizerapi.Config{
+				OS: &imagecustomizerapi.OS{
+					Packages: imagecustomizerapi.Packages{
+						RemovePackageManager: ptrutils.PtrTo(true),
+					},
+				},
+			},
+			BaseConfigPath: "/base",
+		},
+		{
+			Config:         &imagecustomizerapi.Config{},
+			BaseConfigPath: "/current",
+		},
+	}
+
+	result := resolveRemovePackageManager(configChain)
+	assert.Equal(t, true, result)
+}
+
+func TestResolveRemovePackageManagerOverride(t *testing.T) {
+	configChain := []*ConfigWithBasePath{
+		{
+			Config: &imagecustomizerapi.Config{
+				OS: &imagecustomizerapi.OS{
+					Packages: imagecustomizerapi.Packages{
+						RemovePackageManager: ptrutils.PtrTo(true),
+					},
+				},
+			},
+			BaseConfigPath: "/base",
+		},
+		{
+			Config: &imagecustomizerapi.Config{
+				OS: &imagecustomizerapi.OS{
+					Packages: imagecustomizerapi.Packages{
+						RemovePackageManager: ptrutils.PtrTo(false),
+					},
+				},
+			},
+			BaseConfigPath: "/current",
+		},
+	}
+
+	result := resolveRemovePackageManager(configChain)
+	assert.Equal(t, false, result)
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
@@ -216,16 +216,16 @@ func doOsCustomizations(ctx context.Context, rc *ResolvedConfig, imageConnection
 		}
 	}
 
+	err = prepareUki(ctx, rc.BuildDirAbs, rc.Uki, imageChroot, toolsChroot, distroHandler)
+	if err != nil {
+		return err
+	}
+
 	if rc.RemovePackageManager {
 		err = removeOsPackageManager(ctx, distroHandler, imageChroot, toolsChroot)
 		if err != nil {
 			return fmt.Errorf("%w:\n%w", ErrRemovePackageManager, err)
 		}
-	}
-
-	err = prepareUki(ctx, rc.BuildDirAbs, rc.Uki, imageChroot, toolsChroot, distroHandler)
-	if err != nil {
-		return err
 	}
 
 	err = restoreResolvConf(ctx, resolvConf, imageChroot)

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
@@ -216,6 +216,13 @@ func doOsCustomizations(ctx context.Context, rc *ResolvedConfig, imageConnection
 		}
 	}
 
+	if rc.RemovePackageManager {
+		err = removeOsPackageManager(ctx, distroHandler, imageChroot, toolsChroot)
+		if err != nil {
+			return fmt.Errorf("%w:\n%w", ErrRemovePackageManager, err)
+		}
+	}
+
 	err = prepareUki(ctx, rc.BuildDirAbs, rc.Uki, imageChroot, toolsChroot, distroHandler)
 	if err != nil {
 		return err

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages.go
@@ -6,9 +6,12 @@ package imagecustomizerlib
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagecustomizerapi"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/file"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/logger"
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/safechroot"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -17,16 +20,19 @@ import (
 
 var (
 	// Package-related errors
-	ErrPackageRepoMetadataRefresh = NewImageCustomizerError("Packages:RepoMetadataRefresh", "failed to refresh repo metadata")
-	ErrInvalidPackageListFile     = NewImageCustomizerError("Packages:InvalidPackageListFile", "failed to read package list file")
-	ErrPackageRemove              = NewImageCustomizerError("Packages:Remove", "failed to remove packages")
-	ErrPackageAutoRemove          = NewImageCustomizerError("Packages:AutoRemove", "failed to autoremove orphaned packages")
-	ErrPackageUpdate              = NewImageCustomizerError("Packages:Update", "failed to update packages")
-	ErrPackagesUpdateInstalled    = NewImageCustomizerError("Packages:UpdateInstalled", "failed to update installed packages")
-	ErrPackageInstall             = NewImageCustomizerError("Packages:Install", "failed to install packages")
-	ErrPackageCacheClean          = NewImageCustomizerError("Packages:CacheClean", "failed to clean cache")
-	ErrMountRpmSources            = NewImageCustomizerError("Packages:MountRpmSources", "failed to mount RPM sources")
-	ErrSnapshotTimeNotSupported   = NewImageCustomizerError("Packages:SnapshotTimeNotSupported", "snapshot time is not supported")
+	ErrPackageRepoMetadataRefresh       = NewImageCustomizerError("Packages:RepoMetadataRefresh", "failed to refresh repo metadata")
+	ErrInvalidPackageListFile           = NewImageCustomizerError("Packages:InvalidPackageListFile", "failed to read package list file")
+	ErrPackageRemove                    = NewImageCustomizerError("Packages:Remove", "failed to remove packages")
+	ErrPackageAutoRemove                = NewImageCustomizerError("Packages:AutoRemove", "failed to autoremove orphaned packages")
+	ErrPackageUpdate                    = NewImageCustomizerError("Packages:Update", "failed to update packages")
+	ErrPackagesUpdateInstalled          = NewImageCustomizerError("Packages:UpdateInstalled", "failed to update installed packages")
+	ErrPackageInstall                   = NewImageCustomizerError("Packages:Install", "failed to install packages")
+	ErrPackageCacheClean                = NewImageCustomizerError("Packages:CacheClean", "failed to clean cache")
+	ErrMountRpmSources                  = NewImageCustomizerError("Packages:MountRpmSources", "failed to mount RPM sources")
+	ErrSnapshotTimeNotSupported         = NewImageCustomizerError("Packages:SnapshotTimeNotSupported", "snapshot time is not supported")
+	ErrRemovePackageManager             = NewImageCustomizerError("Packages:RemovePackageManager", "failed to remove package manager")
+	ErrRemovePackageManagerPackages     = NewImageCustomizerError("Packages:RemovePackageManagerPackages", "failed to remove package manager packages")
+	ErrRemovePackageManagerFilesAndDirs = NewImageCustomizerError("Packages:RemovePackageManagerFilesAndDirs", "failed to remove package manager files and directories")
 )
 
 // addRemoveAndUpdatePackages orchestrates the complete package management workflow
@@ -121,4 +127,40 @@ func needPackageSources(config *imagecustomizerapi.OS) bool {
 
 func needPackageCleanup(config *imagecustomizerapi.OS) bool {
 	return needPackageSources(config) || len(config.Packages.Remove) > 0
+}
+
+func removeOsPackageManager(ctx context.Context, distroHandler DistroHandler, imageChroot *safechroot.Chroot,
+	toolsChroot *safechroot.Chroot,
+) error {
+	var err error
+
+	ctx, span := otel.GetTracerProvider().Tracer(OtelTracerName).Start(ctx, "remove_package_manager")
+	defer span.End()
+
+	logger.Log.Infof("Removing package manager")
+
+	err = distroHandler.RemovePackageManagerTools(ctx, imageChroot, toolsChroot)
+	if err != nil {
+		return fmt.Errorf("%w:\n%w", ErrRemovePackageManagerPackages, err)
+	}
+
+	err = distroHandler.RemovePackageManagerFiles(ctx, imageChroot)
+	if err != nil {
+		return fmt.Errorf("%w:\n%w", ErrRemovePackageManagerFilesAndDirs, err)
+	}
+
+	return nil
+}
+
+func removePackageManagementFiles(imageChroot *safechroot.Chroot, filesAndDirsToRemove []string) error {
+	for _, fileToRemove := range filesAndDirsToRemove {
+		logger.Log.Debugf("Removing package management file/dir (%s)", fileToRemove)
+
+		err := os.RemoveAll(filepath.Join(imageChroot.RootDir(), fileToRemove))
+		if err != nil {
+			return fmt.Errorf("failed to remove package management file/dir (%s):\n%w", fileToRemove, err)
+		}
+	}
+
+	return nil
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_deb.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_deb.go
@@ -161,14 +161,16 @@ func refreshDebPackageMetadata(ctx context.Context, imageChroot *safechroot.Chro
 }
 
 func executeAptCommand(args []string, imageChroot *safechroot.Chroot) error {
-	args = append(args,
+	fullArgs := []string{
 		"--yes",
 		"--option", "Dpkg::Options::=--force-confdef",
-		"--option", "Dpkg::Options::=--force-confold")
+		"--option", "Dpkg::Options::=--force-confold",
+	}
+	fullArgs = append(fullArgs, args...)
 
 	env := append(shell.CurrentEnvironment(), getAptEnvironmentVariables()...)
 
-	return shell.NewExecBuilder(packageManagerAPT, args...).
+	return shell.NewExecBuilder(packageManagerAPT, fullArgs...).
 		EnvironmentVariables(env).
 		LogLevel(logrus.DebugLevel, logrus.DebugLevel).
 		ErrorStderrLines(1).
@@ -382,4 +384,43 @@ func getAllPackagesFromChrootDeb(imageChroot safechroot.ChrootInterface) ([]cosi
 	}
 
 	return packages, nil
+}
+
+func debRemovePackageManagerTools(imageChroot *safechroot.Chroot, packageManagementPackages []string,
+) error {
+	err := debEnsurePackagesRemoved(imageChroot, packageManagementPackages, true /*removeEssentialPackages*/)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func debEnsurePackagesRemoved(imageChroot *safechroot.Chroot, packages []string, removeEssentialPackages bool,
+) error {
+	packagesToRemove := []string(nil)
+	for _, packageName := range packages {
+		installed, err := isPackageInstalledDeb(imageChroot, packageName)
+		if err != nil {
+			return err
+		}
+
+		if installed {
+			packagesToRemove = append(packagesToRemove, packageName)
+		}
+	}
+
+	args := []string{"remove", "--auto-remove"}
+	if removeEssentialPackages {
+		args = append(args, "--allow-remove-essential")
+	}
+	args = append(args, "--")
+	args = append(args, packagesToRemove...)
+
+	err := executeAptCommand(args, imageChroot)
+	if err != nil {
+		return fmt.Errorf("%w (%v):\n%w", ErrPackageRemove, packagesToRemove, err)
+	}
+
+	return nil
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_deb.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_deb.go
@@ -410,6 +410,11 @@ func debEnsurePackagesRemoved(imageChroot *safechroot.Chroot, packages []string,
 		}
 	}
 
+	if len(packagesToRemove) <= 0 {
+		// Nothing to do.
+		return nil
+	}
+
 	args := []string{"remove", "--auto-remove"}
 	if removeEssentialPackages {
 		args = append(args, "--allow-remove-essential")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_rpm.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_rpm.go
@@ -419,7 +419,7 @@ func rpmEnsurePackagesRemoved(imageChroot *safechroot.Chroot, pmHandler rpmPacka
 		}, args...)
 	}
 
-	err := pmHandler.executeCommand(args, imageChroot, toolsChroot)
+	err := executeRpmPackageManagerCommand(args, imageChroot, toolsChroot, pmHandler)
 	if err != nil {
 		return fmt.Errorf("%w (%v):\n%w", ErrPackageRemove, packagesToRemove, err)
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_rpm.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_rpm.go
@@ -377,3 +377,52 @@ func getAllPackagesFromChrootRpm(imageChroot safechroot.ChrootInterface, toolsCh
 
 	return packages, nil
 }
+
+func rpmRemovePackageManagerTools(imageChroot *safechroot.Chroot, pmHandler rpmPackageManagerHandler,
+	toolsChroot *safechroot.Chroot, packageManagementPackages []string,
+) error {
+	err := rpmEnsurePackagesRemoved(imageChroot, pmHandler, toolsChroot, packageManagementPackages,
+		true /*removeProtectedPackages*/)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func rpmEnsurePackagesRemoved(imageChroot *safechroot.Chroot, pmHandler rpmPackageManagerHandler,
+	toolsChroot *safechroot.Chroot, packages []string, removeProtectedPackages bool,
+) error {
+	packagesToRemove := []string(nil)
+	for _, packageName := range packages {
+		installed, err := pmHandler.isPackageInstalled(imageChroot, toolsChroot, packageName)
+		if err != nil {
+			return err
+		}
+
+		if installed {
+			packagesToRemove = append(packagesToRemove, packageName)
+		}
+	}
+
+	args := []string{"--assumeyes", "--disablerepo", "*"}
+	if removeProtectedPackages {
+		args = append(args, "--setopt=protected_packages=")
+	}
+	args = append(args, "remove")
+	args = append(args, packagesToRemove...)
+
+	if toolsChroot != nil {
+		args = append([]string{
+			"--releasever=" + pmHandler.getReleaseVersion(),
+			"--installroot=/" + toolsRootImageDir,
+		}, args...)
+	}
+
+	err := pmHandler.executeCommand(args, imageChroot, toolsChroot)
+	if err != nil {
+		return fmt.Errorf("%w (%v):\n%w", ErrPackageRemove, packagesToRemove, err)
+	}
+
+	return nil
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_rpm.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_rpm.go
@@ -405,6 +405,11 @@ func rpmEnsurePackagesRemoved(imageChroot *safechroot.Chroot, pmHandler rpmPacka
 		}
 	}
 
+	if len(packagesToRemove) <= 0 {
+		// Nothing to do.
+		return nil
+	}
+
 	args := []string{"--assumeyes", "--disablerepo", "*"}
 	if removeProtectedPackages {
 		args = append(args, "--setopt=protected_packages=")

--- a/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizepackages_test.go
@@ -948,6 +948,57 @@ func testCustomizeImagePackagesInstallOnline(t *testing.T, baseImageInfo testBas
 	ensurePackageCacheCleanup(t, imageConnection, baseImageInfo)
 }
 
+func TestCustomizeImageRemovePackageManager(t *testing.T) {
+	for _, baseImageInfo := range slices.Concat(baseImageAzureLinuxAll, baseImageUbuntuAll) {
+		t.Run(baseImageInfo.Name, func(t *testing.T) {
+			testCustomizeImageRemovePackageManager(t, baseImageInfo)
+		})
+	}
+}
+
+func testCustomizeImageRemovePackageManager(t *testing.T, baseImageInfo testBaseImageInfo) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
+
+	testTmpDir := filepath.Join(tmpDir, fmt.Sprintf("TestCustomizeImageRemovePackageManager_%s", baseImageInfo.Name))
+	defer os.RemoveAll(testTmpDir)
+
+	buildDir := filepath.Join(testTmpDir, "build")
+	outImageFilePath := filepath.Join(testTmpDir, "image.raw")
+	configFile := filepath.Join(testDir, "remove-package-manager.yaml")
+
+	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+		baseImageInfo.PreviewFeatures)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	imageConnection, err := testutils.ConnectToImage(buildDir, outImageFilePath, true, baseImageInfo.MountPoints)
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer imageConnection.Close()
+
+	// Ensure LookPathChroot() is working correctly.
+	_, err = shell.LookPathChroot("sh", imageConnection.Chroot().RootDir())
+	assert.NoError(t, err)
+
+	// Ensure all the package manager commands were removed from the image.
+	removedCommands := []string{"rpm", "tdnf", "dnf", "dnf5", "apt", "apt-get"}
+	for _, command := range removedCommands {
+		_, err := shell.LookPathChroot(command, imageConnection.Chroot().RootDir())
+		assert.Error(t, err)
+	}
+
+	// Ensure files have been removed.
+	removedFiles := slices.Concat(packageManagementDirsDeb, packageManagementDirsFedora,
+		packageManagementDirsAzl3)
+
+	for _, removedFile := range removedFiles {
+		_, err := os.Stat(filepath.Join(imageConnection.Chroot().RootDir(), removedFile))
+		assert.ErrorIsf(t, err, os.ErrNotExist, "file/dir (%s) should be removed", removedFile)
+	}
+}
+
 func getPkgVersionFromChroot(imageConnection *imageconnection.ImageConnection, pkgName string) (string, error) {
 	var versionOutput string
 	out, _, err := shell.NewExecBuilder("rpm", "-q", pkgName).

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler.go
@@ -47,6 +47,12 @@ type DistroHandler interface {
 		imageChroot *safechroot.Chroot, toolsChroot *safechroot.Chroot, rpmsSources []string, useBaseImageRpmRepos bool,
 		snapshotTime imagecustomizerapi.PackageSnapshotTime) error
 
+	// Removes the package management tools (e.g. rpm, dnf, apt).
+	RemovePackageManagerTools(ctx context.Context, imageChroot *safechroot.Chroot, toolsChroot *safechroot.Chroot) error
+
+	// Removes the package management directories (e.g. rpm db).
+	RemovePackageManagerFiles(ctx context.Context, imageChroot *safechroot.Chroot) error
+
 	// IsPackageInstalled reports whether packageName is installed in the image's package database. When toolsChroot is
 	// non-nil, implementations that depend on an in-image package manager should run their query inside toolsChroot
 	// against installroot=/_imageroot instead of imageChroot — this allows the check to work on images that ship no

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
@@ -105,6 +105,17 @@ func (d *aclDistroHandler) ManagePackages(ctx context.Context, buildDir string, 
 		snapshotTime, d.packageManager)
 }
 
+func (d *aclDistroHandler) RemovePackageManagerTools(ctx context.Context, imageChroot *safechroot.Chroot,
+	toolsChroot *safechroot.Chroot,
+) error {
+	return rpmRemovePackageManagerTools(imageChroot, d.packageManager, toolsChroot, packageManagementPackagesAzl3)
+}
+
+func (d *aclDistroHandler) RemovePackageManagerFiles(ctx context.Context, imageChroot *safechroot.Chroot,
+) error {
+	return removePackageManagementFiles(imageChroot, packageManagementDirsAzl3)
+}
+
 // IsPackageInstalled queries the image's rpm database via tdnf. When toolsChroot is provided, tdnf runs
 // inside toolsChroot against the image bind-mounted at /_imageroot (required for stock ACL, which has no
 // in-image tdnf). When toolsChroot is nil, tdnf runs directly inside the image chroot (works on ACL-T).

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux.go
@@ -41,6 +41,14 @@ var (
 	systemdBootPackagesAzl3       = []string{systemdBootPackage}
 	liveOSRequiredPackagesAzl3    = []string{"squashfs-tools", "tar", "device-mapper", "curl"}
 	liveOSInitrdDracutModulesAzl3 = []string{"dmsquash-live", "livenet", "selinux"}
+	packageManagementPackagesAzl3 = []string{"tdnf", "dnf", "rpm"}
+	packageManagementDirsAzl3     = []string{
+		"/var/lib/rpm",
+		"/var/lib/dnf",
+		"/usr/lib/sysimage/tdnf",
+		"/var/cache/tdnf",
+		"/var/cache/dnf",
+	}
 )
 
 func newAzureLinuxDistroHandler(targetOs targetos.TargetOs) *azureLinuxDistroHandler {
@@ -79,6 +87,17 @@ func (d *azureLinuxDistroHandler) ManagePackages(ctx context.Context, buildDir s
 	return managePackagesRpm(
 		ctx, buildDir, baseConfigPath, config, imageChroot, toolsChroot, rpmsSources, useBaseImageRpmRepos,
 		snapshotTime, d.packageManager)
+}
+
+func (d *azureLinuxDistroHandler) RemovePackageManagerTools(ctx context.Context, imageChroot *safechroot.Chroot,
+	toolsChroot *safechroot.Chroot,
+) error {
+	return rpmRemovePackageManagerTools(imageChroot, d.packageManager, toolsChroot, packageManagementPackagesAzl3)
+}
+
+func (d *azureLinuxDistroHandler) RemovePackageManagerFiles(ctx context.Context, imageChroot *safechroot.Chroot,
+) error {
+	return removePackageManagementFiles(imageChroot, packageManagementDirsAzl3)
 }
 
 // IsPackageInstalled implements DistroHandler.

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux4.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux4.go
@@ -132,6 +132,17 @@ func (d *azureLinux4DistroHandler) ManagePackages(ctx context.Context, buildDir 
 		snapshotTime, d.packageManager)
 }
 
+func (d *azureLinux4DistroHandler) RemovePackageManagerTools(ctx context.Context, imageChroot *safechroot.Chroot,
+	toolsChroot *safechroot.Chroot,
+) error {
+	return rpmRemovePackageManagerTools(imageChroot, d.packageManager, toolsChroot, packageManagementPackagesFedora)
+}
+
+func (d *azureLinux4DistroHandler) RemovePackageManagerFiles(ctx context.Context, imageChroot *safechroot.Chroot,
+) error {
+	return removePackageManagementFiles(imageChroot, packageManagementDirsFedora)
+}
+
 func (d *azureLinux4DistroHandler) IsPackageInstalled(imageChroot safechroot.ChrootInterface,
 	toolsChroot *safechroot.Chroot, packageName string,
 ) (bool, error) {

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
@@ -101,6 +101,17 @@ var (
 	// initramfs builds. Loading it from the initramfs instead would deny execute on the initramfs binaries under
 	// enforcing policy.
 	liveOSInitrdDracutModulesFedora = []string{"dmsquash-live", "livenet"}
+
+	packageManagementPackagesFedora = []string{"dnf5", "rpm"}
+	packageManagementDirsFedora     = []string{
+		"/var/lib/rpm",
+		"/var/lib/dnf",
+		"/usr/lib/sysimage/libdnf5",
+		"/usr/lib/sysimage/rpm",
+		"/var/cache/dnf",
+		"/var/cache/libdnf5",
+		"/var/cache/dnf5daemon-server",
+	}
 )
 
 func newFedoraDistroHandler(targetOs targetos.TargetOs) *fedoraDistroHandler {
@@ -158,6 +169,17 @@ func (d *fedoraDistroHandler) ManagePackages(ctx context.Context, buildDir strin
 		ctx, buildDir, baseConfigPath, config, imageChroot, toolsChroot, rpmsSources, useBaseImageRpmRepos,
 		snapshotTime, d.packageManager,
 	)
+}
+
+func (d *fedoraDistroHandler) RemovePackageManagerTools(ctx context.Context, imageChroot *safechroot.Chroot,
+	toolsChroot *safechroot.Chroot,
+) error {
+	return rpmRemovePackageManagerTools(imageChroot, d.packageManager, toolsChroot, packageManagementPackagesFedora)
+}
+
+func (d *fedoraDistroHandler) RemovePackageManagerFiles(ctx context.Context, imageChroot *safechroot.Chroot,
+) error {
+	return removePackageManagementFiles(imageChroot, packageManagementDirsFedora)
 }
 
 func (d *fedoraDistroHandler) IsPackageInstalled(imageChroot safechroot.ChrootInterface,

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_ubuntu.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_ubuntu.go
@@ -37,6 +37,20 @@ var (
 	ErrUbuntuUnsupportedDisableBaseImageRepos = NewImageCustomizerError("Validation:UbuntuUnsupportedDisableBaseImageRepos", "disabling base image package repositories is not supported yet for Ubuntu images")
 
 	liveOSRequiredPackagesUbuntu = []string{"squashfs-tools", "tar", "dmsetup", "curl"}
+
+	packageManagementPackagesDeb = []string{
+		"apt",
+		"apt-utils",
+		// Ideally 'dpkg' would be included here. But there seems to be some silliness with package dependencies in
+		// Ubuntu. Though, it looks like this might be fixed in Ubuntu 26.04.
+	}
+
+	packageManagementDirsDeb = []string{
+		"/var/lib/apt",
+		"/var/cache/apt",
+		// Excluding dpkg directory removal since the package can't be removed.
+		// "/var/lib/dpkg",
+	}
 )
 
 func newUbuntuDistroHandler(targetOs targetos.TargetOs) *ubuntuDistroHandler {
@@ -107,6 +121,17 @@ func (d *ubuntuDistroHandler) ManagePackages(ctx context.Context, buildDir strin
 	rpmsSources []string, useBaseImageRpmRepos bool, snapshotTime imagecustomizerapi.PackageSnapshotTime,
 ) error {
 	return managePackagesDeb(ctx, config, imageChroot)
+}
+
+func (d *ubuntuDistroHandler) RemovePackageManagerTools(ctx context.Context, imageChroot *safechroot.Chroot,
+	toolsChroot *safechroot.Chroot,
+) error {
+	return debRemovePackageManagerTools(imageChroot, packageManagementPackagesDeb)
+}
+
+func (d *ubuntuDistroHandler) RemovePackageManagerFiles(ctx context.Context, imageChroot *safechroot.Chroot,
+) error {
+	return removePackageManagementFiles(imageChroot, packageManagementDirsDeb)
 }
 
 // IsPackageInstalled checks if a package is installed using dpkg-query.

--- a/toolkit/tools/pkg/imagecustomizerlib/resolvedconfig.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/resolvedconfig.go
@@ -84,6 +84,9 @@ type ResolvedConfig struct {
 
 	// Image History mode
 	ImageHistory imagecustomizerapi.ImageHistory
+
+	// Remove package manager tools and directories
+	RemovePackageManager bool
 }
 
 func (c *ResolvedConfig) InputFileExt() string {

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/remove-package-manager.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/remove-package-manager.yaml
@@ -1,0 +1,26 @@
+previewFeatures:
+- remove-package-manager
+- preview-distro-version
+
+os:
+  packages:
+    removePackageManager: true
+
+scripts:
+  postCustomization:
+  - content: |
+      set -ux
+
+      du -sh \
+        /var/lib/apt \
+        /var/lib/dnf \
+        /var/lib/rpm \
+        /usr/lib/sysimage/libdnf5 \
+        /usr/lib/sysimage/tdnf \
+        /usr/lib/sysimage/rpm \
+        /var/cache/apt \
+        /var/cache/dnf \
+        /var/cache/dnf5daemon-server \
+        /var/cache/libdnf5 \
+        /var/cache/tdnf \
+        || true


### PR DESCRIPTION
Add API for removing the package manager tooling and their directories.

This change does not include the implementation for the package manifest file since the design for that is still pending.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
