### PR TITLE
Improve DiskSize.IsValid().

### DIFF
--- a/toolkit/tools/imagecustomizerapi/btrfsquotaconfig.go
+++ b/toolkit/tools/imagecustomizerapi/btrfsquotaconfig.go
@@ -17,12 +17,24 @@ type BtrfsQuotaConfig struct {
 
 // IsValid validates the BtrfsQuotaConfig configuration.
 func (q *BtrfsQuotaConfig) IsValid() error {
-	if q.ReferencedLimit != nil && *q.ReferencedLimit <= 0 {
-		return fmt.Errorf("referencedLimit value (%d) must be a positive non-zero number", *q.ReferencedLimit)
+	if q.ReferencedLimit != nil {
+		if err := q.ReferencedLimit.IsValid(); err != nil {
+			return fmt.Errorf("invalid 'referencedLimit' value:\n%w", err)
+		}
+
+		if *q.ReferencedLimit <= 0 {
+			return fmt.Errorf("referencedLimit value (%d) must be a positive non-zero number", *q.ReferencedLimit)
+		}
 	}
 
-	if q.ExclusiveLimit != nil && *q.ExclusiveLimit <= 0 {
-		return fmt.Errorf("exclusiveLimit value (%d) must be a positive non-zero number", *q.ExclusiveLimit)
+	if q.ExclusiveLimit != nil {
+		if err := q.ExclusiveLimit.IsValid(); err != nil {
+			return fmt.Errorf("invalid 'exclusiveLimit' value:\n%w", err)
+		}
+
+		if *q.ExclusiveLimit <= 0 {
+			return fmt.Errorf("exclusiveLimit value (%d) must be a positive non-zero number", *q.ExclusiveLimit)
+		}
 	}
 
 	return nil

--- a/toolkit/tools/imagecustomizerapi/btrfsquotaconfig_test.go
+++ b/toolkit/tools/imagecustomizerapi/btrfsquotaconfig_test.go
@@ -6,6 +6,7 @@ package imagecustomizerapi
 import (
 	"testing"
 
+	"github.com/microsoft/azure-linux-image-tools/toolkit/tools/imagegen/diskutils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -29,6 +30,28 @@ func TestBtrfsQuotaConfigIsValid_ExclusiveLimitZero_Fail(t *testing.T) {
 	assert.ErrorContains(t, err, "exclusiveLimit value (0) must be a positive non-zero number")
 }
 
+func TestBtrfsQuotaConfigIsValid_ReferencedLimitUnaligned_Fail(t *testing.T) {
+	referencedLimit := DiskSize(1 * diskutils.KiB)
+	q := BtrfsQuotaConfig{
+		ReferencedLimit: &referencedLimit,
+	}
+	err := q.IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "invalid 'referencedLimit' value:\n")
+	assert.ErrorContains(t, err, "size (1 KiB) must be a multiple of 1 MiB")
+}
+
+func TestBtrfsQuotaConfigIsValid_ExclusiveLimitUnaligned_Fail(t *testing.T) {
+	exclusiveLimit := DiskSize(1 * diskutils.KiB)
+	q := BtrfsQuotaConfig{
+		ExclusiveLimit: &exclusiveLimit,
+	}
+	err := q.IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "invalid 'exclusiveLimit' value:\n")
+	assert.ErrorContains(t, err, "size (1 KiB) must be a multiple of 1 MiB")
+}
+
 func TestBtrfsQuotaConfigIsValid_BothLimitsZero_Fail(t *testing.T) {
 	referencedLimit := DiskSize(0)
 	exclusiveLimit := DiskSize(0)
@@ -49,7 +72,7 @@ func TestBtrfsQuotaConfigIsValid_Empty_Pass(t *testing.T) {
 }
 
 func TestBtrfsQuotaConfigIsValid_ReferencedLimitPositive_Pass(t *testing.T) {
-	referencedLimit := DiskSize(1024)
+	referencedLimit := DiskSize(1 * diskutils.MiB)
 	q := BtrfsQuotaConfig{
 		ReferencedLimit: &referencedLimit,
 	}
@@ -58,7 +81,7 @@ func TestBtrfsQuotaConfigIsValid_ReferencedLimitPositive_Pass(t *testing.T) {
 }
 
 func TestBtrfsQuotaConfigIsValid_ExclusiveLimitPositive_Pass(t *testing.T) {
-	exclusiveLimit := DiskSize(1024)
+	exclusiveLimit := DiskSize(1 * diskutils.MiB)
 	q := BtrfsQuotaConfig{
 		ExclusiveLimit: &exclusiveLimit,
 	}
@@ -67,8 +90,8 @@ func TestBtrfsQuotaConfigIsValid_ExclusiveLimitPositive_Pass(t *testing.T) {
 }
 
 func TestBtrfsQuotaConfigIsValid_BothLimitsPositive_Pass(t *testing.T) {
-	referencedLimit := DiskSize(2048)
-	exclusiveLimit := DiskSize(1024)
+	referencedLimit := DiskSize(2 * diskutils.MiB)
+	exclusiveLimit := DiskSize(1 * diskutils.MiB)
 	q := BtrfsQuotaConfig{
 		ReferencedLimit: &referencedLimit,
 		ExclusiveLimit:  &exclusiveLimit,

--- a/toolkit/tools/imagecustomizerapi/disk.go
+++ b/toolkit/tools/imagecustomizerapi/disk.go
@@ -44,6 +44,10 @@ func (d *Disk) IsValid() error {
 	}
 
 	if d.MaxSize != nil {
+		if err := d.MaxSize.IsValid(); err != nil {
+			return fmt.Errorf("invalid 'maxSize' value:\n%w", err)
+		}
+
 		if *d.MaxSize <= 0 {
 			return fmt.Errorf("a disk's maxSize value (%d) must be a positive non-zero number", *d.MaxSize)
 		}

--- a/toolkit/tools/imagecustomizerapi/disk_test.go
+++ b/toolkit/tools/imagecustomizerapi/disk_test.go
@@ -27,6 +27,23 @@ func TestDiskIsValid(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestDiskIsValidUnalignedMaxSize(t *testing.T) {
+	disk := &Disk{
+		PartitionTableType: PartitionTableTypeGpt,
+		MaxSize:            ptrutils.PtrTo(DiskSize(3 * diskutils.KiB)),
+		Partitions: []Partition{
+			{
+				Id:    "a",
+				Start: ptrutils.PtrTo(DiskSize(1 * diskutils.MiB)),
+			},
+		},
+	}
+
+	err := disk.IsValid()
+	assert.ErrorContains(t, err, "invalid 'maxSize' value:\n")
+	assert.ErrorContains(t, err, "size (3 KiB) must be a multiple of 1 MiB")
+}
+
 func TestDiskIsValidWithEnd(t *testing.T) {
 	disk := &Disk{
 		PartitionTableType: PartitionTableTypeGpt,

--- a/toolkit/tools/imagecustomizerapi/disksize.go
+++ b/toolkit/tools/imagecustomizerapi/disksize.go
@@ -21,6 +21,12 @@ var (
 type DiskSize uint64
 
 func (s *DiskSize) IsValid() error {
+	// The imager's diskutils works in MiB. So, restrict disk and partition sizes to multiples of 1 MiB.
+	if *s%DefaultPartitionAlignment != 0 {
+		return fmt.Errorf("size (%s) must be a multiple of %s", s.HumanReadable(),
+			DiskSize(DefaultPartitionAlignment).HumanReadable())
+	}
+
 	return nil
 }
 
@@ -119,12 +125,6 @@ func parseDiskSize(diskSizeString string) (DiskSize, error) {
 		num *= multiplier
 	}
 
-	// The imager's diskutils works in MiB. So, restrict disk and partition sizes to multiples of 1 MiB.
-	if num%DefaultPartitionAlignment != 0 {
-		return 0, fmt.Errorf("(%s) must be a multiple of %s", diskSizeString,
-			DiskSize(DefaultPartitionAlignment).HumanReadable())
-	}
-
 	return DiskSize(num), nil
 }
 
@@ -132,6 +132,8 @@ func parseDiskSize(diskSizeString string) (DiskSize, error) {
 // such that it matches the input format.
 func (s DiskSize) String() string {
 	switch {
+	case s == 0:
+		return fmt.Sprintf("%d", s)
 	case s%diskutils.TiB == 0:
 		return fmt.Sprintf("%dT", s/diskutils.TiB)
 	case s%diskutils.GiB == 0:

--- a/toolkit/tools/imagecustomizerapi/partition.go
+++ b/toolkit/tools/imagecustomizerapi/partition.go
@@ -33,6 +33,22 @@ func (p *Partition) IsValid() error {
 		return err
 	}
 
+	if p.Start != nil {
+		if err := p.Start.IsValid(); err != nil {
+			return fmt.Errorf("invalid 'start' value:\n%w", err)
+		}
+	}
+
+	if p.End != nil {
+		if err := p.End.IsValid(); err != nil {
+			return fmt.Errorf("invalid 'end' value:\n%w", err)
+		}
+	}
+
+	if err := p.Size.IsValid(); err != nil {
+		return fmt.Errorf("invalid 'size' value:\n%w", err)
+	}
+
 	if !p.filled && p.End != nil && p.Size.Type != PartitionSizeTypeUnset {
 		return fmt.Errorf("cannot specify both end and size on partition (%s)", p.Id)
 	}

--- a/toolkit/tools/imagecustomizerapi/partition_test.go
+++ b/toolkit/tools/imagecustomizerapi/partition_test.go
@@ -191,3 +191,48 @@ func TestPartitionIsValidTypeUuidInvalid(t *testing.T) {
 	err := partition.IsValid()
 	assert.ErrorContains(t, err, "partition type is unknown and is not a UUID (c12a7328-f81f-11d2-ba4b-00a0c93ec93)")
 }
+
+func TestPartitionIsValidUnalignedStart(t *testing.T) {
+	partition := Partition{
+		Id:    "a",
+		Start: ptrutils.PtrTo(DiskSize(1 * diskutils.KiB)),
+		Size: PartitionSize{
+			Type: PartitionSizeTypeExplicit,
+			Size: DiskSize(1 * diskutils.MiB),
+		},
+	}
+
+	err := partition.IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "invalid 'start' value:\n")
+	assert.ErrorContains(t, err, "size (1 KiB) must be a multiple of 1 MiB")
+}
+
+func TestPartitionIsValidUnalignedEnd(t *testing.T) {
+	partition := Partition{
+		Id:    "a",
+		Start: ptrutils.PtrTo(DiskSize(1 * diskutils.MiB)),
+		End:   ptrutils.PtrTo(DiskSize(1025 * diskutils.KiB)),
+	}
+
+	err := partition.IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "invalid 'end' value:\n")
+	assert.ErrorContains(t, err, "size (1025 KiB) must be a multiple of 1 MiB")
+}
+
+func TestPartitionIsValidUnalignedSize(t *testing.T) {
+	partition := Partition{
+		Id:    "a",
+		Start: ptrutils.PtrTo(DiskSize(1 * diskutils.MiB)),
+		Size: PartitionSize{
+			Type: PartitionSizeTypeExplicit,
+			Size: DiskSize(1 * diskutils.KiB),
+		},
+	}
+
+	err := partition.IsValid()
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "invalid 'size' value:\n")
+	assert.ErrorContains(t, err, "size (1 KiB) must be a multiple of 1 MiB")
+}

--- a/toolkit/tools/imagecustomizerapi/partitionsize.go
+++ b/toolkit/tools/imagecustomizerapi/partitionsize.go
@@ -29,6 +29,19 @@ type PartitionSize struct {
 }
 
 func (s *PartitionSize) IsValid() error {
+	switch s.Type {
+	case PartitionSizeTypeGrow, PartitionSizeTypeUnset:
+		// Nothing else to check.
+
+	case PartitionSizeTypeExplicit:
+		if err := s.Size.IsValid(); err != nil {
+			return err
+		}
+
+	default:
+		return fmt.Errorf("invalid partition size type (%v)", s.Type)
+	}
+
 	return nil
 }
 

--- a/toolkit/tools/imagecustomizerapi/partitionsize_test.go
+++ b/toolkit/tools/imagecustomizerapi/partitionsize_test.go
@@ -10,27 +10,35 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestParitionSizeGrow(t *testing.T) {
+func TestPartitionSizeGrow(t *testing.T) {
 	var size PartitionSize
 	err := UnmarshalAndValidateYaml([]byte("grow"), &size)
 	assert.NoError(t, err)
 }
 
-func TestParitionSizeMiB(t *testing.T) {
+func TestPartitionSizeMiB(t *testing.T) {
 	var size PartitionSize
 	err := UnmarshalAndValidateYaml([]byte("1M"), &size)
 	assert.NoError(t, err)
 	assert.Equal(t, PartitionSize{PartitionSizeTypeExplicit, 1 * diskutils.MiB}, size)
 }
 
-func TestParitionInvalidNotString(t *testing.T) {
+func TestPartitionSizeInvalidNotString(t *testing.T) {
 	var size PartitionSize
 	err := UnmarshalAndValidateYaml([]byte("[]"), &size)
 	assert.ErrorContains(t, err, "failed to parse partition size")
 }
 
-func TestParitionInvalidValue(t *testing.T) {
+func TestPartitionSizeInvalidValue(t *testing.T) {
 	var size PartitionSize
 	err := UnmarshalAndValidateYaml([]byte("cat"), &size)
 	assert.ErrorContains(t, err, "(cat) has incorrect format")
+}
+
+func TestPartitionSizeInvalidType(t *testing.T) {
+	size := PartitionSize{
+		Type: -1,
+	}
+	err := size.IsValid()
+	assert.ErrorContains(t, err, "invalid partition size type (-1)")
 }


### PR DESCRIPTION
Move the DiskSize alignment checks from the unmarshal functions to the IsValid function. This will improve the error message, since the IsValid functions provide more context for the error. Also, it ensures that the check is performed even when the type is initialized programatically.

---

### **Checklist**

- [x] Tests added/updated
- [x] Documentation updated (if needed)
- [x] Code conforms to style guidelines
