### PR TITLE
Update zizmor.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,8 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/workflows/binary-build.yml
+++ b/.github/workflows/binary-build.yml
@@ -131,10 +131,10 @@ jobs:
 
         sudo ./repo/.github/workflows/scripts/retry.sh 5 5 \
           curl -sSLo zizmor-x86_64-unknown-linux-gnu.tar.gz \
-            https://github.com/zizmorcore/zizmor/releases/download/v1.12.1/zizmor-x86_64-unknown-linux-gnu.tar.gz
+            https://github.com/zizmorcore/zizmor/releases/download/v1.29.0/zizmor-x86_64-unknown-linux-gnu.tar.gz
 
         tarHash="$(sha256sum zizmor-x86_64-unknown-linux-gnu.tar.gz | cut -d ' ' -f 1)"
-        if [ "$tarHash" != "d73cd379078cae18d5439ce1f8716d30de5a4d2d29cac62cfbe01e6a8251fe0e" ]; then
+        if [ "$tarHash" != "dd96df044a6e8538d5f423790f453bdd03d49e5b2bcc38214acc41a2f1297839" ]; then
           echo "Bad zizmor tarball"
           exit 1
         fi


### PR DESCRIPTION
PR #863 recently pinned all the GitHub actions, even those owned by GitHub.

The zizmor tool is used to prevent bad practices in GitHub actions. Updating zizmor ensures that the changes made in PR #863 are enforced going forwards.

The zizmor update included a new error that requires golang package update cooldowns be set to >=7 days. So, this change also fixes that.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
