### PR TITLE
test(cosi): validate emitted metadata against Trident COSI schema

### DIFF
--- a/.github/workflows/binary-build.yml
+++ b/.github/workflows/binary-build.yml
@@ -208,7 +208,7 @@ jobs:
       env:
         ARCH: ${{ inputs.arch }}
 
-    - name: Run imagecustomizerapi tests
+    - name: Run imagecustomizerapi and cosiapi tests
       run: |
         set -euxo pipefail
 
@@ -220,6 +220,7 @@ jobs:
         go test -v \
           -coverprofile="$TEST_RESULTS_DIR/api.cov" -covermode count \
           ./imagecustomizerapi \
+          ./cosiapi \
           2>&1 \
           | tee "$TEST_RESULTS_DIR/api.txt"
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/moby/sys/mountinfo v0.7.2
 	github.com/notaryproject/notation-go v1.3.2
 	github.com/opencontainers/image-spec v1.1.1
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/sirupsen/logrus v1.9.4
 	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/contrib/exporters/autoexport v0.69.0

--- a/go.sum
+++ b/go.sum
@@ -26,6 +26,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
+github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
 github.com/fxamacker/cbor/v2 v2.8.0 h1:fFtUGXUzXPHTIUdne5+zzMPTfffl3RD5qYnkY40vtxU=
 github.com/fxamacker/cbor/v2 v2.8.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/go-asn1-ber/asn1-ber v1.5.7 h1:DTX+lbVTWaTw1hQ+PbZPlnDZPEIs0SS/GCZAl535dDk=
@@ -111,6 +113,8 @@ github.com/prometheus/procfs v0.20.1 h1:XwbrGOIplXW/AU3YhIhLODXMJYyC1isLFfYCsTEy
 github.com/prometheus/procfs v0.20.1/go.mod h1:o9EMBZGRyvDrSPH1RqdxhojkuXstoe4UlK79eF5TGGo=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/toolkit/tools/cosiapi/cosimetadata_schema_test.go
