### PR TITLE
Split ACL's UKI cmdline addon into persistent and first-boot addons in create mode.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/aclukiaddon.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/aclukiaddon.go
@@ -1,0 +1,90 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerlib
+
+import (
+	"fmt"
+
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/grub"
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/internal/logger"
+)
+
+var (
+	ErrAclUkiAddonSplit = NewImageCustomizerError("AclUkiAddon:Split",
+		"failed to split kernel command line into ACL UKI addons")
+	ErrAclUkiAddonEmptyPersistentCmdline = NewImageCustomizerError("AclUkiAddon:EmptyPersistentCmdline",
+		"kernel command line has no persistent arguments")
+)
+
+const (
+	// The kernel argument that makes ACL run its first-boot provisioning.
+	aclFirstBootArg = "flatcar.first_boot=detected"
+
+	// Name of the transient addon that carries only aclFirstBootArg.
+	aclFirstBootAddonName = "firstboot.addon.efi"
+)
+
+// aclGetUkiAddonSpecs returns ACL's cmdline addon layout: a persistent <kernel>.addon.efi holding
+// every argument except aclFirstBootArg, plus a transient firstboot.addon.efi holding exactly that
+// argument. If the command line does not contain the argument, the image has already completed its
+// first boot and only the persistent addon spec is returned.
+func aclGetUkiAddonSpecs(kernel string, cmdline string) ([]UkiAddonSpec, error) {
+	persistentCmdline, hasFirstBootArg, err := aclStripFirstBootArg(cmdline)
+	if err != nil {
+		return nil, fmt.Errorf("%w:\n%w", ErrAclUkiAddonSplit, err)
+	}
+
+	if persistentCmdline == "" {
+		return nil, fmt.Errorf("%w (kernel='%s', cmdline='%s')", ErrAclUkiAddonEmptyPersistentCmdline, kernel, cmdline)
+	}
+
+	specs := []UkiAddonSpec{
+		{FileName: ukiAddonFileName(kernel), Cmdline: persistentCmdline},
+	}
+
+	if !hasFirstBootArg {
+		logger.Log.Infof("Kernel (%s) command line has no (%s); not adding a first-boot addon", kernel,
+			aclFirstBootArg)
+		return specs, nil
+	}
+
+	specs = append(specs, UkiAddonSpec{
+		FileName: aclFirstBootAddonName,
+		Cmdline:  aclFirstBootArg,
+	})
+	return specs, nil
+}
+
+// aclStripFirstBootArg removes every occurrence of aclFirstBootArg from cmdline and reports
+// whether any was present.
+func aclStripFirstBootArg(cmdline string) (string, bool, error) {
+	tokens, err := grub.TokenizeConfig(cmdline)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to tokenize kernel command line:\n%w", err)
+	}
+
+	args, err := ParseCommandLineArgs(tokens)
+	if err != nil {
+		return "", false, fmt.Errorf("failed to parse kernel command-line args:\n%w", err)
+	}
+
+	hasFirstBootArg := false
+	persistentArgs := []string(nil)
+	for _, arg := range args {
+		if arg.ValueHasVarExpansion {
+			// The parsed form of an arg with a variable expansion is truncated at the expansion, so
+			// the arg cannot be rewritten faithfully.
+			return "", false, fmt.Errorf("kernel command-line arg (%s) contains a variable expansion", arg.Arg)
+		}
+
+		if arg.Arg == aclFirstBootArg {
+			hasFirstBootArg = true
+			continue
+		}
+
+		persistentArgs = append(persistentArgs, arg.Arg)
+	}
+
+	return GrubArgsToString(persistentArgs), hasFirstBootArg, nil
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/aclukiaddon_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/aclukiaddon_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+package imagecustomizerlib
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAclGetUkiAddonSpecs(t *testing.T) {
+	tests := []struct {
+		name              string
+		cmdline           string
+		expectedSpecs     []UkiAddonSpec
+		expectedErr       error
+		expectedErrSubstr string
+	}{
+		{
+			name:    "first-boot arg in the middle",
+			cmdline: "console=tty0 flatcar.first_boot=detected root=/dev/sda",
+			expectedSpecs: []UkiAddonSpec{
+				{FileName: "vmlinuz-6.6.92.2-2.azl3.addon.efi", Cmdline: "console=tty0 root=/dev/sda"},
+				{FileName: "firstboot.addon.efi", Cmdline: "flatcar.first_boot=detected"},
+			},
+		},
+		{
+			name:    "duplicated first-boot args (first, last, adjacent)",
+			cmdline: "flatcar.first_boot=detected console=tty0 flatcar.first_boot=detected flatcar.first_boot=detected",
+			expectedSpecs: []UkiAddonSpec{
+				{FileName: "vmlinuz-6.6.92.2-2.azl3.addon.efi", Cmdline: "console=tty0"},
+				{FileName: "firstboot.addon.efi", Cmdline: "flatcar.first_boot=detected"},
+			},
+		},
+		{
+			name:    "no first-boot arg (already-booted image)",
+			cmdline: "console=tty0 root=/dev/sda",
+			expectedSpecs: []UkiAddonSpec{
+				{FileName: "vmlinuz-6.6.92.2-2.azl3.addon.efi", Cmdline: "console=tty0 root=/dev/sda"},
+			},
+		},
+		{
+			name:    "extra whitespace collapsed",
+			cmdline: "console=ttyS0,115200n8   flatcar.first_boot=detected  flatcar.oem.id=azure",
+			expectedSpecs: []UkiAddonSpec{
+				{FileName: "vmlinuz-6.6.92.2-2.azl3.addon.efi", Cmdline: "console=ttyS0,115200n8 flatcar.oem.id=azure"},
+				{FileName: "firstboot.addon.efi", Cmdline: "flatcar.first_boot=detected"},
+			},
+		},
+		{
+			name: "similar args preserved",
+			cmdline: "myflatcar.first_boot=detected flatcar.first_boot=1 flatcar.first_boot=detected2 " +
+				"flatcar.first_boot=detected",
+			expectedSpecs: []UkiAddonSpec{
+				{
+					FileName: "vmlinuz-6.6.92.2-2.azl3.addon.efi",
+					Cmdline:  "myflatcar.first_boot=detected flatcar.first_boot=1 flatcar.first_boot=detected2",
+				},
+				{FileName: "firstboot.addon.efi", Cmdline: "flatcar.first_boot=detected"},
+			},
+		},
+		{
+			name:        "first-boot arg only",
+			cmdline:     "flatcar.first_boot=detected",
+			expectedErr: ErrAclUkiAddonEmptyPersistentCmdline,
+		},
+		{
+			name:              "variable expansion",
+			cmdline:           "console=tty0 foo=$bar flatcar.first_boot=detected",
+			expectedErr:       ErrAclUkiAddonSplit,
+			expectedErrSubstr: "variable expansion",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			specs, err := aclGetUkiAddonSpecs("vmlinuz-6.6.92.2-2.azl3", tt.cmdline)
+			if tt.expectedErr != nil {
+				assert.ErrorIs(t, err, tt.expectedErr)
+				if tt.expectedErrSubstr != "" {
+					assert.ErrorContains(t, err, tt.expectedErrSubstr)
+				}
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.expectedSpecs, specs)
+		})
+	}
+}
+
+// TestAclGetUkiAddonSpecsRoundTrip verifies that re-customization converges: the addons merge back
+// in file-name order with the first-boot arg first, and re-splitting that cmdline yields identical
+// specs.
+func TestAclGetUkiAddonSpecsRoundTrip(t *testing.T) {
+	kernel := "vmlinuz-6.6.92.2-2.azl3"
+
+	specs, err := aclGetUkiAddonSpecs(kernel, "console=tty0 flatcar.first_boot=detected root=/dev/sda")
+	assert.NoError(t, err)
+	assert.Len(t, specs, 2)
+
+	respecs, err := aclGetUkiAddonSpecs(kernel, "flatcar.first_boot=detected console=tty0 root=/dev/sda")
+	assert.NoError(t, err)
+	assert.Equal(t, specs, respecs)
+
+	bootedSpecs, err := aclGetUkiAddonSpecs(kernel, "console=tty0 root=/dev/sda")
+	assert.NoError(t, err)
+	assert.Equal(t, specs[:1], bootedSpecs)
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki.go
@@ -61,6 +61,17 @@ type UkiKernelInfo struct {
 	Initramfs string `json:"initramfs,omitempty"` // Optional: empty in modify mode
 }
 
+// UkiAddonSpec describes one cmdline addon file to write for a UKI in create mode.
+type UkiAddonSpec struct {
+	FileName string
+	Cmdline  string
+}
+
+// ukiAddonFileName returns the name of the IC-managed cmdline addon for a kernel.
+func ukiAddonFileName(kernel string) string {
+	return fmt.Sprintf("%s.addon.efi", kernel)
+}
+
 func baseImageHasUkis(imageChroot *safechroot.Chroot, distroHandler DistroHandler) (bool, error) {
 	espDir := filepath.Join(imageChroot.RootDir(), distroHandler.GetEspDir())
 	ukiFiles, err := getUkiFiles(espDir)
@@ -184,6 +195,14 @@ func defaultExtractUkiAddonCmdline(addonFilePath string, buildDir string) (strin
 	return extractCmdlineFromSinglePE(addonFilePath, buildDir)
 }
 
+// defaultGetUkiAddonSpecs returns the standard layout: a single addon per kernel holding the full
+// command line.
+func defaultGetUkiAddonSpecs(kernel string, cmdline string) ([]UkiAddonSpec, error) {
+	return []UkiAddonSpec{
+		{FileName: ukiAddonFileName(kernel), Cmdline: cmdline},
+	}, nil
+}
+
 // extractAndSaveUkiCmdline extracts the kernel cmdline from existing UKI addons and saves them to uki-kernel-info.json.
 func extractAndSaveUkiCmdline(buildDir string, imageChroot *safechroot.Chroot, distroHandler DistroHandler) error {
 	espDir := filepath.Join(imageChroot.RootDir(), distroHandler.GetEspDir())
@@ -202,7 +221,7 @@ func extractAndSaveUkiCmdline(buildDir string, imageChroot *safechroot.Chroot, d
 		ukiFileName := filepath.Base(ukiFile)
 		kernelName := strings.TrimSuffix(ukiFileName, ".efi")
 		addonDirPath := filepath.Join(filepath.Dir(ukiFile), fmt.Sprintf("%s.extra.d", ukiFileName))
-		addonFilePath := filepath.Join(addonDirPath, fmt.Sprintf("%s.addon.efi", kernelName))
+		addonFilePath := filepath.Join(addonDirPath, ukiAddonFileName(kernelName))
 
 		cmdline, err := distroHandler.ExtractUkiAddonCmdline(addonFilePath, buildDir)
 		if err != nil {
@@ -703,7 +722,7 @@ func modifyUkiAddon(ukiFilePath string, stubPath string, rc *ResolvedConfig) err
 
 	// Rebuild the addon with modified cmdline
 	addonDirPath := filepath.Join(filepath.Dir(ukiFilePath), fmt.Sprintf("%s.extra.d", ukiFileName))
-	addonFullPath := filepath.Join(addonDirPath, fmt.Sprintf("%s.addon.efi", kernelName))
+	addonFullPath := filepath.Join(addonDirPath, ukiAddonFileName(kernelName))
 
 	err = os.MkdirAll(addonDirPath, os.ModePerm)
 	if err != nil {
@@ -802,7 +821,7 @@ func createUki(ctx context.Context, rc *ResolvedConfig, distroHandler DistroHand
 
 	for kernel, info := range kernelInfo {
 		err := buildUki(kernel, info.Initramfs, info.Cmdline, osSubreleaseFullPath, stubPath, addonStubPath, rc.BuildDirAbs,
-			systemBootPartitionTmpDir,
+			systemBootPartitionTmpDir, distroHandler,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to build UKI for kernel (%s):\n%w", kernel, err)
@@ -923,6 +942,7 @@ func grubKernelArgsToStringMap(kernelToArgs map[string][]grubConfigLinuxArg) map
 
 func buildUki(kernel string, initramfs string, kernelArgs string, osSubreleaseFullPath string,
 	stubPath string, addonStubPath string, buildDir string, systemBootPartitionTmpDir string,
+	distroHandler DistroHandler,
 ) error {
 	kernelVersion, err := getKernelVersion(kernel)
 	if err != nil {
@@ -935,10 +955,17 @@ func buildUki(kernel string, initramfs string, kernelArgs string, osSubreleaseFu
 		return fmt.Errorf("failed to build main UKI:\n%w", err)
 	}
 
-	// Build UKI addon
-	err = buildUkiAddon(kernel, kernelArgs, addonStubPath, systemBootPartitionTmpDir)
+	// Build UKI cmdline addons
+	addonSpecs, err := distroHandler.GetUkiAddonSpecs(kernel, kernelArgs)
 	if err != nil {
-		return fmt.Errorf("failed to build UKI addon:\n%w", err)
+		return fmt.Errorf("failed to get UKI addon specs:\n%w", err)
+	}
+
+	for _, addonSpec := range addonSpecs {
+		err = buildUkiAddon(kernel, addonSpec.FileName, addonSpec.Cmdline, addonStubPath, systemBootPartitionTmpDir)
+		if err != nil {
+			return fmt.Errorf("failed to build UKI addon (%s):\n%w", addonSpec.FileName, err)
+		}
 	}
 
 	return nil
@@ -995,7 +1022,9 @@ func buildMainUki(kernel string, initramfs string, osSubreleaseFullPath string, 
 	return nil
 }
 
-func buildUkiAddon(kernel string, kernelArgs string, stubPath string, systemBootPartitionTmpDir string) error {
+func buildUkiAddon(kernel string, addonFileName string, kernelArgs string, stubPath string,
+	systemBootPartitionTmpDir string,
+) error {
 	// Create addon directory: <uki-path>.extra.d/
 	ukiFileName := fmt.Sprintf("%s.efi", kernel)
 	ukiFullPath := filepath.Join(systemBootPartitionTmpDir, UkiOutputDir, ukiFileName)
@@ -1006,8 +1035,8 @@ func buildUkiAddon(kernel string, kernelArgs string, stubPath string, systemBoot
 		return fmt.Errorf("failed to create addon directory (%s):\n%w", addonDirPath, err)
 	}
 
-	// Addon output path: <uki-name>.extra.d/<kernel-name>.addon.efi
-	addonFullPath := filepath.Join(addonDirPath, fmt.Sprintf("%s.addon.efi", kernel))
+	// Addon output path: <uki-name>.extra.d/<addon-file-name>
+	addonFullPath := filepath.Join(addonDirPath, addonFileName)
 
 	// Build the addon.
 	ukifyCmd := []string{

--- a/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/customizeuki_test.go
@@ -1295,3 +1295,11 @@ func TestGetFallbackKernelArgs(t *testing.T) {
 		})
 	}
 }
+
+func TestDefaultGetUkiAddonSpecs(t *testing.T) {
+	specs, err := defaultGetUkiAddonSpecs("vmlinuz-6.6.92.2-2.azl3", "console=tty0 rw")
+	assert.NoError(t, err)
+	assert.Equal(t, []UkiAddonSpec{
+		{FileName: "vmlinuz-6.6.92.2-2.azl3.addon.efi", Cmdline: "console=tty0 rw"},
+	}, specs)
+}

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler.go
@@ -104,6 +104,12 @@ type DistroHandler interface {
 	// empty string; all other distros return an error.
 	ExtractUkiAddonCmdline(addonFilePath string, buildDir string) (string, error)
 
+	// GetUkiAddonSpecs returns the cmdline addon files to write for a kernel in UKI
+	// create mode. Most distros emit a single addon holding the full command
+	// line; distros with a first-boot addon contract (e.g. ACL) split the
+	// command line across multiple addons.
+	GetUkiAddonSpecs(kernel string, cmdline string) ([]UkiAddonSpec, error)
+
 	// CleanBootDirectory removes stale kernel/initramfs/UKI artifacts from /boot
 	// after kernel extraction. Distros where /boot IS the ESP (e.g. ACL) only
 	// remove kernel and initramfs files; all other entries are preserved.

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_acl.go
@@ -236,6 +236,11 @@ func (d *aclDistroHandler) ExtractUkiAddonCmdline(addonFilePath string, buildDir
 	return "", fmt.Errorf("failed to stat addon file (%s):\n%w", addonFilePath, statErr)
 }
 
+// GetUkiAddonSpecs splits the command line across ACL's persistent and first-boot addons.
+func (d *aclDistroHandler) GetUkiAddonSpecs(kernel string, cmdline string) ([]UkiAddonSpec, error) {
+	return aclGetUkiAddonSpecs(kernel, cmdline)
+}
+
 func (d *aclDistroHandler) CleanBootDirectory(imageChroot *safechroot.Chroot) error {
 	// ACL mounts the ESP directly at /boot, so /boot IS the ESP.
 	// Only remove kernel/initramfs file patterns; preserve all directories and other files.

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux.go
@@ -161,6 +161,10 @@ func (d *azureLinuxDistroHandler) ExtractUkiAddonCmdline(addonFilePath string, b
 	return defaultExtractUkiAddonCmdline(addonFilePath, buildDir)
 }
 
+func (d *azureLinuxDistroHandler) GetUkiAddonSpecs(kernel string, cmdline string) ([]UkiAddonSpec, error) {
+	return defaultGetUkiAddonSpecs(kernel, cmdline)
+}
+
 func (d *azureLinuxDistroHandler) CleanBootDirectory(imageChroot *safechroot.Chroot) error {
 	return defaultCleanBootDirectory(imageChroot, d.GetEspDir(), false)
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux4.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_azurelinux4.go
@@ -242,6 +242,10 @@ func (d *azureLinux4DistroHandler) ExtractUkiAddonCmdline(addonFilePath string, 
 	return defaultExtractUkiAddonCmdline(addonFilePath, buildDir)
 }
 
+func (d *azureLinux4DistroHandler) GetUkiAddonSpecs(kernel string, cmdline string) ([]UkiAddonSpec, error) {
+	return defaultGetUkiAddonSpecs(kernel, cmdline)
+}
+
 func (d *azureLinux4DistroHandler) CleanBootDirectory(imageChroot *safechroot.Chroot) error {
 	return defaultCleanBootDirectory(imageChroot, d.GetEspDir(), false)
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_fedora.go
@@ -250,6 +250,10 @@ func (d *fedoraDistroHandler) ExtractUkiAddonCmdline(addonFilePath string, build
 	return defaultExtractUkiAddonCmdline(addonFilePath, buildDir)
 }
 
+func (d *fedoraDistroHandler) GetUkiAddonSpecs(kernel string, cmdline string) ([]UkiAddonSpec, error) {
+	return defaultGetUkiAddonSpecs(kernel, cmdline)
+}
+
 func (d *fedoraDistroHandler) CleanBootDirectory(imageChroot *safechroot.Chroot) error {
 	return defaultCleanBootDirectory(imageChroot, d.GetEspDir(), false)
 }

--- a/toolkit/tools/pkg/imagecustomizerlib/distrohandler_ubuntu.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/distrohandler_ubuntu.go
@@ -204,6 +204,10 @@ func (d *ubuntuDistroHandler) ExtractUkiAddonCmdline(addonFilePath string, build
 	return defaultExtractUkiAddonCmdline(addonFilePath, buildDir)
 }
 
+func (d *ubuntuDistroHandler) GetUkiAddonSpecs(kernel string, cmdline string) ([]UkiAddonSpec, error) {
+	return defaultGetUkiAddonSpecs(kernel, cmdline)
+}
+
 func (d *ubuntuDistroHandler) CleanBootDirectory(imageChroot *safechroot.Chroot) error {
 	return defaultCleanBootDirectory(imageChroot, d.GetEspDir(), false)
 }


### PR DESCRIPTION
ACL images keep their kernel cmdline in two systemd-boot addons: a persistent `<kernel>.addon.efi` plus a transient `firstboot.addon.efi` holding exactly `flatcar.first_boot=detected`, which the OS deletes after the first boot so provisioning runs once. `uki: create` currently rebuilds one merged addon, so the first-boot argument becomes permanent and provisioning re-runs on every boot.

This change adds `DistroHandler.GetUkiAddonSpecs` to decide the addon set per kernel: the default returns today's single addon (non-ACL behavior unchanged); ACL returns the persistent addon without the first-boot argument (error if nothing remains) plus `firstboot.addon.efi` with exactly that argument, and skips the first-boot addon when the incoming cmdline lacks the argument (already-booted image). `modify`/`passthrough` are untouched, signing stays out of scope, and there is no new config API (rides the existing ACL preview gate). Round trips converge: split-on-write plus the existing merge-on-read.

- [x] Tests added/updated: pure table + round-trip tests for the split; full suite matches `main`.
- [x] Documentation updated (if needed) — not needed: behavior is automatic for ACL images.
- [x] Code conforms to style guidelines.
