### PR TITLE
Fix absolute paths handling in inject-files config.

### DIFF
--- a/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput.go
@@ -440,29 +440,38 @@ func injectFilesIntoImage(buildDir string, baseConfigPath string, rawImageFile s
 	}
 
 	partitionsToMountpoints := make(map[imagecustomizerapi.InjectFilePartition]string)
+	partUuidsToMountpoints := make(map[string]string)
 	var mountedPartitions []*safemount.Mount
 
-	for idx, item := range metadata {
+	for _, item := range metadata {
 		partitionKey := item.Partition
-		if _, exists := partitionsToMountpoints[partitionKey]; !exists {
-			partitionsToMountpoints[partitionKey] = filepath.Join(buildDir, fmt.Sprintf("inject-partition-%d", idx))
 
+		mountPath, exists := partitionsToMountpoints[item.Partition]
+		if !exists {
 			partition, _, err := findPartition(item.Partition.MountIdType, item.Partition.Id, diskPartitions)
 			if err != nil {
 				return err
 			}
 
-			mount, err := safemount.NewMount(partition.Path, partitionsToMountpoints[partitionKey], partition.FileSystemType, 0, "", true)
-			if err != nil {
-				return fmt.Errorf("%w (partition='%s'):\n%w", ErrArtifactInjectFilesPartitionMount, partition.Path, err)
-			}
-			defer mount.Close()
+			mountPath, exists = partUuidsToMountpoints[partition.PartUuid]
+			if !exists {
+				mountPath = filepath.Join(buildDir, fmt.Sprintf("inject-partition-%d", len(mountedPartitions)))
 
-			mountedPartitions = append(mountedPartitions, mount)
+				mount, err := safemount.NewMount(partition.Path, mountPath, partition.FileSystemType, 0, "", true)
+				if err != nil {
+					return fmt.Errorf("%w (partition='%s'):\n%w", ErrArtifactInjectFilesPartitionMount, partition.Path, err)
+				}
+				defer mount.Close()
+
+				mountedPartitions = append(mountedPartitions, mount)
+				partUuidsToMountpoints[partition.PartUuid] = mountPath
+			}
+
+			partitionsToMountpoints[partitionKey] = mountPath
 		}
 
-		srcPath := filepath.Join(baseConfigPath, item.Source)
-		destPath := filepath.Join(partitionsToMountpoints[partitionKey], item.Destination)
+		srcPath := file.GetAbsPathWithBase(baseConfigPath, item.Source)
+		destPath := filepath.Join(mountPath, item.Destination)
 		err := file.Copy(srcPath, destPath)
 		if err != nil {
 			return fmt.Errorf("%w (source='%s', destination='%s'):\n%w", ErrArtifactBinaryCopy, srcPath, destPath, err)

--- a/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput_test.go
+++ b/toolkit/tools/pkg/imagecustomizerlib/artifactsinputoutput_test.go
@@ -59,11 +59,34 @@ func TestOutputAndInjectArtifacts(t *testing.T) {
 
 	espFiles := verifyAndSignOutputtedArtifacts(t, baseImageInfo, outputArtifactsDir, false)
 
+	injectConfigPath := filepath.Join(outputArtifactsDir, "inject-files.yaml")
+
+	// Add extra file to config.
+	var config imagecustomizerapi.InjectFilesConfig
+	err = imagecustomizerapi.UnmarshalYamlFile(injectConfigPath, &config)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	aFilePath := filepath.Join(testDir, "files/a.txt")
+	config.InjectFiles = append(config.InjectFiles, imagecustomizerapi.InjectArtifactMetadata{
+		Partition: imagecustomizerapi.InjectFilePartition{
+			MountIdType: imagecustomizerapi.MountIdentifierTypePartLabel,
+			Id:          "EFI System Partition",
+		},
+		Source:      aFilePath,
+		Destination: "/a.txt",
+	})
+
+	err = imagecustomizerapi.MarshalYamlFile(injectConfigPath, &config)
+	if !assert.NoError(t, err) {
+		return
+	}
+
 	// Use new buildDir to ensure the buildDir is created if it doesn't exist.
 	buildDirInject := filepath.Join(buildDir, "inject")
 
 	// Inject artifacts into a fresh copy of the raw image
-	injectConfigPath := filepath.Join(outputArtifactsDir, "inject-files.yaml")
 	options := InjectFilesOptions{
 		BuildDir:       buildDirInject,
 		InputImageFile: outImageFilePath,
@@ -101,6 +124,7 @@ func TestOutputAndInjectArtifacts(t *testing.T) {
 	defer imageConnection.Close()
 
 	verifyInjectedFiles(t, filepath.Join(imageConnection.Chroot().RootDir(), "boot/efi"), espFiles)
+	verifyFileContentsSame(t, aFilePath, filepath.Join(imageConnection.Chroot().RootDir(), "/boot/efi/a.txt"))
 }
 
 // artifactsOutputConfigFile returns the artifacts-output test config file appropriate for the

--- a/toolkit/tools/pkg/imagecustomizerlib/testdata/artifacts-output-base.yaml
+++ b/toolkit/tools/pkg/imagecustomizerlib/testdata/artifacts-output-base.yaml
@@ -9,6 +9,7 @@ storage:
     - id: esp
       type: esp
       size: 100M
+      label: EFI System Partition
 
     - id: boot
       size: 1G


### PR DESCRIPTION
The `inject-files` command currently doesn't treat absolute paths as absolute paths. This change fixes this.

Also, fix an issue with inject-files where a partition will be mounted twice if referred to in two different ways (e.g. part UUID, and part label).

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
