### PR TITLE
Fix ACL mount dirs dir overlay.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/imageutils.go
@@ -110,7 +110,7 @@ func connectToExistingImageHelper(imageConnection *imageconnection.ImageConnecti
 	}
 
 	mountPoints, readonlyPartUuids, tempDirectories, err := partitionLayoutToMountPoints(partitionsLayout, partitions,
-		readonly, readOnlyVerity, distroHandler, buildDir, includeDefaultMounts)
+		readonly, readOnlyVerity, distroHandler, buildDir, includeDefaultMounts, mountPath)
 	if err != nil {
 		return nil, nil, nil, nil, fmt.Errorf("failed to find mount info for disk:\n%w", err)
 	}
@@ -166,7 +166,7 @@ func reconnectToExistingImageHelper(imageFilePath string, buildDir string, mount
 	}
 
 	mountPoints, readonlyPartUuids, tempDirectories, err := partitionLayoutToMountPoints(partitionsLayout, partitions,
-		readonly, readOnlyVerity, distroHandler, buildDir, includeDefaultMounts)
+		readonly, readOnlyVerity, distroHandler, buildDir, includeDefaultMounts, mountPath)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to find mount info for disk:\n%w", err)
 	}
@@ -382,8 +382,10 @@ func createImageBoilerplate(distroHandler DistroHandler, imageConnection *imagec
 		return nil, "", fmt.Errorf("failed to discover partitions from fstab entries:\n%w", err)
 	}
 
+	imageChrootDir := filepath.Join(buildDir, chrootDirName)
+
 	mountPoints, _, tempDirectories, err := partitionLayoutToMountPoints(partitionsLayout, diskPartitions, false, false,
-		distroHandler, buildDir, false)
+		distroHandler, buildDir, false, imageChrootDir)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to find mount info for disk:\n%w", err)
 	}
@@ -391,8 +393,6 @@ func createImageBoilerplate(distroHandler DistroHandler, imageConnection *imagec
 	imageConnection.AddOwnedDirectories(tempDirectories...)
 
 	// Create chroot environment.
-	imageChrootDir := filepath.Join(buildDir, chrootDirName)
-
 	err = imageConnection.ConnectChroot(imageChrootDir, false, nil, mountPoints, false)
 	if err != nil {
 		return nil, "", err

--- a/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
@@ -679,7 +679,7 @@ func createMountsDirOverlay(buildDir string, includeDefaultMounts bool, layout [
 
 	// Overlay the ACL root on top of the special directories directory.
 	mountPoint := safechroot.NewPreDefaultsMountPoint("overlay", "/", "overlay", unix.MS_RDONLY,
-		fmt.Sprintf("lowerdir=%s:%s", mountDirsDir, rootMountPoint))
+		fmt.Sprintf("lowerdir=%s:%s", rootMountPoint, mountDirsDir))
 
 	ok = true
 	return mountPoint, mountDirsDir, nil

--- a/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/partitionutils.go
@@ -540,6 +540,7 @@ func discoverPartitionLayout(fstabEntries []diskutils.FstabEntry, diskPartitions
 
 func partitionLayoutToMountPoints(layout []fstabEntryPartNum, diskPartitions []diskutils.PartitionInfo,
 	readonly bool, readOnlyVerity bool, distroHandler DistroHandler, buildDir string, includeDefaultMounts bool,
+	rootMountPoint string,
 ) ([]*safechroot.MountPoint, []string, []string, error) {
 	// Convert fstab entries into mount points.
 	var mountPoints []*safechroot.MountPoint
@@ -604,7 +605,8 @@ func partitionLayoutToMountPoints(layout []fstabEntryPartNum, diskPartitions []d
 			mountPoints = append(mountPoints, mountPoint)
 
 			if setReadOnly && distroHandler.RootMissingMountDirectories() {
-				mountPoint, tempDir, err := createMountsDirOverlay(buildDir, includeDefaultMounts, layout)
+				mountPoint, tempDir, err := createMountsDirOverlay(buildDir, includeDefaultMounts, layout,
+					rootMountPoint)
 				if err != nil {
 					return nil, nil, nil, err
 				}
@@ -634,6 +636,7 @@ func partitionLayoutToMountPoints(layout []fstabEntryPartNum, diskPartitions []d
 }
 
 func createMountsDirOverlay(buildDir string, includeDefaultMounts bool, layout []fstabEntryPartNum,
+	rootMountPoint string,
 ) (*safechroot.MountPoint, string, error) {
 	// The Azure Container Linux image doesn't create empty directories for some of the standard Linux
 	// mounts (e.g. /dev) or even its own mounts (e.g. /oem). So, when mounting as read-only, we have to
@@ -676,7 +679,7 @@ func createMountsDirOverlay(buildDir string, includeDefaultMounts bool, layout [
 
 	// Overlay the ACL root on top of the special directories directory.
 	mountPoint := safechroot.NewPreDefaultsMountPoint("overlay", "/", "overlay", unix.MS_RDONLY,
-		fmt.Sprintf("lowerdir=%s:/", mountDirsDir))
+		fmt.Sprintf("lowerdir=%s:%s", mountDirsDir, rootMountPoint))
 
 	ok = true
 	return mountPoint, mountDirsDir, nil


### PR DESCRIPTION
The ACL image doesn't create placeholder directories for special directories (e.g. `/dev`). In PR #771, a workaround was added when mounting the image as read-only that creates an overlay that holds placeholder directories for the special directories. However, this change accidentally messed up the overlay settings so that the host root directory was used instead of the customization OS's root directory.