### PR TITLE
Ignore `go test -c` output binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ out/
 
 *.tmp
 
+# Go
+*.test
+
 # Python
 __pycache__/
 *.py[cod]

--- a/toolkit/tools/internal/grub/tokentests/.gitignore
+++ b/toolkit/tools/internal/grub/tokentests/.gitignore
@@ -1,1 +1,4 @@
 actual/
+
+# These are test input fixtures, not `go test -c` binaries.
+!*.test


### PR DESCRIPTION
Ignores the `<package>.test` binaries that `go test -c` leaves behind.

The `!*.test` negation is needed because `toolkit/tools/internal/grub/tokentests/` tracks `*.test` files that are grub tokenizer fixtures, not Go binaries.

### Checklist
- [ ] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