+++ b/toolkit/tools/cosiapi/cosimetadata_schema_test.go
@@ -1,0 +1,256 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// This test guards the COSI metadata that Image Customizer emits against the
+// JSON Schema published by Trident (the downstream consumer). If a change to
+// the cosiapi types drifts the emitted metadata.json away from the contract
+// Trident expects, this test fails in IC's own CI, so the break is caught here
+// rather than downstream when Trident picks up a new IC build.
+//
+// The schema is fetched live from the Trident repository at test time so the
+// test always validates against the current contract (rather than a vendored
+// snapshot that can silently go stale). This means the test requires network
+// access to raw.githubusercontent.com.
+
+package cosiapi
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// cosiSchemaURL is the canonical location of the COSI metadata JSON Schema,
+// authored and maintained in the Trident repository (matches the schema's
+// own "$id").
+const cosiSchemaURL = "https://raw.githubusercontent.com/microsoft/trident/main/docs/Reference/Composable-OS-Image/cosi-metadata-v1.2.schema.json"
+
+// sampleSha384 is a syntactically valid 96-hex-character SHA-384 digest.
+var sampleSha384 = strings.Repeat("a", 96)
+
+// fetchCosiSchemaBytes downloads the COSI schema, retrying a few times to ride
+// out transient network blips.
+func fetchCosiSchemaBytes(t *testing.T) []byte {
+	t.Helper()
+
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	var lastErr error
+	for attempt := 1; attempt <= 3; attempt++ {
+		body, err := func() ([]byte, error) {
+			resp, err := client.Get(cosiSchemaURL)
+			if err != nil {
+				return nil, err
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != http.StatusOK {
+				return nil, fmt.Errorf("unexpected status %s", resp.Status)
+			}
+			return io.ReadAll(resp.Body)
+		}()
+		if err == nil {
+			return body
+		}
+
+		lastErr = err
+		if attempt < 3 {
+			time.Sleep(time.Duration(attempt) * time.Second)
+		}
+	}
+
+	require.NoError(t, lastErr, "fetching COSI schema from %s", cosiSchemaURL)
+	return nil
+}
+
+func loadCosiSchema(t *testing.T) *jsonschema.Schema {
+	t.Helper()
+
+	schemaBytes := fetchCosiSchemaBytes(t)
+
+	schemaDoc, err := jsonschema.UnmarshalJSON(bytes.NewReader(schemaBytes))
+	require.NoError(t, err, "parsing COSI schema")
+
+	compiler := jsonschema.NewCompiler()
+	err = compiler.AddResource(cosiSchemaURL, schemaDoc)
+	require.NoError(t, err, "adding COSI schema resource")
+
+	schema, err := compiler.Compile(cosiSchemaURL)
+	require.NoError(t, err, "compiling COSI schema")
+
+	return schema
+}
+
+func validateAgainstSchema(t *testing.T, schema *jsonschema.Schema, metadata MetadataJson) {
+	t.Helper()
+
+	metadataBytes, err := json.Marshal(metadata)
+	require.NoError(t, err, "marshaling metadata")
+
+	instance, err := jsonschema.UnmarshalJSON(bytes.NewReader(metadataBytes))
+	require.NoError(t, err, "re-parsing marshaled metadata")
+
+	err = schema.Validate(instance)
+	if err != nil {
+		t.Errorf("emitted COSI metadata.json does not satisfy the Trident COSI schema "+
+			"(%s). The cosiapi types have drifted from the contract Trident consumes; "+
+			"update the types to match the current schema.\nmetadata:\n%s\nvalidation error:\n%v",
+			cosiSchemaURL, string(metadataBytes), err)
+	}
+}
+
+func sampleImageFile(path string) ImageFile {
+	return ImageFile{
+		Path:             path,
+		CompressedSize:   1024,
+		UncompressedSize: 4096,
+		Sha384:           sampleSha384,
+	}
+}
+
+// grubImageMetadata is a representative COSI for a GRUB-booted image with a
+// dm-verity-sealed root filesystem.
+func grubImageMetadata() MetadataJson {
+	partition1 := 1
+	partition2 := 2
+	hashOffset := uint64(536870912)
+
+	return MetadataJson{
+		Version:   "1.2",
+		OsArch:    "x86_64",
+		OsRelease: "NAME=\"Microsoft Azure Linux\"\nVERSION=\"3.0\"\n",
+		Id:        "6f3b1c2a-4d5e-6f70-8192-a3b4c5d6e7f8",
+		Disk: Disk{
+			Size:    4294967296,
+			Type:    DiskTypeGpt,
+			LbaSize: 512,
+			GptRegions: []GptDiskRegion{
+				{Image: sampleImageFile("images/gpt.raw.zst"), Type: RegionTypePrimaryGpt},
+				{Image: sampleImageFile("images/esp.raw.zst"), Type: RegionTypePartition, Number: &partition1},
+				{Image: sampleImageFile("images/root.raw.zst"), Type: RegionTypePartition, Number: &partition2},
+			},
+		},
+		Images: []FileSystem{
+			{
+				Image:      sampleImageFile("images/esp.raw.zst"),
+				MountPoint: "/boot/efi",
+				FsType:     "vfat",
+				FsUuid:     "C3D4-250D",
+				PartType:   "c12a7328-f81f-11d2-ba4b-00a0c93ec93b",
+			},
+			{
+				Image:      sampleImageFile("images/root.raw.zst"),
+				MountPoint: "/",
+				FsType:     "ext4",
+				FsUuid:     "11111111-2222-3333-4444-555555555555",
+				PartType:   "0fc63daf-8483-4772-8e79-3d69d8477de4",
+				Verity: &VerityConfig{
+					Image:      sampleImageFile("images/root-hash.raw.zst"),
+					Roothash:   sampleSha384,
+					HashOffset: &hashOffset,
+				},
+			},
+		},
+		Bootloader: Bootloader{Type: BootloaderTypeGrub},
+		OsPackages: []OsPackage{
+			{Name: "kernel", Version: "6.6.2", Release: "1.azl3", Arch: "x86_64"},
+			{Name: "systemd", Version: "255", Release: "6.azl3", Arch: "x86_64"},
+		},
+		Compression: Compression{MaxWindowLog: 27},
+	}
+}
+
+// systemdBootImageMetadata is a representative COSI for a systemd-boot image
+// booting a standalone UKI.
+func systemdBootImageMetadata() MetadataJson {
+	partition1 := 1
+
+	return MetadataJson{
+		Version:   "1.2",
+		OsArch:    "aarch64",
+		OsRelease: "NAME=\"Microsoft Azure Linux\"\nVERSION=\"3.0\"\n",
+		Id:        "1a2b3c4d-5e6f-7081-9203-a4b5c6d7e8f9",
+		Disk: Disk{
+			Size:    2147483648,
+			Type:    DiskTypeGpt,
+			LbaSize: 4096,
+			GptRegions: []GptDiskRegion{
+				{Image: sampleImageFile("images/gpt.raw.zst"), Type: RegionTypePrimaryGpt},
+				{Image: sampleImageFile("images/esp.raw.zst"), Type: RegionTypePartition, Number: &partition1},
+			},
+		},
+		Images: []FileSystem{
+			{
+				Image:      sampleImageFile("images/esp.raw.zst"),
+				MountPoint: "/boot/efi",
+				FsType:     "vfat",
+				FsUuid:     "A1B2-C3D4",
+				PartType:   "c12a7328-f81f-11d2-ba4b-00a0c93ec93b",
+			},
+		},
+		Bootloader: Bootloader{
+			Type: BootloaderTypeSystemdBoot,
+			SystemdBoot: &SystemDBoot{
+				Entries: []SystemDBootEntry{
+					{
+						Type:    SystemDBootEntryTypeUKIStandalone,
+						Path:    "/EFI/Linux/azl-6.6.2.efi",
+						Cmdline: "root=PARTUUID=... rw quiet",
+						Kernel:  "6.6.2-1.azl3",
+					},
+				},
+			},
+		},
+		OsPackages:  []OsPackage{},
+		Compression: Compression{MaxWindowLog: 31},
+	}
+}
+
+// TestMetadataJsonMatchesTridentSchema validates that representative COSI
+// metadata produced from the cosiapi types conforms to the Trident-authored
+// COSI JSON Schema. Requires network access (fetches the schema from Trident).
+func TestMetadataJsonMatchesTridentSchema(t *testing.T) {
+	schema := loadCosiSchema(t)
+
+	testCases := map[string]MetadataJson{
+		"grub-with-verity": grubImageMetadata(),
+		"systemd-boot-uki": systemdBootImageMetadata(),
+	}
+
+	for name, metadata := range testCases {
+		t.Run(name, func(t *testing.T) {
+			validateAgainstSchema(t, schema, metadata)
+		})
+	}
+}
+
+// TestCosiSchemaTargetsExpectedVersion is a tripwire: if Trident bumps the COSI
+// revision, the version constant emitted by IC (cosicommon.go sets
+// MetadataJson.Version) must be updated to match.
+func TestCosiSchemaTargetsExpectedVersion(t *testing.T) {
+	schema := loadCosiSchema(t)
+
+	// A metadata document declaring the version IC currently emits must validate.
+	metadata := grubImageMetadata()
+	metadata.Version = "1.2"
+	validateAgainstSchema(t, schema, metadata)
+
+	// A metadata document declaring a different version must NOT validate,
+	// confirming the schema still pins version 1.2.
+	metadata.Version = "9.9"
+	metadataBytes, err := json.Marshal(metadata)
+	require.NoError(t, err)
+	instance, err := jsonschema.UnmarshalJSON(bytes.NewReader(metadataBytes))
+	require.NoError(t, err)
+	assert.Error(t, schema.Validate(instance),
+		"schema should pin metadata version 1.2; a 9.9 document unexpectedly validated")
+}


### PR DESCRIPTION
## What

Adds a unit test that validates the COSI `metadata.json` Image Customizer emits against the JSON Schema authored in the Trident repo (the downstream consumer of COSI images).

Image Customizer emits COSI metadata that Trident consumes. Today, when IC changes the metadata shape, Trident is the first to notice, often only after picking up a new IC build in preview/release. This test moves that detection **upstream into IC's own CI**, so schema-breaking drift fails in the IC PR that introduces it.

## How

- New `toolkit/tools/cosiapi/cosimetadata_schema_test.go`:
  - Fetches the schema **live** from the Trident source of truth (`raw.githubusercontent.com/microsoft/trident/main/docs/Reference/Composable-OS-Image/cosi-metadata-v1.2.schema.json`), so validation always runs against the current contract rather than a snapshot that can go stale.
  - Builds representative COSI metadata from the `cosiapi` types (GRUB + dm-verity, and systemd-boot + UKI) and validates each against the schema.
  - Includes a version tripwire: if Trident bumps the COSI revision, the `Version` constant IC emits (`cosicommon.go`) must be updated to match.
- Adds `github.com/santhosh-tekuri/jsonschema/v6` (JSON Schema draft 2020-12 validator).
- Runs `./cosiapi` in the existing hermetic unit-test job (`binary-build.yml`); the package was not covered by CI before.

## Dependency / why draft

The test fetches the schema from Trident `main`, so it requires the schema to be present there. It is currently in **microsoft/trident#714** (`docs(cosi): add JSON Schema for COSI metadata v1.2`), not yet merged. **This PR stays draft until #714 lands on Trident main**; until then the `./cosiapi` job will fail with a 404.

Requires network access to `raw.githubusercontent.com` during `go test`.