### PR TITLE
diskutils: fix typo in retry logic

### DIFF
--- a/toolkit/tools/imagegen/diskutils/diskutils.go
+++ b/toolkit/tools/imagegen/diskutils/diskutils.go
@@ -999,7 +999,7 @@ func requestKernelRereadPartitionTable(diskDevPath string) error {
 
 	waitTime := 125 * time.Millisecond
 	retries := 10
-	for i := 0; ; i = 1 {
+	for i := 0; ; i++ {
 		_, _, errno := unix.Syscall(unix.SYS_IOCTL, diskFile.Fd(), unix.BLKRRPART, 0)
 		switch {
 		case errno == unix.EBUSY && i < retries:


### PR DESCRIPTION
Increment the partition-reread retry counter instead of resetting
it to 1, restoring the retry limit and preventing indefinite backoff.

Signed-off-by: Muhammad Falak R Wani <falakreyaz@gmail.com>

<!-- Description: Please provide a summary of the changes and the motivation behind them. -->

---

### **Checklist**
- [ ] Tests added/updated
- [ ] Documentation updated (if needed)
- [x] Code conforms to style guidelines
