### PR TITLE
Fix kernel command-line options being carried over through hard-reset

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput_test.go
@@ -341,7 +341,7 @@ func testOutputAndInjectArtifactsCosiHelper(t *testing.T, baseImageInfo testBase
 
 	verifyInjectedFiles(t, espMountPath, espFiles)
 	verifyVerityUki(t, espMountPath, rootPartitionPath, rootHashPartitionPath, "UUID="+rootUuid, "UUID="+rootHashUuid,
-		"root", buildDir, "", "restart-on-corruption", false /*inlineVerity*/)
+		"root", buildDir, "restart-on-corruption", false /*inlineVerity*/)
 }
 
 func verifyAndSignOutputtedArtifacts(t *testing.T, baseImageInfo testBaseImageInfo, outputArtifactsDir string, expectVerityHash bool) []string {

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
@@ -62,7 +62,7 @@ func doOsCustomizations(ctx context.Context, rc *ResolvedConfig, imageConnection
 			}
 
 			// Save the base kernel command-line now so that we can apply those changes later via uki-kernel-info.json.
-			// Skip this when the bootloader is being hard-reset, pre-seeding here would carry the old UKI cmdline
+			// Skip this when the bootloader is being hard-reset. Pre-seeding here would carry the old UKI cmdline
 			// to the new UKI, defeating the reset.
 			if rc.BootLoader.ResetType != imagecustomizerapi.ResetBootLoaderTypeHard {
 				ukiBuildDir := filepath.Join(rc.BuildDirAbs, UkiBuildDir)

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeos.go
@@ -61,16 +61,20 @@ func doOsCustomizations(ctx context.Context, rc *ResolvedConfig, imageConnection
 				return err
 			}
 
-			// Save the base kernel command-line now so that we can apply those changes later via uki-kernel-info.json
-			ukiBuildDir := filepath.Join(rc.BuildDirAbs, UkiBuildDir)
-			err = os.MkdirAll(ukiBuildDir, os.ModePerm)
-			if err != nil {
-				return fmt.Errorf("failed to create UKI build directory:\n%w", err)
-			}
+			// Save the base kernel command-line now so that we can apply those changes later via uki-kernel-info.json.
+			// Skip this when the bootloader is being hard-reset, pre-seeding here would carry the old UKI cmdline
+			// to the new UKI, defeating the reset.
+			if rc.BootLoader.ResetType != imagecustomizerapi.ResetBootLoaderTypeHard {
+				ukiBuildDir := filepath.Join(rc.BuildDirAbs, UkiBuildDir)
+				err = os.MkdirAll(ukiBuildDir, os.ModePerm)
+				if err != nil {
+					return fmt.Errorf("failed to create UKI build directory:\n%w", err)
+				}
 
-			err = saveUkiBaseCmdlineForCreate(rc.BuildDirAbs, imageChroot, distroHandler)
-			if err != nil {
-				return err
+				err = saveUkiBaseCmdlineForCreate(rc.BuildDirAbs, imageChroot, distroHandler)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeselinux_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeselinux_test.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/file"
@@ -201,82 +200,40 @@ func TestCustomizeImageSELinuxNoPolicy(t *testing.T) {
 func verifyKernelCommandLine(t *testing.T, imageConnection *imageconnection.ImageConnection, hasUkis bool,
 	existsArgs []string, notExistsArgs []string,
 ) {
-	var cmdline string
-	var err error
+	var kernelToArgs map[string]string
 
 	if hasUkis {
-		// UKI image: extract cmdline from UKI files.
-		ukiDir := filepath.Join(imageConnection.Chroot().RootDir(), "boot/efi/EFI/Linux")
-		cmdline, err = extractCmdlineFromUkiForTest(ukiDir)
-		if err != nil {
-			t.Fatalf("Failed to extract cmdline from UKI: %v", err)
+		// UKI image: extract the command line from every UKI (main image + all addons) on the ESP.
+		espPath := filepath.Join(imageConnection.Chroot().RootDir(), "boot/efi")
+
+		scratchDir, err := os.MkdirTemp("", "test-cmdline-extraction-*")
+		if !assert.NoError(t, err) {
+			return
+		}
+		defer os.RemoveAll(scratchDir)
+
+		kernelToArgs, err = extractKernelCmdlineFromUkiEfis(espPath, scratchDir)
+		if !assert.NoError(t, err) {
 			return
 		}
 	} else {
-		// GRUB image: read grub.cfg or BLS entries.
+		// GRUB image: read the kernel arguments for every kernel from grub.cfg / BLS entries.
 		bootDir := filepath.Join(imageConnection.Chroot().RootDir(), "boot")
 
 		distroHandler, err := NewDistroHandlerFromChroot(imageConnection.Chroot())
-		if err != nil {
-			t.Fatalf("Failed to detect distro handler: %v", err)
+		if !assert.NoError(t, err) {
 			return
 		}
 
 		parsedKernelToArgs, err := distroHandler.ReadGrubConfigLinuxArgs(bootDir)
-		if err != nil {
-			t.Fatalf("Failed to extract kernel args from boot config: %v", err)
+		if !assert.NoError(t, err) {
 			return
 		}
-		kernelToArgs := grubKernelArgsToStringMap(parsedKernelToArgs)
 
-		for _, opts := range kernelToArgs {
-			// Like in the UKI scenario, we only test the first seen.
-			cmdline = opts
-			break
-		}
+		kernelToArgs = grubKernelArgsToStringMap(parsedKernelToArgs)
 	}
 
-	for _, existsArg := range existsArgs {
-		assert.Containsf(t, cmdline, existsArg,
-			"ensure kernel command arg exists (%s)", existsArg)
-	}
-
-	for _, notExistsArg := range notExistsArgs {
-		assert.NotContainsf(t, cmdline, notExistsArg,
-			"ensure kernel command arg not exists (%s)", notExistsArg)
-	}
-}
-
-func extractCmdlineFromUkiForTest(ukiDir string) (string, error) {
-	files, err := os.ReadDir(ukiDir)
-	if err != nil {
-		return "", fmt.Errorf("failed to read UKI directory: %w", err)
-	}
-
-	for _, f := range files {
-		if f.IsDir() {
-			continue
-		}
-		if strings.HasSuffix(f.Name(), ".efi") {
-			ukiPath := filepath.Join(ukiDir, f.Name())
-
-			tempDir, err := os.MkdirTemp("", "test-cmdline-extraction-*")
-			if err != nil {
-				return "", fmt.Errorf("failed to create temp directory: %w", err)
-			}
-			defer os.RemoveAll(tempDir)
-
-			// Use production code to extract cmdline (handles main UKI and all addons)
-			cmdline, err := extractCmdlineFromUkiWithObjcopy(ukiPath, tempDir)
-			if err != nil {
-				return "", fmt.Errorf("failed to extract cmdline: %w", err)
-			}
-
-			return cmdline, nil
-		}
-	}
-
-	return "", fmt.Errorf("no UKI files found or cmdline not extracted")
+	assertKernelCmdlineArgs(t, kernelToArgs, existsArgs, notExistsArgs)
 }
 
 // partitionsSELinuxEnforcingConfigFile returns the partitions-selinux-enforcing test config file appropriate for the

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki.go
@@ -340,9 +340,16 @@ func prepareUkiHelper(ctx context.Context, buildDir string, uki *imagecustomizer
 		return fmt.Errorf("%w:\n%w", ErrUKIFileCopy, err)
 	}
 
-	// Extract kernel command line arguments from either boot config or UKI.
-	espDir := filepath.Join(imageChroot.RootDir(), distroHandler.GetEspDir())
-	kernelToArgs, err := extractKernelToArgs(espDir, bootDir, buildDir, distroHandler)
+	// Read the kernel command-line arguments from the grub boot config only. We do not fall back to reading them from
+	// the UKIs here: for a UKI base image (which has no grub.cfg) the existing UKI command-lines should already be
+	// captured in uki-kernel-info.json, which is read below and takes precedence over these grub-derived args. So when
+	// there is no grub.cfg, extractKernelToArgs returns an empty map and that saved info supplies the command-line
+	// instead.
+	//
+	// BLS-based distros such as Azure Linux 4 prefer the per-kernel loader/entries/*.conf BLS files, but fall back to
+	// the `set kernelopts="..."` default in grub.cfg when no BLS entries are found. grub2-mkconfig writes the kernel
+	// command line into that kernelopts default.
+	kernelToArgs, err := extractKernelToArgs(bootDir, distroHandler)
 	if err != nil {
 		return fmt.Errorf("%w:\n%w", ErrUKIKernelCmdlineExtract, err)
 	}
@@ -750,36 +757,16 @@ func createUki(ctx context.Context, rc *ResolvedConfig, distroHandler DistroHand
 	return nil
 }
 
-func extractKernelToArgs(espPath string, bootDir string, buildDir string, distroHandler DistroHandler,
-) (map[string]string, error) {
-	// Try extracting from boot config (grub.cfg or BLS entries) first.
-	var kernelToArgs map[string]string
+func extractKernelToArgs(bootDir string, distroHandler DistroHandler) (map[string]string, error) {
 	parsedKernelToArgs, err := distroHandler.ReadGrubConfigLinuxArgs(bootDir)
 	if err != nil {
 		if !errors.Is(err, fs.ErrNotExist) {
 			return nil, fmt.Errorf("failed to extract kernel args from boot config:\n%w", err)
 		}
-	} else {
-		kernelToArgs = grubKernelArgsToStringMap(parsedKernelToArgs)
-		if len(kernelToArgs) > 0 {
-			// Successfully extracted kernel cmdline from boot config.
-			return kernelToArgs, nil
-		}
+		return map[string]string{}, nil
 	}
 
-	// Fallback to extracting from UKI.
-	kernelToArgs, err = extractKernelCmdlineFromUkiEfis(espPath, buildDir)
-	if err != nil && !errors.Is(err, fs.ErrNotExist) {
-		return nil, fmt.Errorf("failed to extract kernel args from UKI:\n%w", err)
-	} else if errors.Is(err, fs.ErrNotExist) {
-		return nil, fmt.Errorf("no kernel arguments found from either boot config or UKI")
-	}
-
-	if len(kernelToArgs) == 0 {
-		return nil, fmt.Errorf("no kernel command-line arguments extracted from UKI files in (%s)", espPath)
-	}
-
-	return kernelToArgs, nil
+	return grubKernelArgsToStringMap(parsedKernelToArgs), nil
 }
 
 // readKernelCmdlinesFromGrubCfg reads kernel command-line arguments from the grub.cfg,

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
@@ -20,7 +20,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-const nulPaddingFillerArg = "rd.debug"
+const nulPaddingFillerArg = "console=ttyAMA0,115200n8"
 
 func TestCustomizeImageVerityUsrUki(t *testing.T) {
 	for _, baseImageInfo := range baseImageAzureLinux3Plus {
@@ -51,7 +51,7 @@ func testCustomizeImageVerityUsrUkiHelper(t *testing.T, baseImageInfo testBaseIm
 	previewFeatures := []imagecustomizerapi.PreviewFeature{imagecustomizerapi.PreviewFeatureToolsDir}
 	previewFeatures = append(previewFeatures, baseImageInfo.PreviewFeatures...)
 
-	// --tools-dir exercises the toolsChroot path in isPackageInstalled used by UKI 'create' validation.
+	// --tools-dir exercises the toolsChroot path in isPackageInstalled used by UKI 'create' validation. Adds rd.info.
 	err = CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
 		BuildDir:             buildDir,
 		InputImageFile:       baseImage,
@@ -66,12 +66,12 @@ func testCustomizeImageVerityUsrUkiHelper(t *testing.T, baseImageInfo testBaseIm
 		return
 	}
 
-	ukiFilesChecksums, _, ok := verifyUsrVerity(t, buildDir, outImageFilePath, nil, nil)
+	ukiFilesChecksums, _, ok := verifyUsrVerity(t, buildDir, outImageFilePath, []string{"rd.info"}, nil, nil, nil)
 	if !ok {
 		return
 	}
 
-	// Customize again without changing /usr verity or the UKI.
+	// Customize again without changing /usr verity or the UKI, or resetting the bootloader.
 	outImageFilePath2 := filepath.Join(testTempDir, "image2.raw")
 	configFile2 := filepath.Join(testDir, "verity-reinit-usr-nop.yaml")
 
@@ -81,7 +81,7 @@ func testCustomizeImageVerityUsrUkiHelper(t *testing.T, baseImageInfo testBaseIm
 		return
 	}
 
-	verifyUsrVerity(t, buildDir, outImageFilePath2, ukiFilesChecksums, nil)
+	verifyUsrVerity(t, buildDir, outImageFilePath2, []string{"rd.info"}, nil, ukiFilesChecksums, nil)
 }
 
 func TestCustomizeImageVerityUsrUkiRecustomize(t *testing.T) {
@@ -105,39 +105,58 @@ func testCustomizeImageVerityUsrUkiRecustomizeHelper(t *testing.T, baseImageInfo
 	defer os.RemoveAll(testTempDir)
 
 	buildDir := filepath.Join(testTempDir, "build")
-	outImageFilePath := filepath.Join(testTempDir, "image.raw")
-	configFile := filepath.Join(testDir, verityUsrUkiConfigFile(t, baseImageInfo))
 
-	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
+	// Adds systemd.log_level=debug but doesn't convert to UKI.
+	outImageFilePath0 := filepath.Join(testTempDir, "image0.raw")
+	config0 := imagecustomizerapi.Config{
+		OS: &imagecustomizerapi.OS{
+			KernelCommandLine: imagecustomizerapi.KernelCommandLine{
+				ExtraCommandLine: []string{"systemd.log_level=debug"},
+			},
+		},
+	}
+	err = basicCustomizeImage(t.Context(), buildDir, testDir, &config0, baseImage, outImageFilePath0, "raw",
 		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	ukiFilesChecksums, addonFilesChecksums, ok := verifyUsrVerity(t, buildDir, outImageFilePath, nil, nil)
+	// Converts to UKI and enables verity, removing systemd.log_level=debug (the bootloader is also being hard-reset).
+	// Adds rd.info.
+	outImageFilePath1 := filepath.Join(testTempDir, "image1.raw")
+	configFile1 := filepath.Join(testDir, verityUsrUkiConfigFile(t, baseImageInfo))
+
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile1, outImageFilePath0, outImageFilePath1,
+		"raw", baseImageInfo.PreviewFeatures)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	ukiFilesChecksums, addonFilesChecksums, ok := verifyUsrVerity(t, buildDir, outImageFilePath1, []string{"rd.info"},
+		[]string{"systemd.log_level=debug"}, nil, nil)
 	if !ok {
 		return
 	}
 
 	// Re-customize the UKI image with 'os.uki.mode: create', os.kernelCommandLine.extraCommandLine, and
-	// 'os.bootloader.resetType: hard-reset'.
+	// 'os.bootloader.resetType: hard-reset'. Removes rd.info, adds rd.debug.
 	outImageFilePath2 := filepath.Join(testTempDir, "image2.raw")
 	configFile2 := filepath.Join(testDir, "verity-reinit-usr-uki.yaml")
 
-	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile2, outImageFilePath, outImageFilePath2, "raw",
-		baseImageInfo.PreviewFeatures)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile2, outImageFilePath1, outImageFilePath2,
+		"raw", baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	newUkiFilesChecksums, newAddonFilesChecksums, ok := verifyUsrVerity(t, buildDir, outImageFilePath2, nil, nil)
+	newUkiFilesChecksums, newAddonFilesChecksums, ok := verifyUsrVerity(t, buildDir, outImageFilePath2,
+		[]string{"rd.debug"}, []string{"rd.info"}, ukiFilesChecksums, nil)
 	if !ok {
 		return
 	}
 
-	verifyUsrVerityUkiRecustomized(t, buildDir, outImageFilePath2,
-		ukiFilesChecksums, newUkiFilesChecksums, addonFilesChecksums, newAddonFilesChecksums,
-		"rd.info")
+	verifyUsrVerityUkiRecustomized(t, buildDir, outImageFilePath2, ukiFilesChecksums, newUkiFilesChecksums,
+		addonFilesChecksums, newAddonFilesChecksums)
 }
 
 func TestCustomizeImageVerityUsrUkiPassthrough(t *testing.T) {
@@ -164,13 +183,14 @@ func testCustomizeImageVerityUsrUkiPassthroughHelper(t *testing.T, baseImageInfo
 	outImageFilePath := filepath.Join(testTempDir, "image.raw")
 	configFile := filepath.Join(testDir, verityUsrUkiConfigFile(t, baseImageInfo))
 
+	// Adds rd.info.
 	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
 		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	ukiFilesChecksums, _, ok := verifyUsrVerity(t, buildDir, outImageFilePath, nil, nil)
+	ukiFilesChecksums, _, ok := verifyUsrVerity(t, buildDir, outImageFilePath, []string{"rd.info"}, nil, nil, nil)
 	if !ok {
 		return
 	}
@@ -178,13 +198,15 @@ func testCustomizeImageVerityUsrUkiPassthroughHelper(t *testing.T, baseImageInfo
 	outImageFilePath2 := filepath.Join(testTempDir, "image-passthrough.raw")
 	configFile2 := filepath.Join(testDir, "verity-usr-uki-passthrough.yaml")
 
-	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile2, outImageFilePath, outImageFilePath2, "raw",
-		baseImageInfo.PreviewFeatures)
+	// Does not reset the bootloader, preserving rd.info.
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile2, outImageFilePath, outImageFilePath2,
+		"raw", baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	passthroughUkiChecksums, _, ok := verifyUsrVerity(t, buildDir, outImageFilePath2, ukiFilesChecksums, nil)
+	passthroughUkiChecksums, _, ok := verifyUsrVerity(t, buildDir, outImageFilePath2, []string{"rd.info"}, nil,
+		ukiFilesChecksums, nil)
 	if !ok {
 		return
 	}
@@ -219,6 +241,7 @@ func testCustomizeImageVerityRootUkiHelper(t *testing.T, baseImageInfo testBaseI
 	testTempDir := filepath.Join(tmpDir, fmt.Sprintf("TestCustomizeImageRootVerityUki_%s", baseImageInfo.Name))
 	defer os.RemoveAll(testTempDir)
 
+	// Adds rd.info.
 	buildDir := filepath.Join(testTempDir, "build")
 	outImageFilePath := filepath.Join(testTempDir, "image.raw")
 	configFile := filepath.Join(testDir, verityRootUkiConfigFile(t, baseImageInfo))
@@ -230,14 +253,15 @@ func testCustomizeImageVerityRootUkiHelper(t *testing.T, baseImageInfo testBaseI
 		return
 	}
 
-	_, ok := verifyRootVerityUki(t, buildDir, outImageFilePath, nil)
+	_, ok := verifyRootVerityUki(t, buildDir, outImageFilePath, []string{"rd.info"}, nil, nil)
 	if !ok {
 		return
 	}
 
-	// Customize again without changing /root verity or the UKI.
+	// Customize again without changing /root verity or the UKI. Resets the kernel command-line back to the stock image,
+	// dropping rd.info and adding rd.debug.
 	outImageFilePath2 := filepath.Join(testTempDir, "image2.raw")
-	configFile2 := filepath.Join(testDir, "verity-reinit-root-nop.yaml")
+	configFile2 := filepath.Join(testDir, "verity-reinit-root-hard-reset.yaml")
 
 	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile2, outImageFilePath, outImageFilePath2, "raw",
 		baseImageInfo.PreviewFeatures)
@@ -245,7 +269,7 @@ func testCustomizeImageVerityRootUkiHelper(t *testing.T, baseImageInfo testBaseI
 		return
 	}
 
-	verifyRootVerityUki(t, buildDir, outImageFilePath2, nil)
+	verifyRootVerityUki(t, buildDir, outImageFilePath2, []string{"rd.debug"}, []string{"rd.info"}, nil)
 }
 
 func TestCustomizeImageVerityUsrUkiRecustomizeCmdline(t *testing.T) {
@@ -271,7 +295,7 @@ func testCustomizeImageVerityUsrUkiRecustomizeCmdlineHelper(t *testing.T, baseIm
 	buildDir := filepath.Join(testTempDir, "build")
 
 	// Pass 1: turn the grub-based base image into a UKI image. IC removes grub.cfg and writes
-	// UKIs to the ESP, matching the ACL template image layout (UKIs present, no grub.cfg).
+	// UKIs to the ESP, matching the ACL template image layout (UKIs present, no grub.cfg). Adds rd.info.
 	outImageFilePath1 := filepath.Join(testTempDir, "uki-base.raw")
 	configFile1 := filepath.Join(testDir, verityUsrUkiConfigFile(t, baseImageInfo))
 	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile1, baseImage, outImageFilePath1, "raw",
@@ -280,13 +304,14 @@ func testCustomizeImageVerityUsrUkiRecustomizeCmdlineHelper(t *testing.T, baseIm
 		return
 	}
 
-	ukiFilesChecksums1, addonFilesChecksums1, ok := verifyUsrVerity(t, buildDir, outImageFilePath1, nil, nil)
+	ukiFilesChecksums1, addonFilesChecksums1, ok := verifyUsrVerity(t, buildDir, outImageFilePath1, []string{"rd.info"},
+		nil, nil, nil)
 	if !ok {
 		return
 	}
 
-	// Pass 2: re-customize that UKI image with 'os.uki.mode: create' and os.kernelCommandLine.extraCommandLine but no
-	// 'os.bootloader.resetType: hard-reset'.
+	// Pass 2: re-customize that UKI image with 'os.uki.mode: create' and os.kernelCommandLine.extraCommandLine but
+	// doesn't hard-reset the bootloader. Preserves rd.info and adds console=ttyAMA0,115200n8.
 	outImageFilePath2 := filepath.Join(testTempDir, "image.raw")
 	configFile2 := filepath.Join(testDir, "verity-reinit-usr-uki-cmdline.yaml")
 	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile2, outImageFilePath1, outImageFilePath2, "raw",
@@ -295,26 +320,22 @@ func testCustomizeImageVerityUsrUkiRecustomizeCmdlineHelper(t *testing.T, baseIm
 		return
 	}
 
-	ukiFilesChecksums2, addonFilesChecksums2, ok := verifyUsrVerity(t, buildDir, outImageFilePath2, nil, nil)
+	ukiFilesChecksums2, addonFilesChecksums2, ok := verifyUsrVerity(t, buildDir, outImageFilePath2,
+		[]string{"rd.info", "console=ttyAMA0,115200n8"}, nil, nil, nil)
 	if !ok {
 		return
 	}
 
-	// Create mode must preserve each main UKI while regenerating the addon, and the gb200
-	// extraCommandLine must have reached the regenerated UKIs — the specific behaviour this test
-	// exercises via the default (non hard-reset) AddKernelCommandLine path.
-	verifyUsrVerityUkiRecustomized(t, buildDir, outImageFilePath2,
-		ukiFilesChecksums1, ukiFilesChecksums2, addonFilesChecksums1, addonFilesChecksums2,
-		"console=ttyAMA0,115200n8")
+	// Create mode must preserve each main UKI while regenerating the addon.
+	verifyUsrVerityUkiRecustomized(t, buildDir, outImageFilePath2, ukiFilesChecksums1, ukiFilesChecksums2,
+		addonFilesChecksums1, addonFilesChecksums2)
 }
 
 // verifyUsrVerityUkiRecustomized checks that re-customizing a usr-verity UKI image in create mode
 // preserved each main UKI (kernel/initramfs/os-release unchanged) while regenerating its addon
-// (cmdline changed), and that /boot contains only the ESP. When expectedCmdlineArgs are given, it
-// also asserts every regenerated UKI's kernel command-line contains each of them.
+// (cmdline changed), and that /boot contains only the ESP.
 func verifyUsrVerityUkiRecustomized(t *testing.T, buildDir string, imagePath string,
 	oldUkiChecksums, newUkiChecksums, oldAddonChecksums, newAddonChecksums map[string]string,
-	expectedCmdlineArgs ...string,
 ) {
 	// The main UKI (kernel + os-release + initramfs) must not change; only the addon (cmdline) does.
 	for ukiFile, oldChecksum := range oldUkiChecksums {
@@ -359,25 +380,26 @@ func verifyUsrVerityUkiRecustomized(t *testing.T, buildDir string, imagePath str
 		}
 	}
 	assert.True(t, hasEfi, "/boot must contain the 'efi' directory")
-
-	// Optionally verify specific kernel command-line args reached the regenerated UKIs.
-	if len(expectedCmdlineArgs) > 0 {
-		espPath := filepath.Join(imageConnection.Chroot().RootDir(), "/boot/efi")
-		kernelToArgs, err := extractKernelCmdlineFromUkiEfis(espPath, buildDir)
-		if !assert.NoError(t, err) {
-			return
-		}
-		assert.GreaterOrEqual(t, len(kernelToArgs), 1, "expected at least one UKI in the ESP")
-		for kernel, args := range kernelToArgs {
-			for _, expected := range expectedCmdlineArgs {
-				assert.Contains(t, args, expected,
-					"regenerated UKI for kernel (%s) should contain cmdline arg (%s)", kernel, expected)
-			}
-		}
-	}
 }
 
-func verifyUsrVerity(t *testing.T, buildDir string, imagePath string,
+// verifyUkiCmdlineArgs asserts that every UKI on the ESP has each of extraCommandLine present in its kernel
+// command-line and none of absentCommandLine present.
+func verifyUkiCmdlineArgs(t *testing.T, espPath string, buildDir string, extraCommandLine []string,
+	absentCommandLine []string,
+) {
+	if len(extraCommandLine) == 0 && len(absentCommandLine) == 0 {
+		return
+	}
+
+	kernelToArgs, err := extractKernelCmdlineFromUkiEfis(espPath, buildDir)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assertKernelCmdlineArgs(t, kernelToArgs, extraCommandLine, absentCommandLine)
+}
+
+func verifyUsrVerity(t *testing.T, buildDir string, imagePath string, extraCommandLine []string, absentCommandLine []string,
 	expectedUkiFilesChecksums map[string]string, expectedAddonFilesChecksums map[string]string,
 ) (map[string]string, map[string]string, bool) {
 	// Connect to customized image.
@@ -424,7 +446,9 @@ func verifyUsrVerity(t *testing.T, buildDir string, imagePath string,
 	usrDevice := testutils.PartitionDevPath(imageConnection, 3)
 	usrHashDevice := testutils.PartitionDevPath(imageConnection, 4)
 	verifyVerityUki(t, espPath, usrDevice, usrHashDevice, "PARTUUID="+partitions[3].PartUuid,
-		"PARTUUID="+partitions[4].PartUuid, "usr", buildDir, "rd.info", "panic-on-corruption", false /*inlineVerity*/)
+		"PARTUUID="+partitions[4].PartUuid, "usr", buildDir, "panic-on-corruption", false /*inlineVerity*/)
+
+	verifyUkiCmdlineArgs(t, espPath, buildDir, extraCommandLine, absentCommandLine)
 
 	// Verify fstab entries
 	expectedFstabEntries := []diskutils.FstabEntry{
@@ -523,7 +547,8 @@ func verifyUsrVerity(t *testing.T, buildDir string, imagePath string,
 	return ukiFilesChecksums, addonFilesChecksums, true
 }
 
-func verifyRootVerityUki(t *testing.T, buildDir string, imagePath string, expectedUkiFilesChecksums map[string]string,
+func verifyRootVerityUki(t *testing.T, buildDir string, imagePath string, extraCommandLine []string, absentCommandLine []string,
+	expectedUkiFilesChecksums map[string]string,
 ) (map[string]string, bool) {
 	// Connect to customized image.
 	mountPoints := []testutils.MountPoint{
@@ -564,7 +589,9 @@ func verifyRootVerityUki(t *testing.T, buildDir string, imagePath string, expect
 	rootDevice := testutils.PartitionDevPath(imageConnection, 3)
 	rootHashDevice := testutils.PartitionDevPath(imageConnection, 4)
 	verifyVerityUki(t, espPath, rootDevice, rootHashDevice, "PARTUUID="+partitions[3].PartUuid,
-		"PARTUUID="+partitions[4].PartUuid, "root", buildDir, "", "panic-on-corruption", false /*inlineVerity*/)
+		"PARTUUID="+partitions[4].PartUuid, "root", buildDir, "panic-on-corruption", false /*inlineVerity*/)
+
+	verifyUkiCmdlineArgs(t, espPath, buildDir, extraCommandLine, absentCommandLine)
 
 	expectedFstabEntries := []diskutils.FstabEntry{
 		{
@@ -796,7 +823,7 @@ func testCustomizeImageVerityUsrUkiRecustomizeNulPaddedCmdlineHelper(t *testing.
 	buildDir := filepath.Join(testTempDir, "build")
 
 	// Build an inline-usr-verity UKI image whose addon command line ends with
-	// `systemd.verity_usr_options=...,hash-offset=<N>`.
+	// `systemd.verity_usr_options=...,hash-offset=<N>`. Adds rd.info and <nulPaddingFillerArg>.
 	ukiImageFilePath := filepath.Join(testTempDir, "uki-verity.raw")
 	configFile := filepath.Join(testDir, verityUsrInlineUkiConfigFile(t, baseImageInfo))
 	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, ukiImageFilePath, "raw",
@@ -806,12 +833,12 @@ func testCustomizeImageVerityUsrUkiRecustomizeNulPaddedCmdlineHelper(t *testing.
 	}
 
 	// Rewrite the addon `.cmdline` with shorter, NUL-terminated content so the re-read command line carries trailing
-	// NUL padding after its last argument.
+	// NUL padding after its last argument. Removes <nulPaddingFillerArg>.
 	if !injectAddonCmdlineNulPadding(t, buildDir, ukiImageFilePath) {
 		return
 	}
 
-	// Re-customize.
+	// Re-customize. Resets the bootloader, so removes rd.info and adds rd.debug.
 	outImageFilePath := filepath.Join(testTempDir, "recustomized.raw")
 	reinitConfigFile := filepath.Join(testDir, "verity-reinit-usr-uki.yaml")
 	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, reinitConfigFile, ukiImageFilePath, outImageFilePath,
@@ -822,7 +849,7 @@ func testCustomizeImageVerityUsrUkiRecustomizeNulPaddedCmdlineHelper(t *testing.
 
 	// Validate the re-customized image. Reading the UKI addon command line back is the code path the fix touches, so
 	// this also confirms the usr-verity configuration is well-formed, including a parseable inline hash-offset.
-	verifyUsrInlineVerityUki(t, buildDir, outImageFilePath)
+	verifyUsrInlineVerityUki(t, buildDir, outImageFilePath, []string{"rd.debug"}, []string{"rd.info", nulPaddingFillerArg})
 }
 
 // injectAddonCmdlineNulPadding rewrites every UKI addon `.cmdline` section on the image's ESP with shorter,
@@ -902,7 +929,7 @@ func injectAddonCmdlineNulPadding(t *testing.T, buildDir string, imageFilePath s
 // kernel command line back from the UKI addons on the ESP (the code path the NUL-trim fix touches), checks the
 // systemd.verity_usr_* arguments including a parseable inline hash-offset, and runs `veritysetup verify` against the
 // usr partition.
-func verifyUsrInlineVerityUki(t *testing.T, buildDir string, imageFilePath string) {
+func verifyUsrInlineVerityUki(t *testing.T, buildDir string, imageFilePath string, extraCommandLine []string, absentCommandLine []string) {
 	imageConnection, err := testutils.ConnectToImage(buildDir, imageFilePath, false, /*includeDefaultMounts*/
 		[]testutils.MountPoint{
 			{
@@ -926,8 +953,10 @@ func verifyUsrInlineVerityUki(t *testing.T, buildDir string, imageFilePath strin
 	espPath := filepath.Join(imageConnection.Chroot().RootDir(), "/boot/efi")
 	usrDevice := testutils.PartitionDevPath(imageConnection, 3)
 	usrPartUuid := "PARTUUID=" + partitions[3].PartUuid
-	verifyVerityUki(t, espPath, usrDevice, usrDevice, usrPartUuid, usrPartUuid, "usr", buildDir, "rd.info",
+	verifyVerityUki(t, espPath, usrDevice, usrDevice, usrPartUuid, usrPartUuid, "usr", buildDir,
 		"panic-on-corruption", true /*inlineVerity*/)
+
+	verifyUkiCmdlineArgs(t, espPath, buildDir, extraCommandLine, absentCommandLine)
 
 	err = imageConnection.CleanClose()
 	assert.NoError(t, err)

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
@@ -84,6 +84,101 @@ func testCustomizeImageVerityUsrUkiHelper(t *testing.T, baseImageInfo testBaseIm
 	verifyUsrVerity(t, buildDir, outImageFilePath2, []string{"rd.info"}, nil, ukiFilesChecksums, nil)
 }
 
+func TestCustomizeImageUkiCreateNoBootloaderReset(t *testing.T) {
+	for _, baseImageInfo := range baseImageAzureLinux3Plus {
+		t.Run(baseImageInfo.Name, func(t *testing.T) {
+			testCustomizeImageUkiCreateNoBootloaderResetHelper(t, baseImageInfo)
+		})
+	}
+}
+
+func testCustomizeImageUkiCreateNoBootloaderResetHelper(t *testing.T, baseImageInfo testBaseImageInfo) {
+	baseImage := checkSkipForCustomizeImage(t, baseImageInfo)
+
+	ukifyExists, err := file.CommandExists("ukify")
+	assert.NoError(t, err)
+	if !ukifyExists {
+		t.Skip("The 'ukify' command is not available")
+	}
+
+	testTempDir := filepath.Join(tmpDir,
+		fmt.Sprintf("TestCustomizeImageUkiCreateNoBootloaderReset_%s", baseImageInfo.Name))
+	defer os.RemoveAll(testTempDir)
+
+	buildDir := filepath.Join(testTempDir, "build")
+
+	// Pass 1: Enlarge the ESP (the stock ESP may be too small to hold a UKI) and add systemd.log_level=debug.
+	outImageFilePath1 := filepath.Join(testTempDir, "image1.raw")
+	config1 := imagecustomizerapi.Config{
+		Storage: imagecustomizerapi.Storage{
+			BootType: imagecustomizerapi.BootTypeEfi,
+			Disks: []imagecustomizerapi.Disk{
+				{
+					PartitionTableType: imagecustomizerapi.PartitionTableTypeGpt,
+					Partitions: []imagecustomizerapi.Partition{
+						{
+							Id:   "esp",
+							Type: imagecustomizerapi.PartitionTypeESP,
+							Size: imagecustomizerapi.PartitionSize{
+								Type: imagecustomizerapi.PartitionSizeTypeExplicit,
+								Size: 250 * diskutils.MiB,
+							},
+						},
+						{
+							Id: "root",
+							Size: imagecustomizerapi.PartitionSize{
+								Type: imagecustomizerapi.PartitionSizeTypeExplicit,
+								Size: 6 * diskutils.GiB,
+							},
+						},
+					},
+				},
+			},
+			FileSystems: []imagecustomizerapi.FileSystem{
+				{
+					DeviceId: "esp",
+					Type:     imagecustomizerapi.FileSystemTypeFat32,
+					MountPoint: &imagecustomizerapi.MountPoint{
+						Path:    "/boot/efi",
+						Options: "umask=0077",
+					},
+				},
+				{
+					DeviceId: "root",
+					Type:     imagecustomizerapi.FileSystemTypeExt4,
+					MountPoint: &imagecustomizerapi.MountPoint{
+						Path: "/",
+					},
+				},
+			},
+		},
+		OS: &imagecustomizerapi.OS{
+			BootLoader: imagecustomizerapi.BootLoader{
+				ResetType: imagecustomizerapi.ResetBootLoaderTypeHard,
+			},
+			KernelCommandLine: imagecustomizerapi.KernelCommandLine{
+				ExtraCommandLine: []string{"systemd.log_level=debug"},
+			},
+		},
+	}
+	err = basicCustomizeImage(t.Context(), buildDir, testDir, &config1, baseImage, outImageFilePath1, "raw",
+		baseImageInfo.PreviewFeatures)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	// Pass 2: Convert grub -> UKI add rd.info but do not reset bootloader, keeping systemd.log_level=debug.
+	outImageFilePath2 := filepath.Join(testTempDir, "image2.raw")
+	configFile2 := filepath.Join(testDir, ukiNoResetConfigFile(t, baseImageInfo))
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile2, outImageFilePath1, outImageFilePath2,
+		"raw", baseImageInfo.PreviewFeatures)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	verifyUkiCmdline(t, buildDir, outImageFilePath2, []string{"systemd.log_level=debug", "rd.info"}, nil)
+}
+
 func TestCustomizeImageVerityUsrUkiRecustomize(t *testing.T) {
 	for _, baseImageInfo := range baseImageAzureLinux3Plus {
 		t.Run(baseImageInfo.Name, func(t *testing.T) {
@@ -399,6 +494,28 @@ func verifyUkiCmdlineArgs(t *testing.T, espPath string, buildDir string, extraCo
 	assertKernelCmdlineArgs(t, kernelToArgs, extraCommandLine, absentCommandLine)
 }
 
+// verifyUkiCmdline connects to a (non-verity) UKI image and asserts that every UKI on the ESP has each of
+// extraCommandLine present in its kernel command line and none of absentCommandLine present.
+func verifyUkiCmdline(t *testing.T, buildDir string, imageFilePath string, extraCommandLine []string,
+	absentCommandLine []string,
+) {
+	imageConnection, err := testutils.ConnectToImage(buildDir, imageFilePath, false, /*includeDefaultMounts*/
+		[]testutils.MountPoint{
+			{
+				PartitionNum:   1,
+				Path:           "/boot/efi",
+				FileSystemType: "vfat",
+			},
+		})
+	if !assert.NoError(t, err) {
+		return
+	}
+	defer imageConnection.Close()
+
+	espPath := filepath.Join(imageConnection.Chroot().RootDir(), "/boot/efi")
+	verifyUkiCmdlineArgs(t, espPath, buildDir, extraCommandLine, absentCommandLine)
+}
+
 func verifyUsrVerity(t *testing.T, buildDir string, imagePath string, extraCommandLine []string, absentCommandLine []string,
 	expectedUkiFilesChecksums map[string]string, expectedAddonFilesChecksums map[string]string,
 ) (map[string]string, map[string]string, bool) {
@@ -673,6 +790,20 @@ func verityUsrUkiConfigFile(t *testing.T, baseImageInfo testBaseImageInfo) strin
 		return fmt.Sprintf("verity-usr-uki-%s-azl4.yaml", runtime.GOARCH)
 	default:
 		t.Fatalf("unsupported base image version for verity-usr-uki test: %s", baseImageInfo.Version)
+		return ""
+	}
+}
+
+// ukiNoResetConfigFile returns the pass-2 grub->UKI-without-reset test config file appropriate for the given base
+// image version (azl3 vs azl4) and host architecture.
+func ukiNoResetConfigFile(t *testing.T, baseImageInfo testBaseImageInfo) string {
+	switch baseImageInfo.Version {
+	case baseImageVersionAzl3:
+		return "uki-noreset-azl3.yaml"
+	case baseImageVersionAzl4:
+		return fmt.Sprintf("uki-noreset-%s-azl4.yaml", runtime.GOARCH)
+	default:
+		t.Fatalf("unsupported base image version for uki-noreset test: %s", baseImageInfo.Version)
 		return ""
 	}
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
@@ -399,7 +399,7 @@ func assertKernelCmdlineArgs(t *testing.T, kernelToArgs map[string]string, extra
 
 	// Verify each extra command line arg is present in every kernel's command line.
 	for _, extraArg := range extraCommandLine {
-		cmdlineRegexp := regexp.MustCompile(fmt.Sprintf(` %s( |$)`, regexp.QuoteMeta(extraArg)))
+		cmdlineRegexp := regexp.MustCompile(fmt.Sprintf(`(^| )%s( |$)`, regexp.QuoteMeta(extraArg)))
 
 		for kernel, args := range kernelToArgs {
 			assert.Regexp(t, cmdlineRegexp, args,
@@ -409,7 +409,7 @@ func assertKernelCmdlineArgs(t *testing.T, kernelToArgs map[string]string, extra
 
 	// Verify each absent command line arg is present in no kernel's command line.
 	for _, absentArg := range absentCommandLine {
-		cmdlineRegexp := regexp.MustCompile(fmt.Sprintf(` %s( |$)`, regexp.QuoteMeta(absentArg)))
+		cmdlineRegexp := regexp.MustCompile(fmt.Sprintf(`(^| )%s( |$)`, regexp.QuoteMeta(absentArg)))
 
 		for kernel, args := range kernelToArgs {
 			assert.NotRegexp(t, cmdlineRegexp, args,

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeverity_test.go
@@ -42,23 +42,23 @@ func testCustomizeImageVerityHelper(t *testing.T, testName string, baseImageInfo
 	outImageFilePath := filepath.Join(testTempDir, "image.raw")
 	configFile := getRootVerityConfigFile(t, baseImageInfo, false /*useToolsDir*/)
 
-	// Customize image.
+	// Customize image. Adds rd.info.
 	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
 		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	verifyRootVerity(t, baseImageInfo, buildDir, outImageFilePath)
+	verifyRootVerity(t, baseImageInfo, buildDir, outImageFilePath, []string{"rd.info"}, nil)
 
-	// Recustomize the image.
+	// Recustomize the image. Resets the bootloader but also re-adds rd.info.
 	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, outImageFilePath, "raw",
 		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	verifyRootVerity(t, baseImageInfo, buildDir, outImageFilePath)
+	verifyRootVerity(t, baseImageInfo, buildDir, outImageFilePath, []string{"rd.info"}, nil)
 }
 
 func getRootVerityConfigFile(t *testing.T, baseImageInfo testBaseImageInfo, useToolsDir bool) string {
@@ -92,7 +92,7 @@ func getRootVerityConfigFile(t *testing.T, baseImageInfo testBaseImageInfo, useT
 }
 
 func verifyRootVerity(t *testing.T, baseImageInfo testBaseImageInfo, buildDir string,
-	outImageFilePath string,
+	outImageFilePath string, extraCommandLine []string, absentCommandLine []string,
 ) {
 	// Connect to customized image.
 	mountPoints := []testutils.MountPoint{
@@ -134,8 +134,10 @@ func verifyRootVerity(t *testing.T, baseImageInfo testBaseImageInfo, buildDir st
 	rootDevice := testutils.PartitionDevPath(imageConnection, 3)
 	hashDevice := testutils.PartitionDevPath(imageConnection, 4)
 	verifyVerityGrub(t, bootPath, rootDevice, hashDevice, "PARTUUID="+partitions[3].PartUuid,
-		"PARTUUID="+partitions[4].PartUuid, "root", "rd.info", baseImageInfo, "panic-on-corruption",
+		"PARTUUID="+partitions[4].PartUuid, "root", baseImageInfo, "panic-on-corruption",
 		false /*inlineVerity*/)
+
+	verifyGrubCmdlineArgs(t, bootPath, baseImageInfo, extraCommandLine, absentCommandLine)
 
 	err = imageConnection.CleanClose()
 	if !assert.NoError(t, err) {
@@ -179,7 +181,7 @@ func testCustomizeImageVerityCosiExtractHelper(t *testing.T, baseImageInfo testB
 	hashPartitionNum := 4
 	varPartitionNum := 5
 
-	// Customize image, shrink partitions, and split the partitions into individual files.
+	// Customize image, shrink partitions, and split the partitions into individual files. Adds rd.info.
 	err := CustomizeImageWithConfigFile(t.Context(), configFile, ImageCustomizerOptions{
 		BuildDir:             buildDir,
 		InputImageFile:       baseImage,
@@ -316,7 +318,9 @@ func testCustomizeImageVerityCosiExtractHelper(t *testing.T, baseImageInfo testB
 
 	// Verify that verity is configured correctly.
 	verifyVerityGrub(t, bootMountPath, rootDevice.DevicePath(), hashDevice.DevicePath(), "PARTLABEL=root",
-		"PARTLABEL=roothash", "root", "rd.info", baseImageInfo, "panic-on-corruption", false /*inlineVerity*/)
+		"PARTLABEL=roothash", "root", baseImageInfo, "panic-on-corruption", false /*inlineVerity*/)
+
+	verifyGrubCmdlineArgs(t, bootMountPath, baseImageInfo, []string{"rd.info"}, nil /*absentCommandLine*/)
 }
 
 func rootVerityPartLabelsConfigFile(t *testing.T, baseImageInfo testBaseImageInfo, useToolsDir bool) string {
@@ -339,7 +343,7 @@ func rootVerityPartLabelsConfigFile(t *testing.T, baseImageInfo testBaseImageInf
 }
 
 func verifyVerityGrub(t *testing.T, bootPath string, dataDevice string, hashDevice string, dataId string, hashId string,
-	verityType string, extraCommandLine string, baseImageInfo testBaseImageInfo, corruptionOption string,
+	verityType string, baseImageInfo testBaseImageInfo, corruptionOption string,
 	inlineVerity bool,
 ) {
 	distroHandler, err := NewDistroHandler(baseImageInfo.TargetOs())
@@ -360,23 +364,62 @@ func verifyVerityGrub(t *testing.T, bootPath string, dataDevice string, hashDevi
 	// Verify verity.
 	verifyVerityHelper(t, kernelArgsList, dataDevice, hashDevice, dataId, hashId, verityType, corruptionOption,
 		inlineVerity)
+}
 
-	// Verify extra command line args.
-	cmdlineRegexp := regexp.MustCompile(fmt.Sprintf(` %s( |$)`, regexp.QuoteMeta(extraCommandLine)))
+// verifyGrubCmdlineArgs reads the kernel command line for every kernel from the GRUB boot config at bootPath and checks
+// that each arg in extraCommandLine is present in every kernel command line and each arg in absentCommandLine is
+// present in none.
+func verifyGrubCmdlineArgs(t *testing.T, bootPath string, baseImageInfo testBaseImageInfo, extraCommandLine []string,
+	absentCommandLine []string,
+) {
+	if len(extraCommandLine) == 0 && len(absentCommandLine) == 0 {
+		return
+	}
 
-	// Count the number of linux lines contain the extra command line args.
-	extraCommandLineMatchCount := 0
-	for _, kernelArgs := range kernelArgsList {
-		if cmdlineRegexp.MatchString(kernelArgs) {
-			extraCommandLineMatchCount += 1
+	distroHandler, err := NewDistroHandler(baseImageInfo.TargetOs())
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	kernelToArgs, err := distroHandler.ReadGrubConfigLinuxArgs(bootPath)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assertKernelCmdlineArgs(t, grubKernelArgsToStringMap(kernelToArgs), extraCommandLine, absentCommandLine)
+}
+
+// assertKernelCmdlineArgs checks that every arg in extraCommandLine appears as a whole argument in every kernel's
+// command line, and every arg in absentCommandLine appears in none of them. kernelToArgs maps each kernel name to its
+// full command line.
+func assertKernelCmdlineArgs(t *testing.T, kernelToArgs map[string]string, extraCommandLine []string,
+	absentCommandLine []string,
+) {
+	assert.NotEmpty(t, kernelToArgs, "expected at least one kernel command line to verify")
+
+	// Verify each extra command line arg is present in every kernel's command line.
+	for _, extraArg := range extraCommandLine {
+		cmdlineRegexp := regexp.MustCompile(fmt.Sprintf(` %s( |$)`, regexp.QuoteMeta(extraArg)))
+
+		for kernel, args := range kernelToArgs {
+			assert.Regexp(t, cmdlineRegexp, args,
+				"kernel (%s) command line should contain arg (%s): %s", kernel, extraArg, args)
 		}
 	}
 
-	assert.Equal(t, len(kernelArgsList), extraCommandLineMatchCount)
+	// Verify each absent command line arg is present in no kernel's command line.
+	for _, absentArg := range absentCommandLine {
+		cmdlineRegexp := regexp.MustCompile(fmt.Sprintf(` %s( |$)`, regexp.QuoteMeta(absentArg)))
+
+		for kernel, args := range kernelToArgs {
+			assert.NotRegexp(t, cmdlineRegexp, args,
+				"kernel (%s) command line should NOT contain arg (%s): %s", kernel, absentArg, args)
+		}
+	}
 }
 
 func verifyVerityUki(t *testing.T, espPath string, dataDevice string,
-	hashDevice string, dataId string, hashId string, verityType string, buildDir string, extraCommandLine string,
+	hashDevice string, dataId string, hashId string, verityType string, buildDir string,
 	corruptionOption string, inlineVerity bool,
 ) {
 	// Extract kernel command line args.
@@ -394,13 +437,6 @@ func verifyVerityUki(t *testing.T, espPath string, dataDevice string,
 	// Verify verity
 	verifyVerityHelper(t, kernelArgsList, dataDevice, hashDevice, dataId, hashId, verityType, corruptionOption,
 		inlineVerity)
-
-	// Verify extra command line
-	if extraCommandLine != "" {
-		for _, kernelArgs := range kernelArgsList {
-			assert.Regexp(t, fmt.Sprintf(` %s( |$)`, regexp.QuoteMeta(extraCommandLine)), kernelArgs)
-		}
-	}
 }
 
 func verifyVerityHelper(t *testing.T, kernelArgsList []string, dataDevice string,
@@ -497,16 +533,16 @@ func testCustomizeImageVerityUsrHelper(t *testing.T, testName string, baseImageI
 	outImageFilePath := filepath.Join(testTempDir, "image.raw")
 	configFile := filepath.Join(testDir, "verity-usr-config.yaml")
 
-	// Customize image.
+	// Customize image. Adds rd.info.
 	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
 		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	verityUsrVerity(t, baseImageInfo, buildDir, outImageFilePath, "")
+	verityUsrVerity(t, baseImageInfo, buildDir, outImageFilePath, "", []string{"rd.info"}, nil)
 
-	// Recustomize image.
+	// Recustomize image. Resets the bootloader but also re-adds rd.info.
 	// This helps verify that verity-enabled images can be recustomized.
 	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, outImageFilePath, "raw",
 		baseImageInfo.PreviewFeatures)
@@ -514,11 +550,11 @@ func testCustomizeImageVerityUsrHelper(t *testing.T, testName string, baseImageI
 		return
 	}
 
-	verityUsrVerity(t, baseImageInfo, buildDir, outImageFilePath, "")
+	verityUsrVerity(t, baseImageInfo, buildDir, outImageFilePath, "", []string{"rd.info"}, nil)
 }
 
 func verityUsrVerity(t *testing.T, baseImageInfo testBaseImageInfo, buildDir string,
-	outImageFilePath string, corruptionOption string,
+	outImageFilePath string, corruptionOption string, extraCommandLine []string, absentCommandLine []string,
 ) {
 	// Connect to usr verity image.
 	mountPoints := []testutils.MountPoint{
@@ -554,7 +590,9 @@ func verityUsrVerity(t *testing.T, baseImageInfo testBaseImageInfo, buildDir str
 	usrDevice := testutils.PartitionDevPath(imageConnection, 2)
 	hashDevice := testutils.PartitionDevPath(imageConnection, 3)
 	verifyVerityGrub(t, bootPath, usrDevice, hashDevice, "UUID="+partitions[2].Uuid,
-		"UUID="+partitions[3].Uuid, "usr", "rd.info", baseImageInfo, corruptionOption, false /*inlineVerity*/)
+		"UUID="+partitions[3].Uuid, "usr", baseImageInfo, corruptionOption, false /*inlineVerity*/)
+
+	verifyGrubCmdlineArgs(t, bootPath, baseImageInfo, extraCommandLine, absentCommandLine)
 }
 
 func TestCustomizeImageVerityUsr2Stage(t *testing.T) {
@@ -579,7 +617,7 @@ func testCustomizeImageVerityUsr2StageHelper(t *testing.T, testName string, base
 	stage2FilePath := filepath.Join(testTempDir, "image2.raw")
 	stage3FilePath := filepath.Join(testTempDir, "image3.vhdx")
 
-	// Stage 1: Create the partitions for verity.
+	// Stage 1: Create the partitions for verity. Adds rd.info.
 	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, stage1ConfigFile, baseImage, stage1FilePath, "qcow2",
 		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
@@ -593,11 +631,11 @@ func testCustomizeImageVerityUsr2StageHelper(t *testing.T, testName string, base
 		return
 	}
 
-	verityUsrVerity(t, baseImageInfo, buildDir, stage2FilePath, "panic-on-corruption")
+	verityUsrVerity(t, baseImageInfo, buildDir, stage2FilePath, "panic-on-corruption", []string{"rd.info"}, nil)
 
 	// Stage 3: Re-apply verity settings.
-	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, stage3ConfigFile, stage2FilePath, stage3FilePath, "vhdx",
-		baseImageInfo.PreviewFeatures)
+	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, stage3ConfigFile, stage2FilePath, stage3FilePath,
+		"vhdx", baseImageInfo.PreviewFeatures)
 	assert.ErrorContains(t, err, "verity (verityusr) data partition is invalid")
 	assert.ErrorContains(t, err, "partition already in use as existing verity device's (usr) data partition")
 }
@@ -623,32 +661,32 @@ func testCustomizeImageVerityReinitRootHelper(t *testing.T, testName string, bas
 	stage1FilePath := filepath.Join(testTempDir, "image1.raw")
 	stage2FilePath := filepath.Join(testTempDir, "image2.raw")
 
-	// Stage 1: Initialize verity.
+	// Stage 1: Initialize verity. Adds rd.info.
 	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, stage1ConfigFile, baseImage, stage1FilePath, "raw",
 		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	verifyRootVerity(t, baseImageInfo, buildDir, stage1FilePath)
+	verifyRootVerity(t, baseImageInfo, buildDir, stage1FilePath, []string{"rd.info"}, nil)
 
-	// Stage 2a: Reinitialize verity.
+	// Stage 2a: Reinitialize verity. Does not reset bootloader, so rd.info remains.
 	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, stage2aConfigFile, stage1FilePath, stage2FilePath, "raw",
 		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	verifyRootVerity(t, baseImageInfo, buildDir, stage2FilePath)
+	verifyRootVerity(t, baseImageInfo, buildDir, stage2FilePath, []string{"rd.info"}, nil)
 
-	// Stage 2b: Reinitialize verity + hard-reset bootloader.
+	// Stage 2b: Reinitialize verity + hard-reset bootloader. Resets the bootloader, removing rd.info and adding rd.debug.
 	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, stage2bConfigFile, stage1FilePath, stage2FilePath, "raw",
 		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	verifyRootVerity(t, baseImageInfo, buildDir, stage2FilePath)
+	verifyRootVerity(t, baseImageInfo, buildDir, stage2FilePath, []string{"rd.debug"}, []string{"rd.info"})
 }
 
 func TestCustomizeImageVerityReinitUsr(t *testing.T) {
@@ -671,14 +709,14 @@ func testCustomizeImageVerityReinitUsrHelper(t *testing.T, testName string, base
 	stage1FilePath := filepath.Join(testTempDir, "image.raw")
 	stage2FilePath := filepath.Join(testTempDir, "image.raw")
 
-	// Stage 1: Initialize verity.
+	// Stage 1: Initialize verity. Adds rd.info.
 	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, stage1ConfigFile, baseImage, stage1FilePath, "raw",
 		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	verityUsrVerity(t, baseImageInfo, buildDir, stage1FilePath, "")
+	verityUsrVerity(t, baseImageInfo, buildDir, stage1FilePath, "", []string{"rd.info"}, nil)
 
 	// Stage 2: Reinitialize verity.
 	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, stage2ConfigFile, stage1FilePath, stage2FilePath, "raw",
@@ -687,7 +725,7 @@ func testCustomizeImageVerityReinitUsrHelper(t *testing.T, testName string, base
 		return
 	}
 
-	verityUsrVerity(t, baseImageInfo, buildDir, stage2FilePath, "")
+	verityUsrVerity(t, baseImageInfo, buildDir, stage2FilePath, "", []string{"rd.info"}, nil)
 }
 
 func TestUpdateSubvolOption_EmptyOptions_Pass(t *testing.T) {
@@ -790,23 +828,24 @@ func testCustomizeImageVerityBtrfsRootHelper(t *testing.T, testName string, base
 	outImageFilePath := filepath.Join(testTempDir, "image.raw")
 	configFile := filepath.Join(testDir, "verity-btrfs-root-subvolume.yaml")
 
-	// Customize image with verity + btrfs subvolume.
+	// Customize image with verity + btrfs subvolume. Adds rd.info.
 	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
 		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	verifyBtrfsVerityRoot(t, baseImageInfo, outImageFilePath, testTempDir, "root")
+	verifyBtrfsVerityRoot(t, baseImageInfo, outImageFilePath, testTempDir, "root", []string{"rd.info"}, nil)
 
 	// Recustomize the image to verify that verity-enabled btrfs images can be recustomized.
+	// Resets the bootloader, but also re-adds rd.info.
 	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, outImageFilePath, "raw",
 		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	verifyBtrfsVerityRoot(t, baseImageInfo, outImageFilePath, testTempDir, "root")
+	verifyBtrfsVerityRoot(t, baseImageInfo, outImageFilePath, testTempDir, "root", []string{"rd.info"}, nil)
 }
 
 // TestCustomizeImageVerityBtrfsNoSubvolumes tests verity with a BTRFS root filesystem without subvolumes.
@@ -830,30 +869,30 @@ func testCustomizeImageVerityBtrfsNoSubvolumesHelper(t *testing.T, testName stri
 	outImageFilePath := filepath.Join(testTempDir, "image.raw")
 	configFile := filepath.Join(testDir, "verity-btrfs-root-no-subvolumes.yaml")
 
-	// Customize image with verity + btrfs (no subvolumes).
+	// Customize image with verity + btrfs (no subvolumes). Adds rd.info.
 	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
 		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	verifyBtrfsVerityRoot(t, baseImageInfo, outImageFilePath, testTempDir, "" /*subvolPath*/)
+	verifyBtrfsVerityRoot(t, baseImageInfo, outImageFilePath, testTempDir, "" /*subvolPath*/, []string{"rd.info"}, nil)
 
-	// Recustomize the image.
+	// Recustomize the image. Resets the bootloader, but also re-adds rd.info.
 	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, outImageFilePath, "raw",
 		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	verifyBtrfsVerityRoot(t, baseImageInfo, outImageFilePath, testTempDir, "" /*subvolPath*/)
+	verifyBtrfsVerityRoot(t, baseImageInfo, outImageFilePath, testTempDir, "" /*subvolPath*/, []string{"rd.info"}, nil)
 }
 
 // verifyBtrfsVerityRoot verifies that verity is correctly configured on a BTRFS root filesystem.
 // It checks the fstab entry has the correct subvol= option (if applicable) and verifies
 // the verity hash using veritysetup.
 func verifyBtrfsVerityRoot(t *testing.T, baseImageInfo testBaseImageInfo, outImageFilePath string, testTempDir string,
-	subvolPath string,
+	subvolPath string, extraCommandLine []string, absentCommandLine []string,
 ) {
 	// Attach the image.
 	loopback, err := safeloopback.NewLoopback(outImageFilePath)
@@ -884,7 +923,9 @@ func verifyBtrfsVerityRoot(t *testing.T, baseImageInfo testBaseImageInfo, outIma
 	defer bootMount.Close()
 
 	verifyVerityGrub(t, bootMountDir, rootPartitionPath, hashPartitionPath, "PARTUUID="+partitions[3].PartUuid,
-		"PARTUUID="+partitions[4].PartUuid, "root", "rd.info", baseImageInfo, "panic-on-corruption", false)
+		"PARTUUID="+partitions[4].PartUuid, "root", baseImageInfo, "panic-on-corruption", false)
+
+	verifyGrubCmdlineArgs(t, bootMountDir, baseImageInfo, extraCommandLine, absentCommandLine)
 
 	err = bootMount.CleanClose()
 	if !assert.NoError(t, err) {
@@ -1030,8 +1071,10 @@ func verifyRootInlineVerity(t *testing.T, baseImageInfo testBaseImageInfo, build
 	bootPath := filepath.Join(imageConnection.Chroot().RootDir(), "/boot")
 	rootDevice := testutils.PartitionDevPath(imageConnection, 3)
 	verifyVerityGrub(t, bootPath, rootDevice, rootDevice, "PARTUUID="+partitions[3].PartUuid,
-		"PARTUUID="+partitions[3].PartUuid, "root", "rd.info", baseImageInfo, "panic-on-corruption",
+		"PARTUUID="+partitions[3].PartUuid, "root", baseImageInfo, "panic-on-corruption",
 		true /*inlineVerity*/)
+
+	verifyGrubCmdlineArgs(t, bootPath, baseImageInfo, []string{"rd.info"}, nil /*absentCommandLine*/)
 
 	err = imageConnection.CleanClose()
 	if !assert.NoError(t, err) {
@@ -1057,25 +1100,25 @@ func testCustomizeImageVerityUsrInlineHelper(t *testing.T, testName string, base
 	outImageFilePath := filepath.Join(testTempDir, "image.raw")
 	configFile := filepath.Join(testDir, "verity-usr-inline.yaml")
 
-	// Customize image.
+	// Customize image. Adds rd.info.
 	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "raw",
 		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	verifyUsrInlineVerity(t, baseImageInfo, buildDir, outImageFilePath)
+	verifyUsrInlineVerity(t, baseImageInfo, buildDir, outImageFilePath, []string{"rd.info"}, nil)
 
-	// Recustomize the image.
+	// Recustomize the image. Resets the bootloader but also re-adds rd.info.
 	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, outImageFilePath, "raw",
 		baseImageInfo.PreviewFeatures)
 	if !assert.NoError(t, err) {
 		return
 	}
 
-	verifyUsrInlineVerity(t, baseImageInfo, buildDir, outImageFilePath)
+	verifyUsrInlineVerity(t, baseImageInfo, buildDir, outImageFilePath, []string{"rd.info"}, nil)
 
-	// Reinit verity without customizing partitions.
+	// Reinit verity without customizing partitions. Preserves rd.info.
 	configFile = filepath.Join(testDir, "verity-reinit.yaml")
 
 	err = basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, outImageFilePath, outImageFilePath, "raw",
@@ -1084,11 +1127,11 @@ func testCustomizeImageVerityUsrInlineHelper(t *testing.T, testName string, base
 		return
 	}
 
-	verifyUsrInlineVerity(t, baseImageInfo, buildDir, outImageFilePath)
+	verifyUsrInlineVerity(t, baseImageInfo, buildDir, outImageFilePath, []string{"rd.info"}, nil)
 }
 
 func verifyUsrInlineVerity(t *testing.T, baseImageInfo testBaseImageInfo, buildDir string,
-	outImageFilePath string,
+	outImageFilePath string, extraCommandLine []string, absentCommandLine []string,
 ) {
 	// Connect to customized image.
 	mountPoints := []testutils.MountPoint{
@@ -1124,8 +1167,10 @@ func verifyUsrInlineVerity(t *testing.T, baseImageInfo testBaseImageInfo, buildD
 	bootPath := filepath.Join(imageConnection.Chroot().RootDir(), "/boot")
 	usrDevice := testutils.PartitionDevPath(imageConnection, 2)
 	verifyVerityGrub(t, bootPath, usrDevice, usrDevice, "PARTUUID="+partitions[2].PartUuid,
-		"PARTUUID="+partitions[2].PartUuid, "usr", "rd.info", baseImageInfo, "ignore-corruption",
+		"PARTUUID="+partitions[2].PartUuid, "usr", baseImageInfo, "ignore-corruption",
 		true /*inlineVerity*/)
+
+	verifyGrubCmdlineArgs(t, bootPath, baseImageInfo, extraCommandLine, absentCommandLine)
 
 	err = imageConnection.CleanClose()
 	if !assert.NoError(t, err) {
@@ -1155,7 +1200,7 @@ func testCustomizeImageVerityRootInlineCosiHelper(t *testing.T, testName string,
 	outImageFilePath := filepath.Join(testTempDir, "image.cosi")
 	configFile := filepath.Join(testDir, verityRootInlineUkiConfigFile(baseImageInfo))
 
-	// Customize image, shrink partitions, and split the partitions into individual files.
+	// Customize image, shrink partitions, and split the partitions into individual files. Adds rd.info.
 	err := basicCustomizeImageWithConfigFile(t.Context(), buildDir, configFile, baseImage, outImageFilePath, "cosi",
 		baseImageInfo.PreviewFeatures)
 
@@ -1284,8 +1329,10 @@ func testCustomizeImageVerityRootInlineCosiHelper(t *testing.T, testName string,
 
 	// Verify that verity is configured correctly.
 	verifyVerityUki(t, espMountPath, rootDevice.DevicePath(), rootDevice.DevicePath(),
-		"UUID="+metadata.Images[2].FsUuid, "UUID="+metadata.Images[2].FsUuid, "root", buildDir, "rd.info",
+		"UUID="+metadata.Images[2].FsUuid, "UUID="+metadata.Images[2].FsUuid, "root", buildDir,
 		"panic-on-corruption", true /*inlineVerity*/)
+
+	verifyUkiCmdlineArgs(t, espMountPath, buildDir, []string{"rd.info"}, nil)
 }
 
 // verityRootInlineUkiConfigFile returns the verity-root-inline-uki test config file appropriate for

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux4.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux4.go
@@ -289,8 +289,7 @@ func (d *azureLinux4DistroHandler) ConfigureDiskBootLoader(imageConnection *imag
 }
 
 func (d *azureLinux4DistroHandler) ReadGrubConfigLinuxArgs(bootDir string) (map[string][]grubConfigLinuxArg, error) {
-	// Azure Linux 4.0 uses BLS (Boot Loader Specification).
-	return readKernelCmdlinesFromBLSEntries(bootDir)
+	return readBLSOrGrubCfgKernelopts(bootDir)
 }
 
 func (d *azureLinux4DistroHandler) ReadNonRecoveryKernelCmdlines(bootDir string, argNames []string) (map[string]string, error) {

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
@@ -297,7 +297,7 @@ func (d *fedoraDistroHandler) ConfigureDiskBootLoader(imageConnection *imageconn
 }
 
 func (d *fedoraDistroHandler) ReadGrubConfigLinuxArgs(bootDir string) (map[string][]grubConfigLinuxArg, error) {
-	return readKernelCmdlinesFromBLSEntries(bootDir)
+	return readBLSOrGrubCfgKernelopts(bootDir)
 }
 
 func (d *fedoraDistroHandler) ReadNonRecoveryKernelCmdlines(bootDir string, argNames []string) (map[string]string, error) {

--- a/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
@@ -5,7 +5,10 @@ package imagecustomizerlib
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io/fs"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -29,6 +32,9 @@ var (
 
 	// Captures the variable a grub 'search' command assigns via '--set=<var>' or '--set <var>' (e.g. root or boot).
 	grubSearchSetTargetRegex = regexp.MustCompile(`\s+--set(?:=|\s+)(\w+)`)
+
+	// Captures the value of the `set kernelopts="..."` default that grub2-mkconfig writes into grub.cfg.
+	grubKerneloptsRegex = regexp.MustCompile(`(?m)^[ \t]*set kernelopts="([^"]*)"`)
 )
 
 const (
@@ -625,6 +631,52 @@ func GrubArgsToString(args []string) string {
 
 	combinedString := builder.String()
 	return combinedString
+}
+
+// readBLSOrGrubCfgKernelopts reads the per-kernel command line for a BLS-based distro. It prefers the
+// loader/entries/*.conf BLS files, and falls back to the `set kernelopts="..."` default.
+func readBLSOrGrubCfgKernelopts(bootDir string) (map[string][]grubConfigLinuxArg, error) {
+	kernelToArgs, err := readKernelCmdlinesFromBLSEntries(bootDir)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			return nil, err
+		}
+	} else if len(kernelToArgs) > 0 {
+		return kernelToArgs, nil
+	}
+
+	return readKernelCmdlinesFromGrubCfgKernelopts(bootDir)
+}
+
+// readKernelCmdlinesFromGrubCfgKernelopts reads the `set kernelopts="..."` default from grub.cfg and maps it to every
+// kernel found in bootDir. Returns an empty map if grub.cfg has no kernelopts default.
+func readKernelCmdlinesFromGrubCfgKernelopts(bootDir string) (map[string][]grubConfigLinuxArg, error) {
+	grubCfgPath := filepath.Join(bootDir, installutils.FedoraGrubCfgRelPath)
+	content, err := os.ReadFile(grubCfgPath)
+	if err != nil {
+		return nil, err
+	}
+
+	match := grubKerneloptsRegex.FindStringSubmatch(string(content))
+	if match == nil {
+		return nil, nil
+	}
+
+	args := parseBLSOptionsValue(match[1])
+	if len(args) == 0 {
+		return nil, nil
+	}
+
+	kernelToInitramfs, err := getKernelToInitramfsMap(bootDir)
+	if err != nil {
+		return nil, err
+	}
+
+	kernelToArgs := make(map[string][]grubConfigLinuxArg, len(kernelToInitramfs))
+	for kernel := range kernelToInitramfs {
+		kernelToArgs[kernel] = args
+	}
+	return kernelToArgs, nil
 }
 
 // Helper function to get common SELinux args based on mode

--- a/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
@@ -680,7 +680,7 @@ func readKernelCmdlinesFromGrubCfgKernelopts(bootDir string) (map[string][]grubC
 }
 
 // findGrubCfgKernelopts returns the value assigned by the `set kernelopts="..."` default that grub2-mkconfig writes
-// into grub.cfg.
+// into grub.cfg. It returns an error if the value cannot be resolved statically.
 func findGrubCfgKernelopts(grubCfgContent string) (string, bool, error) {
 	tokens, err := grub.TokenizeConfig(grubCfgContent)
 	if err != nil {
@@ -698,12 +698,11 @@ func findGrubCfgKernelopts(grubCfgContent string) (string, bool, error) {
 		for _, arg := range args {
 			if arg.Name == grubKernelOpts {
 				if arg.ValueHasVarExpansion {
-					// ParseCommandLineArgs clears values it cannot resolve statically, so a kernelopts default
-					// that references a variable comes back empty. Warn loudly rather than silently returning an
-					// empty kernel command line.
-					logger.Log.Warnf(
-						"Cannot resolve value of kernelopts in grub.cfg because it contains a variable expansion: %s",
-						arg.Token.RawContent)
+					// ParseCommandLineArgs clears values it cannot resolve statically, so a kernelopts default that
+					// references a variable comes back empty. Error instead of returning an empty string.
+					return "", false, fmt.Errorf(
+						"cannot resolve value of 'set kernelopts' in grub.cfg because it contains a variable "+
+							"expansion: %s", arg.Token.RawContent)
 				}
 				return arg.Value, true, nil
 			}

--- a/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
@@ -646,7 +646,7 @@ func readBLSOrGrubCfgKernelopts(bootDir string) (map[string][]grubConfigLinuxArg
 }
 
 // readKernelCmdlinesFromGrubCfgKernelopts reads the `set kernelopts="..."` default from grub.cfg and maps it to every
-// kernel found in bootDir. Returns an empty map if grub.cfg has no kernelopts default.
+// kernel found in bootDir. Returns an error if kernelopts in grub.cfg could not be found.
 func readKernelCmdlinesFromGrubCfgKernelopts(bootDir string) (map[string][]grubConfigLinuxArg, error) {
 	grubCfgPath := filepath.Join(bootDir, installutils.FedoraGrubCfgRelPath)
 	content, err := os.ReadFile(grubCfgPath)

--- a/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils.go
@@ -32,9 +32,6 @@ var (
 
 	// Captures the variable a grub 'search' command assigns via '--set=<var>' or '--set <var>' (e.g. root or boot).
 	grubSearchSetTargetRegex = regexp.MustCompile(`\s+--set(?:=|\s+)(\w+)`)
-
-	// Captures the value of the `set kernelopts="..."` default that grub2-mkconfig writes into grub.cfg.
-	grubKerneloptsRegex = regexp.MustCompile(`(?m)^[ \t]*set kernelopts="([^"]*)"`)
 )
 
 const (
@@ -657,12 +654,15 @@ func readKernelCmdlinesFromGrubCfgKernelopts(bootDir string) (map[string][]grubC
 		return nil, err
 	}
 
-	match := grubKerneloptsRegex.FindStringSubmatch(string(content))
-	if match == nil {
-		return nil, nil
+	kernelopts, found, err := findGrubCfgKernelopts(string(content))
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, fmt.Errorf("failed to find 'set kernelopts' default in grub config (%s)", grubCfgPath)
 	}
 
-	args := parseBLSOptionsValue(match[1])
+	args := parseBLSOptionsValue(kernelopts)
 	if len(args) == 0 {
 		return nil, nil
 	}
@@ -677,6 +677,40 @@ func readKernelCmdlinesFromGrubCfgKernelopts(bootDir string) (map[string][]grubC
 		kernelToArgs[kernel] = args
 	}
 	return kernelToArgs, nil
+}
+
+// findGrubCfgKernelopts returns the value assigned by the `set kernelopts="..."` default that grub2-mkconfig writes
+// into grub.cfg.
+func findGrubCfgKernelopts(grubCfgContent string) (string, bool, error) {
+	tokens, err := grub.TokenizeConfig(grubCfgContent)
+	if err != nil {
+		return "", false, err
+	}
+
+	lines := grub.SplitTokensIntoLines(tokens)
+	for _, line := range grub.FindCommandAll(lines, "set") {
+		// A `set` command assigns a single `name=value` argument, e.g. `set kernelopts="root=... ro ..."`.
+		args, err := ParseCommandLineArgs(line.Tokens[1:])
+		if err != nil {
+			return "", false, err
+		}
+
+		for _, arg := range args {
+			if arg.Name == grubKernelOpts {
+				if arg.ValueHasVarExpansion {
+					// ParseCommandLineArgs clears values it cannot resolve statically, so a kernelopts default
+					// that references a variable comes back empty. Warn loudly rather than silently returning an
+					// empty kernel command line.
+					logger.Log.Warnf(
+						"Cannot resolve value of kernelopts in grub.cfg because it contains a variable expansion: %s",
+						arg.Token.RawContent)
+				}
+				return arg.Value, true, nil
+			}
+		}
+	}
+
+	return "", false, nil
 }
 
 // Helper function to get common SELinux args based on mode

--- a/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils_test.go
@@ -115,3 +115,119 @@ func buildSELinuxArgs(security, selinux, enforcing selinuxArgState) []grubConfig
 	}
 	return args
 }
+
+func TestFindGrubCfgKernelopts(t *testing.T) {
+	testCases := []struct {
+		name          string
+		grubCfg       string
+		expectedValue string
+		expectedFound bool
+	}{
+		// --- Basic extraction ---
+		{
+			name:          "simple quoted kernelopts",
+			grubCfg:       "set kernelopts=\"root=/dev/sda2 ro rd.info\"\n",
+			expectedValue: "root=/dev/sda2 ro rd.info",
+			expectedFound: true,
+		},
+		{
+			name:          "no kernelopts",
+			grubCfg:       "set default=0\nset timeout=5\n",
+			expectedValue: "",
+			expectedFound: false,
+		},
+		{
+			name:          "kernelopts among other set commands",
+			grubCfg:       "set default=0\nset kernelopts=\"root=/dev/sda2 ro rd.info\"\nset timeout=5\n",
+			expectedValue: "root=/dev/sda2 ro rd.info",
+			expectedFound: true,
+		},
+		{
+			name:          "kernelopts on the first line",
+			grubCfg:       "set kernelopts=\"root=/dev/sda2 ro rd.info\"\nset timeout=5\n",
+			expectedValue: "root=/dev/sda2 ro rd.info",
+			expectedFound: true,
+		},
+		{
+			name:          "indented set command",
+			grubCfg:       "\tset kernelopts=\"root=/dev/sda2 ro rd.info\"\n",
+			expectedValue: "root=/dev/sda2 ro rd.info",
+			expectedFound: true,
+		},
+		{
+			name:          "realistic verity command line",
+			grubCfg:       "set kernelopts=\"root=UUID=307dacd1 ro selinux=0 rd.systemd.verity=1 usrhash=abc123 systemd.verity_usr_options=panic-on-corruption\"\n",
+			expectedValue: "root=UUID=307dacd1 ro selinux=0 rd.systemd.verity=1 usrhash=abc123 systemd.verity_usr_options=panic-on-corruption",
+			expectedFound: true,
+		},
+
+		// --- Quoting and escaping ---
+		{
+			name:          "escaped double quotes",
+			grubCfg:       "set kernelopts=\"root=/dev/sda2 ro extra=\\\"a b\\\" rd.info\"\n",
+			expectedValue: "root=/dev/sda2 ro extra=\"a b\" rd.info",
+			expectedFound: true,
+		},
+		{
+			name:          "escaped backslash",
+			grubCfg:       "set kernelopts=\"a\\\\b c\"\n",
+			expectedValue: "a\\b c",
+			expectedFound: true,
+		},
+		{
+			name:          "escaped dollar sign",
+			grubCfg:       "set kernelopts=\"p=\\$v x\"\n",
+			expectedValue: "p=$v x",
+			expectedFound: true,
+		},
+		{
+			name:          "single-quoted value",
+			grubCfg:       "set kernelopts='root=/dev/sda2 ro rd.info'\n",
+			expectedValue: "root=/dev/sda2 ro rd.info",
+			expectedFound: true,
+		},
+		{
+			name:          "unquoted single-token value",
+			grubCfg:       "set kernelopts=ro\n",
+			expectedValue: "ro",
+			expectedFound: true,
+		},
+		{
+			name:          "empty quoted value",
+			grubCfg:       "set kernelopts=\"\"\n",
+			expectedValue: "",
+			expectedFound: true,
+		},
+		{
+			// A value containing an unresolved variable cannot be reproduced statically, so it comes back empty
+			// (and findGrubCfgKernelopts logs a warning).
+			name:          "value with a variable expansion",
+			grubCfg:       "set kernelopts=\"root=$root ro\"\n",
+			expectedValue: "",
+			expectedFound: true,
+		},
+
+		// --- Matching by argument name, not substring ---
+		{
+			name:          "decoy set whose value contains kernelopts=, plus the real one",
+			grubCfg:       "set extra=\"kernelopts=bogus\"\nset kernelopts=\"root=real ro\"\n",
+			expectedValue: "root=real ro",
+			expectedFound: true,
+		},
+		{
+			name:          "only a decoy whose value contains kernelopts=",
+			grubCfg:       "set extra=\"kernelopts=bogus\"\n",
+			expectedValue: "",
+			expectedFound: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			value, found, err := findGrubCfgKernelopts(tc.grubCfg)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expectedFound, found)
+			assert.Equal(t, tc.expectedValue, value)
+		})
+	}
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/grubcfgutils_test.go
@@ -122,6 +122,7 @@ func TestFindGrubCfgKernelopts(t *testing.T) {
 		grubCfg       string
 		expectedValue string
 		expectedFound bool
+		expectError   bool
 	}{
 		// --- Basic extraction ---
 		{
@@ -199,12 +200,11 @@ func TestFindGrubCfgKernelopts(t *testing.T) {
 			expectedFound: true,
 		},
 		{
-			// A value containing an unresolved variable cannot be reproduced statically, so it comes back empty
-			// (and findGrubCfgKernelopts logs a warning).
-			name:          "value with a variable expansion",
-			grubCfg:       "set kernelopts=\"root=$root ro\"\n",
-			expectedValue: "",
-			expectedFound: true,
+			// A value containing an unresolved variable cannot be reproduced statically, so it is an error rather
+			// than silently dropping the kernel command line.
+			name:        "value with a variable expansion",
+			grubCfg:     "set kernelopts=\"root=$root ro\"\n",
+			expectError: true,
 		},
 
 		// --- Matching by argument name, not substring ---
@@ -225,6 +225,10 @@ func TestFindGrubCfgKernelopts(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			value, found, err := findGrubCfgKernelopts(tc.grubCfg)
+			if tc.expectError {
+				assert.Error(t, err)
+				return
+			}
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedFound, found)
 			assert.Equal(t, tc.expectedValue, value)

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/uki-noreset-amd64-azl4.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/uki-noreset-amd64-azl4.yaml
@@ -1,0 +1,22 @@
+# Differs from uki-noreset-azl3 in its use of systemd-boot-unsigned (not systemd-boot) and grub2-efi-x64 (not
+# grub2-efi-binary).
+previewFeatures:
+- base-configs
+
+baseConfigs:
+- path: uki-noreset-base.yaml
+
+os:
+  packages:
+    install:
+    - systemd-boot-unsigned
+
+scripts:
+  postCustomization:
+  - content: |
+      # Workaround: shim-<arch> 15.8 has a hard Requires on grub2-efi-<arch>, so dnf
+      # refuses to remove grub2-efi-<arch> while shim is installed. Removing shim
+      # is not an option because shim is needed for the secure boot chain
+      # (UEFI -> shim -> systemd-boot -> kernel) and its EFI binaries on the ESP
+      # are extracted as build artifacts. Use rpm --nodeps to bypass this.
+      rpm -e --nodeps grub2-efi-x64

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/uki-noreset-arm64-azl4.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/uki-noreset-arm64-azl4.yaml
@@ -1,0 +1,22 @@
+# Differs from uki-noreset-azl3 in its use of systemd-boot-unsigned (not systemd-boot) and grub2-efi-aa64 (not
+# grub2-efi-binary).
+previewFeatures:
+- base-configs
+
+baseConfigs:
+- path: uki-noreset-base.yaml
+
+os:
+  packages:
+    install:
+    - systemd-boot-unsigned
+
+scripts:
+  postCustomization:
+  - content: |
+      # Workaround: shim-<arch> 15.8 has a hard Requires on grub2-efi-<arch>, so dnf
+      # refuses to remove grub2-efi-<arch> while shim is installed. Removing shim
+      # is not an option because shim is needed for the secure boot chain
+      # (UEFI -> shim -> systemd-boot -> kernel) and its EFI binaries on the ESP
+      # are extracted as build artifacts. Use rpm --nodeps to bypass this.
+      rpm -e --nodeps grub2-efi-aa64

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/uki-noreset-azl3.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/uki-noreset-azl3.yaml
@@ -1,0 +1,13 @@
+previewFeatures:
+- base-configs
+
+baseConfigs:
+- path: uki-noreset-base.yaml
+
+os:
+  packages:
+    remove:
+    - grub2-efi-binary
+
+    install:
+    - systemd-boot

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/uki-noreset-base.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/uki-noreset-base.yaml
@@ -1,0 +1,10 @@
+previewFeatures:
+- uki
+
+os:
+  kernelCommandLine:
+    extraCommandLine:
+    - rd.info
+
+  uki:
+    mode: create

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-reinit-bootloader-reset.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-reinit-bootloader-reset.yaml
@@ -10,7 +10,7 @@ os:
 
   kernelCommandLine:
     extraCommandLine:
-    - "rd.info"
+    - "rd.debug"
 
   additionalFiles:
   - content: |

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-reinit-root-hard-reset.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-reinit-root-hard-reset.yaml
@@ -8,8 +8,14 @@ storage:
 os:
   bootloader:
     resetType: hard-reset
+
+  kernelCommandLine:
+    extraCommandLine:
+    - "rd.debug"
+
   uki:
     mode: create
+
   additionalFiles:
   - content: |
       cat, dog, elephant, squirrel

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-reinit-usr-uki.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-reinit-usr-uki.yaml
@@ -8,7 +8,7 @@ storage:
 os:
   kernelCommandLine:
     extraCommandLine:
-    - rd.info
+    - rd.debug
 
   bootloader:
     resetType: hard-reset

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-inline-uki-base.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/verity-usr-inline-uki-base.yaml
@@ -63,7 +63,7 @@ os:
   kernelCommandLine:
     extraCommandLine:
     - rd.info
-    - rd.debug
+    - console=ttyAMA0,115200n8
 
   uki:
     mode: create


### PR DESCRIPTION
When re-customizing a UKI image with `os.bootloader.resetType: hard-reset` and `os.uki.mode: create`, the kernel command line was not reset to the stock image. Arguments added by a previous customization (such as `rd.info`) leaked into the regenerated UKIs, and newly requested `os.kernelCommandLine.extraCommandLine` arguments (such as `rd.debug`) were dropped. This is a regression from #844.

## Fix

- **customizeos.go** — on a hard-reset, skip pre-seeding `uki-kernel-info.json` with the base image's current UKI command line. Pre-seeding carried the old command line through the reset.
- **customizeuki.go** — `extractKernelToArgs` now reads the kernel command line only from the regenerated grub boot config. It no longer falls back to the stale command line embedded in the existing UKIs.
- **grubcfgutils.go / distrohandler_azurelinux4.go / distrohandler_fedora.go** — for BLS-based distros (Azure Linux 4, Fedora), read the command line from `loader/entries/*.conf` and fall back to the `set kernelopts="..."` default that `grub2-mkconfig` writes into `grub.cfg`. That is where a hard-reset lands the regenerated command line on those distros.

## Behavior

Re-customizing a UKI image that previously added `rd.info`, now with hard-reset plus `extraCommandLine: [rd.debug]`:

| Kernel command-line arg | Before | After |
| --- | --- | --- |
| `rd.info` (prior customization) | kept (leaked) | dropped (reset to stock) |
| `rd.debug` (new extraCommandLine) | dropped | added |

## Tests

Added `TestCustomizeImageUkiCreateNoBootloaderReset` and reworked the verity UKI and grub tests to assert the reset command line — each expected arg present in every kernel, each dropped arg absent — across Azure Linux 3, Azure Linux 4, and the non-hard-reset create path.

---

### **Checklist**
- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines